### PR TITLE
Tests Cleanup

### DIFF
--- a/bin/type-check
+++ b/bin/type-check
@@ -12,12 +12,12 @@ args = parser.parse_args()
 init()
 
 # Go to the defined path
-path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')) + '/'
+path = os.path.abspath(os.path.dirname(os.path.dirname(__file__))) + '/'
 
 if (args.path):
-    path += args.path;
+    path += 'src/' + args.path;
 
-os.chdir(os.path.abspath(path))
+os.chdir(path)
 
 # Create .hhconfig file
 config = open('.hhconfig', 'w+')

--- a/docs/en/packages/common/types.md
+++ b/docs/en/packages/common/types.md
@@ -58,15 +58,8 @@ Each alias has a specific use case that should be followed accordingly.
             <td colspan="3">Macros</td>
         </tr>
         <tr>
-            <td>Titon\Common\MacroCallback</td>
-            <td>(function(...): mixed)</td>
-            <td>
-                A callable that defines the arguments and return type for macros.
-            </td>
-        </tr>
-        <tr>
             <td>Titon\Common\MacroMap</td>
-            <td>Map&lt;string, Titon\Common\MacroCallback&gt;</td>
+            <td>Map&lt;string, Closure&gt;</td>
             <td>
                 Maps custom macros by name to their callable definition.
             </td>

--- a/src/Titon/Common/Macroable.hh
+++ b/src/Titon/Common/Macroable.hh
@@ -8,6 +8,7 @@
 namespace Titon\Common;
 
 use Titon\Common\Exception\MissingMacroException;
+use Closure;
 
 /**
  * Provides a mechanism at runtime for defining static methods that can be triggered during __callStatic().
@@ -69,9 +70,9 @@ trait Macroable {
      * Define a custom macro, that will be triggered when a magic static method is called.
      *
      * @param string $key
-     * @param \Titon\Common\MacroCallback $callback
+     * @param \Closure $callback
      */
-    public static function macro(string $key, MacroCallback $callback): void {
+    public static function macro(string $key, Closure $callback): void {
         static::getMacros()->set($key, $callback);
     }
 

--- a/src/Titon/Common/bootstrap.hh
+++ b/src/Titon/Common/bootstrap.hh
@@ -14,6 +14,8 @@
  */
 
 namespace Titon\Common {
+    use Closure;
+
     type ArgumentList = array<mixed>;
     type CacheMap = Map<string, mixed>;
     type DataMap = Map<string, mixed>;

--- a/src/Titon/Common/bootstrap.hh
+++ b/src/Titon/Common/bootstrap.hh
@@ -24,9 +24,8 @@ namespace Titon\Common {
     type InstanceMap<T> = Map<string, T>;
 
     // Macros
-    type MacroCallback = (function(...): mixed);
     type MacroContainer = Map<string, MacroMap>;
-    type MacroMap = Map<string, MacroCallback>;
+    type MacroMap = Map<string, Closure>;
 }
 
 /**

--- a/src/Titon/Controller/Action.hh
+++ b/src/Titon/Controller/Action.hh
@@ -33,7 +33,7 @@ interface Action {
      *
      * @return \Titon\Controller\Controller
      */
-    public function getController(): Controller;
+    public function getController(): ?Controller;
 
     /**
      * Set the parent controller.

--- a/src/Titon/Controller/Action/AbstractAction.hh
+++ b/src/Titon/Controller/Action/AbstractAction.hh
@@ -24,12 +24,12 @@ abstract class AbstractAction implements Action {
      *
      * @var \Titon\Controller\Controller
      */
-    protected Controller $controller;
+    protected ?Controller $controller;
 
     /**
      * {@inheritdoc}
      */
-    public function getController(): Controller {
+    public function getController(): ?Controller {
         return $this->controller;
     }
 

--- a/src/Titon/Debug/bootstrap.hh
+++ b/src/Titon/Debug/bootstrap.hh
@@ -83,18 +83,18 @@ namespace {
     /**
      * @see Titon\Debug\Debugger::debug()
      */
-    function debug(): void {
+    function debug(/* HH_FIXME[4033]: variadic + strict */ ...$vars): void {
         if (Debugger::isOn()) {
-            echo call_user_func_array(class_meth('Titon\Debug\Debugger', 'debug'), func_get_args());
+            echo call_user_func_array(class_meth('Titon\Debug\Debugger', 'debug'), $vars);
         }
     }
 
     /**
      * @see Titon\Debug\Debugger::dump()
      */
-    function dump(): void {
+    function dump(/* HH_FIXME[4033]: variadic + strict */ ...$vars): void {
         if (Debugger::isOn()) {
-            echo call_user_func_array(class_meth('Titon\Debug\Debugger', 'dump'), func_get_args());
+            echo call_user_func_array(class_meth('Titon\Debug\Debugger', 'dump'), $vars);
         }
     }
 }

--- a/src/Titon/Event/bootstrap.hh
+++ b/src/Titon/Event/bootstrap.hh
@@ -20,7 +20,7 @@ namespace Titon\Event {
     type ListenerOption = shape('method' => string, 'priority' => int, 'once' => bool);
     type ObserverList = Vector<Observer>;
     type ObserverContainer = Map<string, ObserverList>;
-    type ObserverCallback = (function(Event, ...): mixed);
+    type ObserverCallback = (function(Event): mixed);
 }
 
 /**

--- a/src/Titon/Route/CallbackRoute.hh
+++ b/src/Titon/Route/CallbackRoute.hh
@@ -9,8 +9,7 @@ namespace Titon\Route;
 
 use Titon\Route\Exception\NoMatchException;
 use \ReflectionFunction;
-
-newtype RouteCallback = (function(...): mixed);
+use \Closure;
 
 /**
  * The CallbackRoute works in a similar fashion to the default Route with the only difference being
@@ -23,17 +22,17 @@ class CallbackRoute extends Route {
     /**
      * The callback to execute during dispatch.
      *
-     * @var \Titon\Route\RouteCallback
+     * @var \Closure
      */
-    protected RouteCallback $callback;
+    protected Closure $callback;
 
     /**
      * Store the tokenized URL to match and the callback to dispatch to.
      *
      * @param string $path
-     * @param \Titon\Route\RouteCallback $callback
+     * @param \Closure $callback
      */
-    public function __construct(string $path, RouteCallback $callback) {
+    public function __construct(string $path, Closure $callback) {
         $this->callback = $callback;
 
         parent::__construct($path, 'CallbackRoute@noop');
@@ -55,19 +54,19 @@ class CallbackRoute extends Route {
     /**
      * Return the callback function.
      *
-     * @return \Titon\Route\RouteCallback
+     * @return \Closure
      */
-    public function getCallback(): RouteCallback {
+    public function getCallback(): Closure {
         return $this->callback;
     }
 
     /**
      * Set the callback function.
      *
-     * @param \Titon\Route\RouteCallback $callback
+     * @param \Closure $callback
      * @return $this
      */
-    public function setCallback(RouteCallback $callback): this {
+    public function setCallback(Closure $callback): this {
         $this->callback = $callback;
 
         return $this;

--- a/src/Titon/Test/TestCase.hh
+++ b/src/Titon/Test/TestCase.hh
@@ -200,6 +200,19 @@ class TestCase extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Return a virtual file system, or create it if it doesn't exist.
+     *
+     * @return \VirtualFileSystem\FileSystem
+     */
+    public function vfs(): FileSystem {
+        if ($this->vfs) {
+            return $this->vfs;
+        }
+
+        return $this->setupVFS();
+    }
+
+    /**
      * Assert that two array values are equal, disregarding the order.
      *
      * @param array<Tk, Tv> $expected

--- a/tests/Titon/Annotation/AnnotationTest.hh
+++ b/tests/Titon/Annotation/AnnotationTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Annotation;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Annotation/AnnotationTest.hh
+++ b/tests/Titon/Annotation/AnnotationTest.hh
@@ -8,9 +8,9 @@ class AnnotationTest extends TestCase {
     protected function setUp() {
         parent::setUp();
 
-        Registry::map('Foo', 'Titon\Annotation\FooAnnotation');
-        Registry::map('Bar', 'Titon\Annotation\BarAnnotation');
-        Registry::map('Baz', 'Titon\Annotation\BazAnnotation');
+        Registry::map('Foo', 'Titon\Test\Stub\Annotation\FooAnnotationStub');
+        Registry::map('Bar', 'Titon\Test\Stub\Annotation\BarAnnotationStub');
+        Registry::map('Baz', 'Titon\Test\Stub\Annotation\BazAnnotationStub');
     }
 
     public function testGetSetName() {
@@ -23,16 +23,4 @@ class AnnotationTest extends TestCase {
         $this->assertEquals('Foo', $anno->getName());
     }
 
-}
-
-// These should be available in the other tests
-
-class FooAnnotation extends Annotation {}
-
-class BarAnnotation extends Annotation {
-    public function __construct(public string $string, public int $int = 0) {}
-}
-
-class BazAnnotation extends Annotation {
-    public function __construct(public array<mixed, mixed> $array) {}
 }

--- a/tests/Titon/Annotation/AnnotationTest.hh
+++ b/tests/Titon/Annotation/AnnotationTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Annotation;
 
 use Titon\Test\TestCase;
 
 class AnnotationTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         Registry::map('Foo', 'Titon\Test\Stub\Annotation\FooAnnotationStub');
@@ -13,7 +13,7 @@ class AnnotationTest extends TestCase {
         Registry::map('Baz', 'Titon\Test\Stub\Annotation\BazAnnotationStub');
     }
 
-    public function testGetSetName() {
+    public function testGetSetName(): void {
         $anno = new Annotation();
 
         $this->assertEquals('', $anno->getName());

--- a/tests/Titon/Annotation/ReaderTest.hh
+++ b/tests/Titon/Annotation/ReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Annotation;
 
 use Titon\Test\Stub\Annotation\BarAnnotationStub;

--- a/tests/Titon/Annotation/ReaderTest.hh
+++ b/tests/Titon/Annotation/ReaderTest.hh
@@ -1,6 +1,10 @@
 <?hh
 namespace Titon\Annotation;
 
+use Titon\Test\Stub\Annotation\BarAnnotationStub;
+use Titon\Test\Stub\Annotation\BazAnnotationStub;
+use Titon\Test\Stub\Annotation\FooAnnotationStub;
+use Titon\Test\Stub\Annotation\ReaderStub;
 use Titon\Test\TestCase;
 
 /**
@@ -17,14 +21,14 @@ class ReaderTest extends TestCase {
     public function testGetAnnotatedMethods() {
         $this->assertEquals(Map {
             'hasAnno' => Map {
-                'Baz' => (new BazAnnotation(['a' => 1]))->setName('Baz')
+                'Baz' => (new BazAnnotationStub(['a' => 1]))->setName('Baz')
             }
         }, $this->object->getAnnotatedMethods());
     }
 
     public function testGetClassAnnotation() {
-        $this->assertEquals((new FooAnnotation())->setName('Foo'), $this->object->getClassAnnotation('Foo'));
-        $this->assertEquals((new BarAnnotation('abc', 123))->setName('Bar'), $this->object->getClassAnnotation('Bar'));
+        $this->assertEquals((new FooAnnotationStub())->setName('Foo'), $this->object->getClassAnnotation('Foo'));
+        $this->assertEquals((new BarAnnotationStub('abc', 123))->setName('Bar'), $this->object->getClassAnnotation('Bar'));
     }
 
     /**
@@ -36,13 +40,13 @@ class ReaderTest extends TestCase {
 
     public function testGetClassAnnotations() {
         $this->assertEquals(Map {
-            'Foo' => (new FooAnnotation())->setName('Foo'),
-            'Bar' => (new BarAnnotation('abc', 123))->setName('Bar')
+            'Foo' => (new FooAnnotationStub())->setName('Foo'),
+            'Bar' => (new BarAnnotationStub('abc', 123))->setName('Bar')
         }, $this->object->getClassAnnotations());
     }
 
     public function testGetMethodAnnotation() {
-        $this->assertEquals((new BazAnnotation(['a' => 1]))->setName('Baz'), $this->object->getMethodAnnotation('hasAnno', 'Baz'));
+        $this->assertEquals((new BazAnnotationStub(['a' => 1]))->setName('Baz'), $this->object->getMethodAnnotation('hasAnno', 'Baz'));
     }
 
     /**
@@ -54,7 +58,7 @@ class ReaderTest extends TestCase {
 
     public function testGetMethodAnnotations() {
         $this->assertEquals(Map {
-            'Baz' => (new BazAnnotation(['a' => 1]))->setName('Baz')
+            'Baz' => (new BazAnnotationStub(['a' => 1]))->setName('Baz')
         }, $this->object->getMethodAnnotations('hasAnno'));
     }
 
@@ -65,13 +69,4 @@ class ReaderTest extends TestCase {
         $this->object->getMethodAnnotations('invalid');
     }
 
-}
-
-<<Foo, Bar('abc', 123)>>
-class ReaderStub {
-
-    <<Baz(['a' => 1])>>
-    public function hasAnno(): void {}
-
-    public function noAnno(): void {}
 }

--- a/tests/Titon/Annotation/ReaderTest.hh
+++ b/tests/Titon/Annotation/ReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Annotation;
 
 use Titon\Test\Stub\Annotation\BarAnnotationStub;
@@ -12,13 +12,13 @@ use Titon\Test\TestCase;
  */
 class ReaderTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new Reader(new ReaderStub());
     }
 
-    public function testGetAnnotatedMethods() {
+    public function testGetAnnotatedMethods(): void {
         $this->assertEquals(Map {
             'hasAnno' => Map {
                 'Baz' => (new BazAnnotationStub(['a' => 1]))->setName('Baz')
@@ -26,7 +26,7 @@ class ReaderTest extends TestCase {
         }, $this->object->getAnnotatedMethods());
     }
 
-    public function testGetClassAnnotation() {
+    public function testGetClassAnnotation(): void {
         $this->assertEquals((new FooAnnotationStub())->setName('Foo'), $this->object->getClassAnnotation('Foo'));
         $this->assertEquals((new BarAnnotationStub('abc', 123))->setName('Bar'), $this->object->getClassAnnotation('Bar'));
     }
@@ -34,29 +34,29 @@ class ReaderTest extends TestCase {
     /**
      * @expectedException \Titon\Annotation\Exception\MissingAnnotationException
      */
-    public function testGetClassAnnotationThrowsMissingError() {
+    public function testGetClassAnnotationThrowsMissingError(): void {
         $this->object->getClassAnnotation('Baz');
     }
 
-    public function testGetClassAnnotations() {
+    public function testGetClassAnnotations(): void {
         $this->assertEquals(Map {
             'Foo' => (new FooAnnotationStub())->setName('Foo'),
             'Bar' => (new BarAnnotationStub('abc', 123))->setName('Bar')
         }, $this->object->getClassAnnotations());
     }
 
-    public function testGetMethodAnnotation() {
+    public function testGetMethodAnnotation(): void {
         $this->assertEquals((new BazAnnotationStub(['a' => 1]))->setName('Baz'), $this->object->getMethodAnnotation('hasAnno', 'Baz'));
     }
 
     /**
      * @expectedException \Titon\Annotation\Exception\MissingAnnotationException
      */
-    public function testGetMethodAnnotationThrowsMissingError() {
+    public function testGetMethodAnnotationThrowsMissingError(): void {
         $this->object->getMethodAnnotation('hasAnno', 'Foo');
     }
 
-    public function testGetMethodAnnotations() {
+    public function testGetMethodAnnotations(): void {
         $this->assertEquals(Map {
             'Baz' => (new BazAnnotationStub(['a' => 1]))->setName('Baz')
         }, $this->object->getMethodAnnotations('hasAnno'));
@@ -65,7 +65,7 @@ class ReaderTest extends TestCase {
     /**
      * @expectedException \ReflectionException
      */
-    public function testGetMethodAnnotationsInvalidMethod() {
+    public function testGetMethodAnnotationsInvalidMethod(): void {
         $this->object->getMethodAnnotations('invalid');
     }
 

--- a/tests/Titon/Annotation/RegistryTest.hh
+++ b/tests/Titon/Annotation/RegistryTest.hh
@@ -10,7 +10,7 @@ class RegistryTest extends TestCase {
     public function testMapAndFactory(): void {
         $annotation = Registry::factory('Bar', ['This is the message!']);
 
-        invariant($annotation instanceof BarAnnotationStub);
+        invariant($annotation instanceof BarAnnotationStub, 'Must be an annotation.');
 
         $this->assertInstanceOf('Titon\Annotation\Annotation', $annotation);
         $this->assertInstanceOf('Titon\Test\Stub\Annotation\BarAnnotationStub', $annotation);
@@ -35,21 +35,21 @@ class RegistryTest extends TestCase {
     public function testArgsArePassedToAnnotation(): void {
         $bar = Registry::factory('Bar', ['abc']);
 
-        invariant($bar instanceof BarAnnotationStub);
+        invariant($bar instanceof BarAnnotationStub, 'Must be an annotation.');
 
         $this->assertEquals('abc', $bar->string);
         $this->assertEquals(0, $bar->int);
 
         $bar = Registry::factory('Bar', ['def', 123]);
 
-        invariant($bar instanceof BarAnnotationStub);
+        invariant($bar instanceof BarAnnotationStub, 'Must be an annotation.');
 
         $this->assertEquals('def', $bar->string);
         $this->assertEquals(123, $bar->int);
 
         $baz = Registry::factory('Baz', [[1, 2, 3]]);
 
-        invariant($baz instanceof BazAnnotationStub);
+        invariant($baz instanceof BazAnnotationStub, 'Must be an annotation.');
 
         $this->assertEquals([1, 2, 3], $baz->array);
     }

--- a/tests/Titon/Annotation/RegistryTest.hh
+++ b/tests/Titon/Annotation/RegistryTest.hh
@@ -9,7 +9,7 @@ class RegistryTest extends TestCase {
         $annotation = Registry::factory('Bar', ['This is the message!']);
 
         $this->assertInstanceOf('Titon\Annotation\Annotation', $annotation);
-        $this->assertInstanceOf('Titon\Annotation\BarAnnotation', $annotation);
+        $this->assertInstanceOf('Titon\Test\Stub\Annotation\BarAnnotationStub', $annotation);
         $this->assertEquals('Bar', $annotation->getName());
         $this->assertEquals('This is the message!', $annotation->string);
     }

--- a/tests/Titon/Annotation/RegistryTest.hh
+++ b/tests/Titon/Annotation/RegistryTest.hh
@@ -1,12 +1,16 @@
-<?hh // strict
+<?hh
 namespace Titon\Annotation;
 
+use Titon\Test\Stub\Annotation\BarAnnotationStub;
+use Titon\Test\Stub\Annotation\BazAnnotationStub;
 use Titon\Test\TestCase;
 
 class RegistryTest extends TestCase {
 
     public function testMapAndFactory(): void {
         $annotation = Registry::factory('Bar', ['This is the message!']);
+
+        invariant($annotation instanceof BarAnnotationStub);
 
         $this->assertInstanceOf('Titon\Annotation\Annotation', $annotation);
         $this->assertInstanceOf('Titon\Test\Stub\Annotation\BarAnnotationStub', $annotation);
@@ -31,15 +35,21 @@ class RegistryTest extends TestCase {
     public function testArgsArePassedToAnnotation(): void {
         $bar = Registry::factory('Bar', ['abc']);
 
+        invariant($bar instanceof BarAnnotationStub);
+
         $this->assertEquals('abc', $bar->string);
         $this->assertEquals(0, $bar->int);
 
         $bar = Registry::factory('Bar', ['def', 123]);
 
+        invariant($bar instanceof BarAnnotationStub);
+
         $this->assertEquals('def', $bar->string);
         $this->assertEquals(123, $bar->int);
 
         $baz = Registry::factory('Baz', [[1, 2, 3]]);
+
+        invariant($baz instanceof BazAnnotationStub);
 
         $this->assertEquals([1, 2, 3], $baz->array);
     }

--- a/tests/Titon/Annotation/RegistryTest.hh
+++ b/tests/Titon/Annotation/RegistryTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Annotation;
 
 use Titon\Test\TestCase;
 
 class RegistryTest extends TestCase {
 
-    public function testMapAndFactory() {
+    public function testMapAndFactory(): void {
         $annotation = Registry::factory('Bar', ['This is the message!']);
 
         $this->assertInstanceOf('Titon\Annotation\Annotation', $annotation);
@@ -17,18 +17,18 @@ class RegistryTest extends TestCase {
     /**
      * @expectedException \Titon\Annotation\Exception\InvalidClassException
      */
-    public function testMapThrowsException() {
+    public function testMapThrowsException(): void {
         Registry::map('Qux', 'Titon\Annotation\Reader');
     }
 
     /**
      * @expectedException \Titon\Annotation\Exception\MissingAnnotationException
      */
-    public function testFactoryThrowsException() {
+    public function testFactoryThrowsException(): void {
         Registry::factory('Qux', []);
     }
 
-    public function testArgsArePassedToAnnotation() {
+    public function testArgsArePassedToAnnotation(): void {
         $bar = Registry::factory('Bar', ['abc']);
 
         $this->assertEquals('abc', $bar->string);

--- a/tests/Titon/Annotation/WireableTest.hh
+++ b/tests/Titon/Annotation/WireableTest.hh
@@ -1,6 +1,7 @@
 <?hh
 namespace Titon\Annotation;
 
+use Titon\Test\Stub\Annotation\WireableStub;
 use Titon\Test\TestCase;
 
 class WireableTest extends TestCase {
@@ -8,7 +9,7 @@ class WireableTest extends TestCase {
     protected function setUp() {
         parent::setUp();
 
-        Registry::map('Wire', 'Titon\Annotation\WireAnnotation');
+        Registry::map('Wire', 'Titon\Test\Stub\Annotation\WireAnnotationStub');
     }
 
     public function testWireAnnotations() {
@@ -36,37 +37,4 @@ class WireableTest extends TestCase {
         }, $stub->method);
     }
 
-}
-
-class WireAnnotation extends Annotation implements Wireable {
-    public function __construct(public string $type, public string $message) {}
-
-    public function wire<T>(T $class, string $method = ''): this {
-        if ($method) {
-            $class->{$this->type}[$method] = $this->message;
-        } else {
-            $class->{$this->type} = $this->message;
-        }
-    }
-}
-
-<<Wire('class', 'This is a class annotation')>>
-class WireableStub {
-    use WiresAnnotations;
-
-    public string $class = '';
-    public Map<string, string> $method = Map {};
-
-    public function __construct(string $type = 'both') {
-        if ($type === 'method') {
-            $this->wireMethodAnnotation('doAction', 'Wire');
-        } else if ($type === 'class') {
-            $this->wireClassAnnotation('Wire');
-        } else {
-            $this->wireAnnotations();
-        }
-    }
-
-    <<Wire('method', 'This is a method annotation')>>
-    public function doAction(): void {}
 }

--- a/tests/Titon/Annotation/WireableTest.hh
+++ b/tests/Titon/Annotation/WireableTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Annotation;
 
 use Titon\Test\Stub\Annotation\WireableStub;

--- a/tests/Titon/Annotation/WireableTest.hh
+++ b/tests/Titon/Annotation/WireableTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Annotation;
 
 use Titon\Test\Stub\Annotation\WireableStub;
@@ -6,13 +6,13 @@ use Titon\Test\TestCase;
 
 class WireableTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         Registry::map('Wire', 'Titon\Test\Stub\Annotation\WireAnnotationStub');
     }
 
-    public function testWireAnnotations() {
+    public function testWireAnnotations(): void {
         $stub = new WireableStub();
 
         $this->assertEquals('This is a class annotation', $stub->class);
@@ -21,14 +21,14 @@ class WireableTest extends TestCase {
         }, $stub->method);
     }
 
-    public function testWireClassAnnotation() {
+    public function testWireClassAnnotation(): void {
         $stub = new WireableStub('class');
 
         $this->assertEquals('This is a class annotation', $stub->class);
         $this->assertEquals(Map {}, $stub->method);
     }
 
-    public function testWireMethodAnnotation() {
+    public function testWireMethodAnnotation(): void {
         $stub = new WireableStub('method');
 
         $this->assertEquals('', $stub->class);

--- a/tests/Titon/Cache/CacheTest.hh
+++ b/tests/Titon/Cache/CacheTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache;
 
 use Titon\Cache\Storage\MemoryStorage;

--- a/tests/Titon/Cache/CacheTest.hh
+++ b/tests/Titon/Cache/CacheTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache;
 
 use Titon\Cache\Storage\MemoryStorage;
@@ -9,7 +9,7 @@ use Titon\Test\TestCase;
  */
 class CacheTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new Cache();
@@ -24,7 +24,7 @@ class CacheTest extends TestCase {
         $this->object->addStorage('custom', $custom);
     }
 
-    public function testDecrement() {
+    public function testDecrement(): void {
         $this->assertEquals(null, $this->object->get('decrement')->get());
         $this->assertEquals(null, $this->object->get('decrement', 'custom')->get());
 
@@ -38,7 +38,7 @@ class CacheTest extends TestCase {
         $this->assertEquals(-5, $this->object->get('decrement', 'custom')->get());
     }
 
-    public function testFlush() {
+    public function testFlush(): void {
         $this->object->set('test', 123);
         $this->assertTrue($this->object->has('key'));
         $this->assertTrue($this->object->has('test'));
@@ -62,7 +62,7 @@ class CacheTest extends TestCase {
         $this->assertFalse($this->object->has('test', 'custom'));
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $this->assertEquals(null, $this->object->get('fakeKey')->get());
         $this->assertEquals('foo', $this->object->get('key')->get());
 
@@ -70,7 +70,7 @@ class CacheTest extends TestCase {
         $this->assertEquals('bar', $this->object->get('key', 'custom')->get());
     }
 
-    public function testHas() {
+    public function testHas(): void {
         $this->assertTrue($this->object->has('key'));
         $this->assertFalse($this->object->has('fakeKey'));
 
@@ -78,7 +78,7 @@ class CacheTest extends TestCase {
         $this->assertFalse($this->object->has('fakeKey', 'custom'));
     }
 
-    public function testIncrement() {
+    public function testIncrement(): void {
         $this->assertEquals(null, $this->object->get('increment')->get());
         $this->assertEquals(null, $this->object->get('increment', 'custom')->get());
 
@@ -92,7 +92,7 @@ class CacheTest extends TestCase {
         $this->assertEquals(2, $this->object->get('increment', 'custom')->get());
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $this->assertEquals('foo', $this->object->get('key')->get());
 
         $this->object->remove('key');
@@ -106,7 +106,7 @@ class CacheTest extends TestCase {
         $this->assertEquals(null, $this->object->get('key', 'custom')->get());
     }
 
-    public function testSet() {
+    public function testSet(): void {
         $this->assertEquals('foo', $this->object->get('key')->get());
 
         $this->object->set('key', 'bar', '+1 hour');
@@ -120,11 +120,11 @@ class CacheTest extends TestCase {
         $this->assertEquals('baz', $this->object->get('key', 'custom')->get());
     }
 
-    public function testStats() {
+    public function testStats(): void {
         $this->assertInstanceOf('HH\Map', $this->object->stats());
     }
 
-    public function testStorages() {
+    public function testStorages(): void {
         $this->object->addStorage('test', new MemoryStorage());
 
         $this->assertInstanceOf('Titon\Cache\Storage', $this->object->getStorage('test'));
@@ -134,16 +134,16 @@ class CacheTest extends TestCase {
     /**
      * @expectedException \Titon\Cache\Exception\MissingStorageException
      */
-    public function testGetStorageMissing() {
+    public function testGetStorageMissing(): void {
         $this->object->getStorage('missing');
     }
 
-    public function testStore() {
-        $this->assertEquals('bar', $this->object->store('foo', function() {
+    public function testStore(): void {
+        $this->assertEquals('bar', $this->object->store('foo', function(): void {
             return 'bar';
         }));
 
-        $this->assertEquals('bar', $this->object->store('foo', function() {
+        $this->assertEquals('bar', $this->object->store('foo', function(): void {
             return 'baz';
         }));
     }

--- a/tests/Titon/Cache/CacheTest.hh
+++ b/tests/Titon/Cache/CacheTest.hh
@@ -139,13 +139,9 @@ class CacheTest extends TestCase {
     }
 
     public function testStore(): void {
-        $this->assertEquals('bar', $this->object->store('foo', function(): void {
-            return 'bar';
-        }));
+        $this->assertEquals('bar', $this->object->store('foo', () ==> 'bar'));
 
-        $this->assertEquals('bar', $this->object->store('foo', function(): void {
-            return 'baz';
-        }));
+        $this->assertEquals('bar', $this->object->store('foo', () ==> 'baz'));
     }
 
 }

--- a/tests/Titon/Cache/ItemTest.hh
+++ b/tests/Titon/Cache/ItemTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache;
 
 use Titon\Test\TestCase;
@@ -9,20 +9,20 @@ use \DateTime;
  */
 class ItemTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new Item('foo', 'bar');
     }
 
-    public function testGetSetValue() {
+    public function testGetSetValue(): void {
         $this->assertEquals('bar', $this->object->get());
 
         $this->object->set(123);
         $this->assertEquals(123, $this->object->get());
     }
 
-    public function testGetSetExpiration() {
+    public function testGetSetExpiration(): void {
         $this->object->setExpiration();
         $this->assertEquals(new DateTime('@' . strtotime('+1 hour')), $this->object->getExpiration());
 
@@ -33,14 +33,14 @@ class ItemTest extends TestCase {
         $this->assertEquals(new DateTime('@' . strtotime('+5 days')), $this->object->getExpiration());
     }
 
-    public function testGetSetKey() {
+    public function testGetSetKey(): void {
         $this->assertEquals('foo', $this->object->getKey());
 
         $this->object->setKey('baz');
         $this->assertEquals('baz', $this->object->getKey());
     }
 
-    public function testIsHit() {
+    public function testIsHit(): void {
         $this->assertFalse($this->object->isHit());
 
         $hit = new HitItem('foo', 'bar');

--- a/tests/Titon/Cache/ItemTest.hh
+++ b/tests/Titon/Cache/ItemTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Cache/Storage/AbstractStorageTest.hh
+++ b/tests/Titon/Cache/Storage/AbstractStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache\Storage;
 
 use Titon\Cache\HitItem;

--- a/tests/Titon/Cache/Storage/AbstractStorageTest.hh
+++ b/tests/Titon/Cache/Storage/AbstractStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache\Storage;
 
 use Titon\Cache\HitItem;
@@ -11,7 +11,7 @@ use Titon\Utility\Config;
  */
 abstract class AbstractStorageTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         // Assert true so we know cache is being written
@@ -20,14 +20,14 @@ abstract class AbstractStorageTest extends TestCase {
         $this->object->save(new Item('count', 1, '+5 minutes'));
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         if ($this->object) {
             $this->object->flush();
             unset($this->object);
         }
     }
 
-    public function testClear() {
+    public function testClear(): void {
         $this->assertTrue($this->object->has('foo'));
 
         $this->object->clear();
@@ -35,7 +35,7 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertFalse($this->object->has('foo'));
     }
 
-    public function testCommitDeferred() {
+    public function testCommitDeferred(): void {
         $this->assertEquals(Vector {}, $this->object->getDeferred());
 
         $item1 = new Item('baz', 123);
@@ -57,18 +57,18 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertTrue($this->object->has('qux'));
     }
 
-    public function testDecrement() {
+    public function testDecrement(): void {
         $this->assertEquals(1, $this->object->get('count'));
         $this->assertEquals(0, $this->object->decrement('count', 1));
         $this->assertEquals(-5, $this->object->decrement('count', 5));
     }
 
-    public function testDecrementInitialSet() {
+    public function testDecrementInitialSet(): void {
         $this->assertSame(-1, $this->object->decrement('missing'));
         $this->assertSame(-6, $this->object->decrement('missing', 5));
     }
 
-    public function testDeleteItem() {
+    public function testDeleteItem(): void {
         $this->assertTrue($this->object->has('foo'));
 
         $this->object->deleteItem('foo');
@@ -76,7 +76,7 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertFalse($this->object->has('foo'));
     }
 
-    public function testDeleteItems() {
+    public function testDeleteItems(): void {
         $this->assertTrue($this->object->has('foo'));
         $this->assertTrue($this->object->has('count'));
 
@@ -86,7 +86,7 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertFalse($this->object->has('count'));
     }
 
-    public function testFlush() {
+    public function testFlush(): void {
         $this->assertTrue($this->object->has('foo'));
 
         $this->object->flush();
@@ -94,7 +94,7 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertFalse($this->object->has('foo'));
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $this->assertEquals(['username' => 'Titon'], $this->object->get('foo'));
         $this->assertEquals(1, $this->object->get('count'));
     }
@@ -102,23 +102,23 @@ abstract class AbstractStorageTest extends TestCase {
     /**
      * @expectedException \Titon\Cache\Exception\MissingItemException
      */
-    public function testGetMissingKey() {
+    public function testGetMissingKey(): void {
         $this->assertEquals(null, $this->object->get('bar'));
     }
 
-    public function testGetItem() {
+    public function testGetItem(): void {
         $this->assertEquals(new HitItem('foo', ['username' => 'Titon']), $this->object->getItem('foo'));
         $this->assertEquals(new HitItem('count', 1), $this->object->getItem('count'));
     }
 
-    public function testGetItemMissingKey() {
+    public function testGetItemMissingKey(): void {
         $item = $this->object->getItem('bar');
 
         $this->assertInstanceOf('Titon\Cache\MissItem', $item); // Expired
         $this->assertFalse($item->isHit());
     }
 
-    public function testGetSetPrefix() {
+    public function testGetSetPrefix(): void {
         $this->assertNotEquals('', $this->object->getPrefix()); // Set in constructor
 
         $this->object->setPrefix('prefix-');
@@ -132,23 +132,23 @@ abstract class AbstractStorageTest extends TestCase {
         Config::set('cache.prefix', '');
     }
 
-    public function testHas() {
+    public function testHas(): void {
         $this->assertTrue($this->object->has('foo'));
         $this->assertFalse($this->object->has('foobar'));
     }
 
-    public function testIncrement() {
+    public function testIncrement(): void {
         $this->assertEquals(1, $this->object->get('count'));
         $this->assertEquals(2, $this->object->increment('count', 1));
         $this->assertEquals(7, $this->object->increment('count', 5));
     }
 
-    public function testIncrementInitialSet() {
+    public function testIncrementInitialSet(): void {
         $this->assertSame(1, $this->object->increment('missing'));
         $this->assertSame(6, $this->object->increment('missing', 5));
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $this->assertTrue($this->object->has('foo'));
 
         $this->object->remove('foo');
@@ -156,7 +156,7 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertFalse($this->object->has('foo'));
     }
 
-    public function testSave() {
+    public function testSave(): void {
         $this->assertFalse($this->object->has('bar'));
 
         $this->object->save(new Item('bar', 123));
@@ -164,7 +164,7 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertTrue($this->object->has('bar'));
     }
 
-    public function testSaveInvalidExpiration() {
+    public function testSaveInvalidExpiration(): void {
         $this->assertFalse($this->object->has('bar'));
 
         $this->object->save(new Item('bar', 123, new \DateTime()));
@@ -172,7 +172,7 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertFalse($this->object->has('bar'));
     }
 
-    public function testSet() {
+    public function testSet(): void {
         $this->assertEquals(['username' => 'Titon'], $this->object->get('foo'));
 
         $this->object->set('foo', ['username' => 'Titon Framework'], strtotime('+10 minutes'));
@@ -180,11 +180,11 @@ abstract class AbstractStorageTest extends TestCase {
         $this->assertEquals(['username' => 'Titon Framework'], $this->object->get('foo'));
     }
 
-    public function testStats() {
+    public function testStats(): void {
         $this->assertInstanceOf('HH\Map', $this->object->stats());
     }
 
-    public function testStore() {
+    public function testStore(): void {
         $this->assertEquals('foo', $this->object->store('storeTest', () ==> 'foo'));
 
         $this->assertEquals('foo', $this->object->store('storeTest', () ==> 'bar'));

--- a/tests/Titon/Cache/Storage/AbstractStorageTest.hh
+++ b/tests/Titon/Cache/Storage/AbstractStorageTest.hh
@@ -185,17 +185,11 @@ abstract class AbstractStorageTest extends TestCase {
     }
 
     public function testStore() {
-        $this->assertEquals('foo', $this->object->store('storeTest', function() {
-            return 'foo';
-        }));
+        $this->assertEquals('foo', $this->object->store('storeTest', () ==> 'foo'));
 
-        $this->assertEquals('foo', $this->object->store('storeTest', function() {
-            return 'bar';
-        }));
+        $this->assertEquals('foo', $this->object->store('storeTest', () ==> 'bar'));
 
-        $this->assertEquals('foo', $this->object->store('storeTest', function() {
-            return 'baz';
-        }));
+        $this->assertEquals('foo', $this->object->store('storeTest', () ==> 'baz'));
     }
 
 }

--- a/tests/Titon/Cache/Storage/ApcStorageTest.hh
+++ b/tests/Titon/Cache/Storage/ApcStorageTest.hh
@@ -1,9 +1,9 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache\Storage;
 
 class ApcStorageTest extends AbstractStorageTest {
 
-    protected function setUp() {
+    protected function setUp(): void {
         if (!extension_loaded('apc')) {
             $this->markTestSkipped('APC is not installed or configured properly');
         }

--- a/tests/Titon/Cache/Storage/ApcStorageTest.hh
+++ b/tests/Titon/Cache/Storage/ApcStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache\Storage;
 
 class ApcStorageTest extends AbstractStorageTest {

--- a/tests/Titon/Cache/Storage/DatabaseStorageTest.hh
+++ b/tests/Titon/Cache/Storage/DatabaseStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache\Storage;
 
 use Titon\Db\Query;
@@ -6,7 +6,7 @@ use Titon\Test\Stub\Repository\Cache;
 
 class DatabaseStorageTest extends AbstractStorageTest {
 
-    protected function setUp() {
+    protected function setUp(): void {
         if (!class_exists('Titon\Db\Query')) {
             $this->markTestSkipped('Requires the model package');
         }
@@ -18,7 +18,7 @@ class DatabaseStorageTest extends AbstractStorageTest {
         parent::setUp();
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         parent::tearDown();
 
         $this->unloadFixtures('Cache');

--- a/tests/Titon/Cache/Storage/DatabaseStorageTest.hh
+++ b/tests/Titon/Cache/Storage/DatabaseStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache\Storage;
 
 use Titon\Db\Query;

--- a/tests/Titon/Cache/Storage/DatabaseStorageTest.hh
+++ b/tests/Titon/Cache/Storage/DatabaseStorageTest.hh
@@ -1,5 +1,5 @@
 <?hh
-namespace Titon\Cache\Storage;
+/*namespace Titon\Cache\Storage;
 
 use Titon\Db\Query;
 use Titon\Test\Stub\Repository\Cache;
@@ -24,4 +24,4 @@ class DatabaseStorageTest extends AbstractStorageTest {
         $this->unloadFixtures('Cache');
     }
 
-}
+}*/

--- a/tests/Titon/Cache/Storage/FileSystemStorageTest.hh
+++ b/tests/Titon/Cache/Storage/FileSystemStorageTest.hh
@@ -1,13 +1,12 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache\Storage;
 
 class FileSystemStorageTest extends AbstractStorageTest {
 
     protected function setUp(): void {
-        $this->setupVFS();
-        $this->vfs->createDirectory('/cache/');
+        $this->vfs()->createDirectory('/cache/');
 
-        $this->object = new FileSystemStorage($this->vfs->path('/cache/'), 'fs-');
+        $this->object = new FileSystemStorage($this->vfs()->path('/cache/'), 'fs-');
 
         parent::setUp();
     }
@@ -20,21 +19,21 @@ class FileSystemStorageTest extends AbstractStorageTest {
     }
 
     public function testFlush(): void {
-        $this->assertFileExists($this->vfs->path('/cache/fs-foo.cache'));
+        $this->assertFileExists($this->vfs()->path('/cache/fs-foo.cache'));
 
         $this->object->flush();
 
-        $this->assertFileNotExists($this->vfs->path('/cache/fs-foo.cache'));
+        $this->assertFileNotExists($this->vfs()->path('/cache/fs-foo.cache'));
     }
 
     public function testRemove(): void {
         $this->assertTrue($this->object->has('foo'));
-        $this->assertFileExists($this->vfs->path('/cache/fs-foo.cache'));
+        $this->assertFileExists($this->vfs()->path('/cache/fs-foo.cache'));
 
         $this->object->remove('foo');
 
         $this->assertFalse($this->object->has('foo'));
-        $this->assertFileNotExists($this->vfs->path('/cache/fs-foo.cache'));
+        $this->assertFileNotExists($this->vfs()->path('/cache/fs-foo.cache'));
     }
 
 }

--- a/tests/Titon/Cache/Storage/FileSystemStorageTest.hh
+++ b/tests/Titon/Cache/Storage/FileSystemStorageTest.hh
@@ -1,9 +1,9 @@
-<?php
+<?hh // strict
 namespace Titon\Cache\Storage;
 
 class FileSystemStorageTest extends AbstractStorageTest {
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->setupVFS();
         $this->vfs->createDirectory('/cache/');
 
@@ -15,11 +15,11 @@ class FileSystemStorageTest extends AbstractStorageTest {
     /**
      * @expectedException \Titon\Io\Exception\InvalidPathException
      */
-    public function testExceptionThrownMissingDir() {
+    public function testExceptionThrownMissingDir(): void {
         new FileSystemStorage('');
     }
 
-    public function testFlush() {
+    public function testFlush(): void {
         $this->assertFileExists($this->vfs->path('/cache/fs-foo.cache'));
 
         $this->object->flush();
@@ -27,7 +27,7 @@ class FileSystemStorageTest extends AbstractStorageTest {
         $this->assertFileNotExists($this->vfs->path('/cache/fs-foo.cache'));
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $this->assertTrue($this->object->has('foo'));
         $this->assertFileExists($this->vfs->path('/cache/fs-foo.cache'));
 

--- a/tests/Titon/Cache/Storage/MemcacheStorageTest.hh
+++ b/tests/Titon/Cache/Storage/MemcacheStorageTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache\Storage;
 
 use \Memcached;
 
 class MemcacheStorageTest extends AbstractStorageTest {
 
-    protected function setUp() {
+    protected function setUp(): void {
         if (!extension_loaded('memcached')) {
             $this->markTestSkipped('Memcache is not installed or configured properly');
         }

--- a/tests/Titon/Cache/Storage/MemcacheStorageTest.hh
+++ b/tests/Titon/Cache/Storage/MemcacheStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache\Storage;
 
 use \Memcached;

--- a/tests/Titon/Cache/Storage/MemoryStorageTest.hh
+++ b/tests/Titon/Cache/Storage/MemoryStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache\Storage;
 
 class MemoryStorageTest extends AbstractStorageTest {

--- a/tests/Titon/Cache/Storage/MemoryStorageTest.hh
+++ b/tests/Titon/Cache/Storage/MemoryStorageTest.hh
@@ -1,9 +1,9 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache\Storage;
 
 class MemoryStorageTest extends AbstractStorageTest {
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->object = new MemoryStorage('memory-');
 
         parent::setUp();

--- a/tests/Titon/Cache/Storage/RedisStorageTest.hh
+++ b/tests/Titon/Cache/Storage/RedisStorageTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Cache\Storage;
 
 use \Redis;

--- a/tests/Titon/Cache/Storage/RedisStorageTest.hh
+++ b/tests/Titon/Cache/Storage/RedisStorageTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Cache\Storage;
 
 use \Redis;
 
 class RedisStorageTest extends AbstractStorageTest {
 
-    protected function setUp() {
+    protected function setUp(): void {
         if (!extension_loaded('redis')) {
             $this->markTestSkipped('Redis is not installed or configured properly');
         }

--- a/tests/Titon/Common/BagTest.hh
+++ b/tests/Titon/Common/BagTest.hh
@@ -1,11 +1,11 @@
 <?hh
 namespace Titon\Common;
 
-use Titon\Common\Bag\AbstractBag;
+use Titon\Test\Stub\Common\BagStub;
 use Titon\Test\TestCase;
 
 /**
- * @property \Titon\Common\BagStub $object
+ * @property \Titon\Common\Bag $object
  */
 class BagTest extends TestCase {
 
@@ -139,9 +139,5 @@ class BagTest extends TestCase {
 
         $this->assertEquals(5, $this->object->count());
     }
-
-}
-
-class BagStub extends AbstractBag {
 
 }

--- a/tests/Titon/Common/BagTest.hh
+++ b/tests/Titon/Common/BagTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\BagStub;
@@ -20,13 +20,13 @@ class BagTest extends TestCase {
         'vector' => Vector {1, 2, 3}
     };
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new BagStub($this->defaults);
     }
 
-    public function testAdd() {
+    public function testAdd(): void {
         $this->object->add(Map {
             'boolean' => false,
             'foo' => 'bar'
@@ -39,11 +39,11 @@ class BagTest extends TestCase {
         $this->assertEquals($defaults, $this->object->all());
     }
 
-    public function testAll() {
+    public function testAll(): void {
         $this->assertEquals($this->defaults, $this->object->all());
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $this->assertEquals(true, $this->object->boolean);
         $this->assertEquals(true, $this->object->get('boolean'));
         $this->object->boolean = false;
@@ -63,11 +63,11 @@ class BagTest extends TestCase {
         $this->assertEquals(null, $this->object->get('fakeKey'));
     }
 
-    public function testKeys() {
+    public function testKeys(): void {
         $this->assertEquals(Vector {'boolean', 'integer', 'string', 'float', 'map', 'vector'}, $this->object->keys());
     }
 
-    public function testSet() {
+    public function testSet(): void {
         $this->object->set('boolean', false);
         $this->assertEquals(false, $this->object->boolean);
 
@@ -96,7 +96,7 @@ class BagTest extends TestCase {
         $this->assertEquals('test', $this->object->get('custom'));
     }
 
-    public function testHas() {
+    public function testHas(): void {
         $this->assertTrue($this->object->has('integer'));
         $this->assertTrue(isset($this->object->integer));
 
@@ -106,7 +106,7 @@ class BagTest extends TestCase {
         $this->assertFalse(isset($this->object->fakeKey));
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $this->object->remove('string')->remove('map');
         $this->assertEquals(Map {
             'boolean' => true,
@@ -122,7 +122,7 @@ class BagTest extends TestCase {
         }, $this->object->all());
     }
 
-    public function testIterator() {
+    public function testIterator(): void {
         $config = Map {};
 
         foreach ($this->object as $key => $value) {
@@ -132,7 +132,7 @@ class BagTest extends TestCase {
         $this->assertEquals($this->defaults, $config);
     }
 
-    public function testCount() {
+    public function testCount(): void {
         $this->assertEquals(6, $this->object->count());
 
         unset($this->object->string);

--- a/tests/Titon/Common/BagTest.hh
+++ b/tests/Titon/Common/BagTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\BagStub;

--- a/tests/Titon/Common/CacheableTest.hh
+++ b/tests/Titon/Common/CacheableTest.hh
@@ -1,10 +1,11 @@
 <?hh
 namespace Titon\Common;
 
+use Titon\Test\Stub\Common\CacheableStub;
 use Titon\Test\TestCase;
 
 /**
- * @property \Titon\Common\CacheableStub $object
+ * @property \Titon\Test\Stub\Common\CacheableStub $object
  */
 class CacheableTest extends TestCase {
 
@@ -40,7 +41,7 @@ class CacheableTest extends TestCase {
         $this->object->cache('class', function($parent) {
             return get_class($parent);
         });
-        $this->assertEquals('Titon\Common\CacheableStub', $this->object->getCache('class'));
+        $this->assertEquals('Titon\Test\Stub\Common\CacheableStub', $this->object->getCache('class'));
 
         $this->object->cache('false', function() {
             return false;
@@ -128,8 +129,4 @@ class CacheableTest extends TestCase {
         $this->assertEquals('value', $this->object->getCache('key'));
     }
 
-}
-
-class CacheableStub {
-    use Cacheable;
 }

--- a/tests/Titon/Common/CacheableTest.hh
+++ b/tests/Titon/Common/CacheableTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\CacheableStub;
@@ -9,75 +9,75 @@ use Titon\Test\TestCase;
  */
 class CacheableTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new CacheableStub();
         $this->object->setCache('key', 'value');
     }
 
-    public function testCache() {
-        $this->object->cache('foo', function() {
+    public function testCache(): void {
+        $this->object->cache('foo', function(): void {
             return 'bar';
         });
         $this->assertEquals('bar', $this->object->getCache('foo'));
 
         // doesn't overwrite
-        $this->object->cache('foo', function() {
+        $this->object->cache('foo', function(): void {
             return 'baz';
         });
         $this->assertEquals('bar', $this->object->getCache('foo'));
 
-        $this->object->cache('number', function() {
+        $this->object->cache('number', function(): void {
             return 12345;
         });
         $this->assertEquals(12345, $this->object->getCache('number'));
 
-        $this->object->cache('closure', function() {
+        $this->object->cache('closure', function(): void {
             return (100 * 22);
         });
         $this->assertEquals(2200, $this->object->getCache('closure'));
 
-        $this->object->cache('class', function($parent) {
+        $this->object->cache('class', function($parent): void {
             return get_class($parent);
         });
         $this->assertEquals('Titon\Test\Stub\Common\CacheableStub', $this->object->getCache('class'));
 
-        $this->object->cache('false', function() {
+        $this->object->cache('false', function(): void {
             return false;
         });
         $this->assertEquals(false, $this->object->getCache('false'));
 
-        $this->object->cache('null', function() {
+        $this->object->cache('null', function(): void {
             return null;
         });
         $this->assertEquals(null, $this->object->getCache('null'));
 
-        $this->object->cache('zero', function() {
+        $this->object->cache('zero', function(): void {
             return 0;
         });
         $this->assertEquals(0, $this->object->getCache('zero'));
 
-        $this->object->cache('array', function() {
+        $this->object->cache('array', function(): void {
             return [];
         });
         $this->assertEquals([], $this->object->getCache('array'));
     }
 
-    public function testCreateCacheKey() {
+    public function testCreateCacheKey(): void {
         $this->assertEquals('foo', $this->object->createCacheKey('foo'));
         $this->assertEquals('foo-bar', $this->object->createCacheKey(['foo', 'bar']));
         $this->assertEquals('foo-12345-bar', $this->object->createCacheKey(['foo', 12345, 'bar']));
         $this->assertEquals('foo-12345-bar-d3e545e5b6dd7d1c9c7be76d5bb18241', $this->object->createCacheKey(['foo', 12345, 'bar', ['nested', 'array']]));
     }
 
-    public function testFlushCache() {
+    public function testFlushCache(): void {
         $this->assertEquals(Map {'key' => 'value'}, $this->object->allCache());
         $this->object->flushCache();
         $this->assertEquals(Map {}, $this->object->allCache());
     }
 
-    public function testGetCache() {
+    public function testGetCache(): void {
         $this->assertEquals('value', $this->object->getCache('key'));
         $this->assertEquals(null, $this->object->getCache('foo'));
 
@@ -94,19 +94,19 @@ class CacheableTest extends TestCase {
         }, $this->object->allCache());
     }
 
-    public function testHasCache() {
+    public function testHasCache(): void {
         $this->assertTrue($this->object->hasCache('key'));
         $this->assertFalse($this->object->hasCache('foo'));
     }
 
-    public function testRemoveCache() {
+    public function testRemoveCache(): void {
         $this->object->removeCache('key');
         $this->object->removeCache('foo');
 
         $this->assertEquals(Map {}, $this->object->allCache());
     }
 
-    public function testSetCache() {
+    public function testSetCache(): void {
         $this->assertEquals('bar', $this->object->setCache('foo', 'bar'));
         $this->assertEquals(12345, $this->object->setCache('key', 12345));
 
@@ -116,7 +116,7 @@ class CacheableTest extends TestCase {
         }, $this->object->allCache());
     }
 
-    public function testToggleCache() {
+    public function testToggleCache(): void {
         $this->assertEquals('value', $this->object->getCache('key'));
 
         $this->object->toggleCache(false);

--- a/tests/Titon/Common/CacheableTest.hh
+++ b/tests/Titon/Common/CacheableTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\CacheableStub;

--- a/tests/Titon/Common/CacheableTest.hh
+++ b/tests/Titon/Common/CacheableTest.hh
@@ -17,48 +17,48 @@ class CacheableTest extends TestCase {
     }
 
     public function testCache(): void {
-        $this->object->cache('foo', function(): void {
+        $this->object->cache('foo', () ==> {
             return 'bar';
         });
         $this->assertEquals('bar', $this->object->getCache('foo'));
 
         // doesn't overwrite
-        $this->object->cache('foo', function(): void {
+        $this->object->cache('foo', () ==> {
             return 'baz';
         });
         $this->assertEquals('bar', $this->object->getCache('foo'));
 
-        $this->object->cache('number', function(): void {
+        $this->object->cache('number', () ==> {
             return 12345;
         });
         $this->assertEquals(12345, $this->object->getCache('number'));
 
-        $this->object->cache('closure', function(): void {
+        $this->object->cache('closure', () ==> {
             return (100 * 22);
         });
         $this->assertEquals(2200, $this->object->getCache('closure'));
 
-        $this->object->cache('class', function($parent): void {
+        $this->object->cache('class', ($parent) ==> {
             return get_class($parent);
         });
         $this->assertEquals('Titon\Test\Stub\Common\CacheableStub', $this->object->getCache('class'));
 
-        $this->object->cache('false', function(): void {
+        $this->object->cache('false', () ==> {
             return false;
         });
         $this->assertEquals(false, $this->object->getCache('false'));
 
-        $this->object->cache('null', function(): void {
+        $this->object->cache('null', () ==> {
             return null;
         });
         $this->assertEquals(null, $this->object->getCache('null'));
 
-        $this->object->cache('zero', function(): void {
+        $this->object->cache('zero', () ==> {
             return 0;
         });
         $this->assertEquals(0, $this->object->getCache('zero'));
 
-        $this->object->cache('array', function(): void {
+        $this->object->cache('array', () ==> {
             return [];
         });
         $this->assertEquals([], $this->object->getCache('array'));

--- a/tests/Titon/Common/MacroableTest.hh
+++ b/tests/Titon/Common/MacroableTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Common;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Common/MacroableTest.hh
+++ b/tests/Titon/Common/MacroableTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Common;
 
 use Titon\Test\TestCase;
@@ -10,28 +10,28 @@ use Titon\Utility\Path;
 
 class MacroableTest extends TestCase {
 
-    public function testHasMacro() {
+    public function testHasMacro(): void {
         $this->assertFalse(Number::hasMacro('toBinary'));
         $this->assertFalse(Number::hasMacro('toFloat'));
 
-        Number::macro('toFloat', function() {});
+        Number::macro('toFloat', function(): void {});
 
         $this->assertFalse(Number::hasMacro('toBinary'));
         $this->assertTrue(Number::hasMacro('toFloat'));
     }
 
-    public function testInheritance() {
+    public function testInheritance(): void {
         $this->assertFalse(Format::hasMacro('foobar'));
         $this->assertFalse(Path::hasMacro('foobar'));
 
-        Format::macro('foobar', function() {});
+        Format::macro('foobar', function(): void {});
 
         $this->assertTrue(Format::hasMacro('foobar'));
         $this->assertFalse(Path::hasMacro('foobar'));
     }
 
-    public function testMacro() {
-        Inflector::macro('caps', function($value) {
+    public function testMacro(): void {
+        Inflector::macro('caps', function($value): void {
             return strtoupper($value);
         });
 
@@ -41,16 +41,16 @@ class MacroableTest extends TestCase {
     /**
      * @expectedException \Titon\Common\Exception\MissingMacroException
      */
-    public function testMacroMissing() {
+    public function testMacroMissing(): void {
         Inflector::lowers('foObAr');
     }
 
-    public function testGetMacros() {
-        $lower = function($value) {
+    public function testGetMacros(): void {
+        $lower = function($value): void {
             return strtolower($value);
         };
 
-        $upper = function($value) {
+        $upper = function($value): void {
             return strtoupper($value);
         };
 

--- a/tests/Titon/Common/MacroableTest.hh
+++ b/tests/Titon/Common/MacroableTest.hh
@@ -14,7 +14,9 @@ class MacroableTest extends TestCase {
         $this->assertFalse(Number::hasMacro('toBinary'));
         $this->assertFalse(Number::hasMacro('toFloat'));
 
-        Number::macro('toFloat', () ==> 0.0);
+        Number::macro('toFloat', function() {
+            return 0.0;
+        });
 
         $this->assertFalse(Number::hasMacro('toBinary'));
         $this->assertTrue(Number::hasMacro('toFloat'));
@@ -24,14 +26,16 @@ class MacroableTest extends TestCase {
         $this->assertFalse(Format::hasMacro('foobar'));
         $this->assertFalse(Path::hasMacro('foobar'));
 
-        Format::macro('foobar', () ==> '');
+        Format::macro('foobar', function() {
+            return '';
+        });
 
         $this->assertTrue(Format::hasMacro('foobar'));
         $this->assertFalse(Path::hasMacro('foobar'));
     }
 
     public function testMacro(): void {
-        Inflector::macro('caps', ($value) ==> {
+        Inflector::macro('caps', function($value) {
             return strtoupper($value);
         });
 
@@ -46,8 +50,13 @@ class MacroableTest extends TestCase {
     }
 
     public function testGetMacros(): void {
-        $lower = ($value) ==> strtolower($value);
-        $upper = ($value) ==> strtoupper($value);
+        $lower = function($value) {
+            return strtolower($value);
+        };
+
+        $upper = function($value) {
+            return strtoupper($value);
+        };
 
         Crypt::macro('lower', $lower);
         Crypt::macro('upper', $upper);

--- a/tests/Titon/Common/MacroableTest.hh
+++ b/tests/Titon/Common/MacroableTest.hh
@@ -14,7 +14,7 @@ class MacroableTest extends TestCase {
         $this->assertFalse(Number::hasMacro('toBinary'));
         $this->assertFalse(Number::hasMacro('toFloat'));
 
-        Number::macro('toFloat', function(): void {});
+        Number::macro('toFloat', () ==> 0.0);
 
         $this->assertFalse(Number::hasMacro('toBinary'));
         $this->assertTrue(Number::hasMacro('toFloat'));
@@ -24,14 +24,14 @@ class MacroableTest extends TestCase {
         $this->assertFalse(Format::hasMacro('foobar'));
         $this->assertFalse(Path::hasMacro('foobar'));
 
-        Format::macro('foobar', function(): void {});
+        Format::macro('foobar', () ==> '');
 
         $this->assertTrue(Format::hasMacro('foobar'));
         $this->assertFalse(Path::hasMacro('foobar'));
     }
 
     public function testMacro(): void {
-        Inflector::macro('caps', function($value): void {
+        Inflector::macro('caps', ($value) ==> {
             return strtoupper($value);
         });
 
@@ -46,13 +46,8 @@ class MacroableTest extends TestCase {
     }
 
     public function testGetMacros(): void {
-        $lower = function($value): void {
-            return strtolower($value);
-        };
-
-        $upper = function($value): void {
-            return strtoupper($value);
-        };
+        $lower = ($value) ==> strtolower($value);
+        $upper = ($value) ==> strtoupper($value);
 
         Crypt::macro('lower', $lower);
         Crypt::macro('upper', $upper);

--- a/tests/Titon/Common/MutableTest.hh
+++ b/tests/Titon/Common/MutableTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\MutableStub;
@@ -9,13 +9,13 @@ use Titon\Test\TestCase;
  */
 class MutableTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new MutableStub();
     }
 
-    public function testAddAll() {
+    public function testAddAll(): void {
         $this->object->set('foo', 'bar');
 
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->all());
@@ -31,7 +31,7 @@ class MutableTest extends TestCase {
         }, $this->object->all());
     }
 
-    public function testFlush() {
+    public function testFlush(): void {
         $this->object->set('foo', 'bar');
 
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->all());
@@ -41,7 +41,7 @@ class MutableTest extends TestCase {
         $this->assertEquals(Map {}, $this->object->all());
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $this->object->set('foo', 'bar');
 
         $this->assertEquals('bar', $this->object->get('foo'));
@@ -50,7 +50,7 @@ class MutableTest extends TestCase {
         $this->assertEquals('default', $this->object->get('missing', 'default'));
     }
 
-    public function testHasRemove() {
+    public function testHasRemove(): void {
         $this->object->set('foo', 'bar');
         $this->object->set('key', 'value');
 
@@ -64,7 +64,7 @@ class MutableTest extends TestCase {
         $this->assertFalse(isset($this->object->key));
     }
 
-    public function testSet() {
+    public function testSet(): void {
         $this->object->set('a', 1);
         $this->object->b = 2;
         $this->object->c = 3;

--- a/tests/Titon/Common/MutableTest.hh
+++ b/tests/Titon/Common/MutableTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\MutableStub;

--- a/tests/Titon/Common/MutableTest.hh
+++ b/tests/Titon/Common/MutableTest.hh
@@ -1,12 +1,11 @@
 <?hh
 namespace Titon\Common;
 
+use Titon\Test\Stub\Common\MutableStub;
 use Titon\Test\TestCase;
-use \IteratorAggregate;
-use \Countable;
 
 /**
- * @property \Titon\Common\MutableStub $object
+ * @property \Titon\Test\Stub\Common\MutableStub $object
  */
 class MutableTest extends TestCase {
 
@@ -75,8 +74,4 @@ class MutableTest extends TestCase {
         $this->assertEquals(Vector {1, 2, 3}, $this->object->values());
     }
 
-}
-
-class MutableStub implements IteratorAggregate, Countable {
-    use Mutable;
 }

--- a/tests/Titon/Common/StaticCacheableTest.hh
+++ b/tests/Titon/Common/StaticCacheableTest.hh
@@ -14,48 +14,48 @@ class StaticCacheableTest extends TestCase {
     }
 
     public function testCache(): void {
-        StaticCacheableStub::cache('foo', function(): void {
+        StaticCacheableStub::cache('foo', () ==> {
             return 'bar';
         });
         $this->assertEquals('bar', StaticCacheableStub::getCache('foo'));
 
         // doesn't overwrite
-        StaticCacheableStub::cache('foo', function(): void {
+        StaticCacheableStub::cache('foo', () ==> {
             return 'baz';
         });
         $this->assertEquals('bar', StaticCacheableStub::getCache('foo'));
 
-        StaticCacheableStub::cache('number', function(): void {
+        StaticCacheableStub::cache('number', () ==> {
             return 12345;
         });
         $this->assertEquals(12345, StaticCacheableStub::getCache('number'));
 
-        StaticCacheableStub::cache('closure', function(): void {
+        StaticCacheableStub::cache('closure', () ==> {
             return (100 * 22);
         });
         $this->assertEquals(2200, StaticCacheableStub::getCache('closure'));
 
-        StaticCacheableStub::cache('class', function(): void {
+        StaticCacheableStub::cache('class', () ==> {
             return 'Titon\Common\StaticCacheableStub';
         });
         $this->assertEquals('Titon\Common\StaticCacheableStub', StaticCacheableStub::getCache('class'));
 
-        StaticCacheableStub::cache('false', function(): void {
+        StaticCacheableStub::cache('false', () ==> {
             return false;
         });
         $this->assertEquals(false, StaticCacheableStub::getCache('false'));
 
-        StaticCacheableStub::cache('null', function(): void {
+        StaticCacheableStub::cache('null', () ==> {
             return null;
         });
         $this->assertEquals(null, StaticCacheableStub::getCache('null'));
 
-        StaticCacheableStub::cache('zero', function(): void {
+        StaticCacheableStub::cache('zero', () ==> {
             return 0;
         });
         $this->assertEquals(0, StaticCacheableStub::getCache('zero'));
 
-        StaticCacheableStub::cache('array', function(): void {
+        StaticCacheableStub::cache('array', () ==> {
             return [];
         });
         $this->assertEquals([], StaticCacheableStub::getCache('array'));

--- a/tests/Titon/Common/StaticCacheableTest.hh
+++ b/tests/Titon/Common/StaticCacheableTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\StaticCacheableStub;
@@ -6,75 +6,75 @@ use Titon\Test\TestCase;
 
 class StaticCacheableTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         StaticCacheableStub::flushCache();
         StaticCacheableStub::setCache('key', 'value');
     }
 
-    public function testCache() {
-        StaticCacheableStub::cache('foo', function() {
+    public function testCache(): void {
+        StaticCacheableStub::cache('foo', function(): void {
             return 'bar';
         });
         $this->assertEquals('bar', StaticCacheableStub::getCache('foo'));
 
         // doesn't overwrite
-        StaticCacheableStub::cache('foo', function() {
+        StaticCacheableStub::cache('foo', function(): void {
             return 'baz';
         });
         $this->assertEquals('bar', StaticCacheableStub::getCache('foo'));
 
-        StaticCacheableStub::cache('number', function() {
+        StaticCacheableStub::cache('number', function(): void {
             return 12345;
         });
         $this->assertEquals(12345, StaticCacheableStub::getCache('number'));
 
-        StaticCacheableStub::cache('closure', function() {
+        StaticCacheableStub::cache('closure', function(): void {
             return (100 * 22);
         });
         $this->assertEquals(2200, StaticCacheableStub::getCache('closure'));
 
-        StaticCacheableStub::cache('class', function() {
+        StaticCacheableStub::cache('class', function(): void {
             return 'Titon\Common\StaticCacheableStub';
         });
         $this->assertEquals('Titon\Common\StaticCacheableStub', StaticCacheableStub::getCache('class'));
 
-        StaticCacheableStub::cache('false', function() {
+        StaticCacheableStub::cache('false', function(): void {
             return false;
         });
         $this->assertEquals(false, StaticCacheableStub::getCache('false'));
 
-        StaticCacheableStub::cache('null', function() {
+        StaticCacheableStub::cache('null', function(): void {
             return null;
         });
         $this->assertEquals(null, StaticCacheableStub::getCache('null'));
 
-        StaticCacheableStub::cache('zero', function() {
+        StaticCacheableStub::cache('zero', function(): void {
             return 0;
         });
         $this->assertEquals(0, StaticCacheableStub::getCache('zero'));
 
-        StaticCacheableStub::cache('array', function() {
+        StaticCacheableStub::cache('array', function(): void {
             return [];
         });
         $this->assertEquals([], StaticCacheableStub::getCache('array'));
     }
 
-    public function testCreateCacheKey() {
+    public function testCreateCacheKey(): void {
         $this->assertEquals('foo', StaticCacheableStub::createCacheKey('foo'));
         $this->assertEquals('foo-bar', StaticCacheableStub::createCacheKey(['foo', 'bar']));
         $this->assertEquals('foo-12345-bar', StaticCacheableStub::createCacheKey(['foo', 12345, 'bar']));
         $this->assertEquals('foo-12345-bar-d3e545e5b6dd7d1c9c7be76d5bb18241', StaticCacheableStub::createCacheKey(['foo', 12345, 'bar', ['nested', 'array']]));
     }
 
-    public function testFlushCache() {
+    public function testFlushCache(): void {
         $this->assertEquals(Map {'key' => 'value'}, StaticCacheableStub::allCache());
         StaticCacheableStub::flushCache();
         $this->assertEquals(Map {}, StaticCacheableStub::allCache());
     }
 
-    public function testGetCache() {
+    public function testGetCache(): void {
         $this->assertEquals('value', StaticCacheableStub::getCache('key'));
         $this->assertEquals(null, StaticCacheableStub::getCache('foo'));
 
@@ -87,19 +87,19 @@ class StaticCacheableTest extends TestCase {
         }, StaticCacheableStub::allCache());
     }
 
-    public function testHasCache() {
+    public function testHasCache(): void {
         $this->assertTrue(StaticCacheableStub::hasCache('key'));
         $this->assertFalse(StaticCacheableStub::hasCache('foo'));
     }
 
-    public function testRemoveCache() {
+    public function testRemoveCache(): void {
         StaticCacheableStub::removeCache('key');
         StaticCacheableStub::removeCache('foo');
 
         $this->assertEquals(Map {}, StaticCacheableStub::allCache());
     }
 
-    public function testSetCache() {
+    public function testSetCache(): void {
         $this->assertEquals('bar', StaticCacheableStub::setCache('foo', 'bar'));
         $this->assertEquals(12345, StaticCacheableStub::setCache('key', 12345));
 

--- a/tests/Titon/Common/StaticCacheableTest.hh
+++ b/tests/Titon/Common/StaticCacheableTest.hh
@@ -1,6 +1,7 @@
 <?hh
 namespace Titon\Common;
 
+use Titon\Test\Stub\Common\StaticCacheableStub;
 use Titon\Test\TestCase;
 
 class StaticCacheableTest extends TestCase {
@@ -108,8 +109,4 @@ class StaticCacheableTest extends TestCase {
         }, StaticCacheableStub::allCache());
     }
 
-}
-
-class StaticCacheableStub {
-    use StaticCacheable;
 }

--- a/tests/Titon/Common/StaticCacheableTest.hh
+++ b/tests/Titon/Common/StaticCacheableTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\StaticCacheableStub;

--- a/tests/Titon/Common/StringableTest.hh
+++ b/tests/Titon/Common/StringableTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\StringableStub;

--- a/tests/Titon/Common/StringableTest.hh
+++ b/tests/Titon/Common/StringableTest.hh
@@ -1,6 +1,7 @@
 <?hh
 namespace Titon\Common;
 
+use Titon\Test\Stub\Common\StringableStub;
 use Titon\Test\TestCase;
 
 class StringableTest extends TestCase {
@@ -8,12 +9,8 @@ class StringableTest extends TestCase {
     public function testToString() {
         $object = new StringableStub();
 
-        $this->assertEquals('Titon\Common\StringableStub', $object->toString());
-        $this->assertEquals('Titon\Common\StringableStub', (string) $object);
+        $this->assertEquals('Titon\Test\Stub\Common\StringableStub', $object->toString());
+        $this->assertEquals('Titon\Test\Stub\Common\StringableStub', (string) $object);
     }
 
-}
-
-class StringableStub {
-    use Stringable;
 }

--- a/tests/Titon/Common/StringableTest.hh
+++ b/tests/Titon/Common/StringableTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Common;
 
 use Titon\Test\Stub\Common\StringableStub;
@@ -6,7 +6,7 @@ use Titon\Test\TestCase;
 
 class StringableTest extends TestCase {
 
-    public function testToString() {
+    public function testToString(): void {
         $object = new StringableStub();
 
         $this->assertEquals('Titon\Test\Stub\Common\StringableStub', $object->toString());

--- a/tests/Titon/Context/DepositoryTest.hh
+++ b/tests/Titon/Context/DepositoryTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Context;
 
 use Titon\Test\Stub\Context\BarStub;
@@ -142,7 +142,7 @@ class DepositoryTest extends TestCase
 
     public function testClosureDependencyResolution()
     {
-        $bar = $this->container->make(function(FooStub $foo) {
+        $bar = $this->container->make(function(FooStub $foo): void {
             return new BarStub($foo);
         });
 

--- a/tests/Titon/Context/DepositoryTest.hh
+++ b/tests/Titon/Context/DepositoryTest.hh
@@ -1,13 +1,8 @@
 <?hh
-/**
- * @author Alex Phillips <exonintrendo@gmail.com>
- * Date: 2/5/15
- * Time: 6:05 PM
- */
-
 namespace Titon\Context;
 
-use Titon\Context\ServiceProvider\AbstractServiceProvider;
+use Titon\Test\Stub\Context\BarStub;
+use Titon\Test\Stub\Context\FooStub;
 use Titon\Test\TestCase;
 
 /**
@@ -24,129 +19,131 @@ class DepositoryTest extends TestCase
 
     public function testRegisterClassName()
     {
-        $this->container->register('foo', 'Titon\Context\Foo');
+        $this->container->register('foo', 'Titon\Test\Stub\Context\FooStub');
 
         $this->assertTrue($this->container->isRegistered('foo'));
-        $this->assertTrue($this->container->isRegistered('Titon\Context\Foo'));
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('foo'));
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('Titon\Context\Foo'));
+        $this->assertTrue($this->container->isRegistered('Titon\Test\Stub\Context\FooStub'));
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
     public function testRegisterInstance()
     {
-        $this->container->register('foo', new Foo());
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('foo'));
+        $this->container->register('foo', new FooStub());
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertTrue($this->container->isSingleton('foo'));
-        $this->assertSame($this->container->make('foo'), $this->container->make('Titon\Context\Foo'));
+        $this->assertSame($this->container->make('foo'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
     public function testRegisterClosure()
     {
         $this->container->register('foo', function(){
-            $foo = new Foo('Foo');
+            $foo = new FooStub('Foo');
 
             return $foo;
         });
 
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('foo'));
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertEquals('Foo', $this->container->make('foo')->getName());
     }
 
     public function testRegisterCallable()
     {
-        $this->container->register('foo', ['Titon\Context\Foo', 'factory']);
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('foo'));
+        $this->container->register('foo', ['Titon\Test\Stub\Context\FooStub', 'factory']);
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
 
-        $this->container->register('Foo', 'Titon\Context\Foo::factory');
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('Foo'));
+        $this->container->register('Foo', 'Titon\Test\Stub\Context\FooStub::factory');
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('Foo'));
     }
 
     public function testAutoDependencyResolution()
     {
-        $test = $this->container->make('Titon\Context\Bar');
-        $this->assertInstanceOf('Titon\Context\Bar', $test);
-        $this->assertInstanceOf('Titon\Context\Foo', $test->getFoo());
+        $test = $this->container->make('Titon\Test\Stub\Context\BarStub');
+        $this->assertInstanceOf('Titon\Test\Stub\Context\BarStub', $test);
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $test->getFoo());
     }
 
     public function testSingletonNestedResolution()
     {
-        $this->container->singleton('foo', 'Titon\Context\Foo');
+        $this->container->singleton('foo', 'Titon\Test\Stub\Context\FooStub');
+
         $foo = $this->container->make('foo');
-        $bar = $this->container->make('Titon\Context\Bar');
+        $bar = $this->container->make('Titon\Test\Stub\Context\BarStub');
+
         $this->assertSame($foo, $bar->getFoo());
-        $this->assertSame($foo, $this->container->make('Titon\Context\Foo'));
+        $this->assertSame($foo, $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
     public function testMethodInjection()
     {
-        $this->container->register('foo', 'Titon\Context\Foo')->call('setName', 'Foo Bar');
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('foo'));
+        $this->container->register('foo', 'Titon\Test\Stub\Context\FooStub')->call('setName', 'Foo Bar');
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertEquals('Foo Bar', $this->container->make('foo')->getName());
 
         $this->container->remove('foo');
 
-        $this->container->register('foo', 'Titon\Context\Foo')->call('setBar', new Bar(new Foo('Alex Phillips')));
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('foo'));
+        $this->container->register('foo', 'Titon\Test\Stub\Context\FooStub')->call('setBar', new BarStub(new FooStub('Alex Phillips')));
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertEquals('Alex Phillips', $this->container->make('foo')->getName());
     }
 
     public function testMethodChaining()
     {
-        $test = $this->container->make('Titon\Context\Bar')->getFoo();
-        $this->assertInstanceOf('Titon\Context\Foo', $test);
+        $test = $this->container->make('Titon\Test\Stub\Context\BarStub')->getFoo();
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $test);
     }
 
     public function testConstructorInjection()
     {
-        $this->container->register('bar', 'Titon\Context\Bar')->with('Titon\Context\Foo');
-        $this->assertInstanceOf('Titon\Context\Bar', $this->container->make('bar'));
+        $this->container->register('bar', 'Titon\Test\Stub\Context\BarStub')->with('Titon\Test\Stub\Context\FooStub');
+        $this->assertInstanceOf('Titon\Test\Stub\Context\BarStub', $this->container->make('bar'));
 
         $this->container->remove('bar');
 
-        $this->container->register('bar', 'Titon\Context\Bar')->with((new Foo())->setName('Foo Bar'));
-        $this->assertInstanceOf('Titon\Context\Bar', $this->container->make('bar'));
+        $this->container->register('bar', 'Titon\Test\Stub\Context\BarStub')->with((new FooStub())->setName('Foo Bar'));
+        $this->assertInstanceOf('Titon\Test\Stub\Context\BarStub', $this->container->make('bar'));
         $this->assertEquals($this->container->make('bar')->getFoo()->getName(), 'Foo Bar');
     }
 
     public function testPassArgumentsAtMake()
     {
-        $this->container->register('bar', 'Titon\Context\Bar');
-        $test = $this->container->make('bar', new Foo('Foo Bar'));
-        $this->assertInstanceOf('Titon\Context\Bar', $test);
+        $this->container->register('bar', 'Titon\Test\Stub\Context\BarStub');
+        $test = $this->container->make('bar', new FooStub('Foo Bar'));
+        $this->assertInstanceOf('Titon\Test\Stub\Context\BarStub', $test);
         $this->assertEquals('Foo Bar', $test->getFoo()->getName());
     }
 
     public function testAliasing()
     {
-        $this->container->register('foo', 'Titon\Context\Foo', true);
-        $this->container->alias('foobar', 'Titon\Context\Foo');
+        $this->container->register('foo', 'Titon\Test\Stub\Context\FooStub', true);
+        $this->container->alias('foobar', 'Titon\Test\Stub\Context\FooStub');
 
         $this->assertSame($this->container->make('foo'), $this->container->make('foobar'));
-        $this->assertSame($this->container->make('foobar'), $this->container->make('Titon\Context\Foo'));
+        $this->assertSame($this->container->make('foobar'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
     public function testAliasChaining()
     {
-        $this->container->register('Titon\Context\Foo')->alias('foo');
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('Titon\Context\Foo'));
-        $this->assertInstanceOf('Titon\Context\Foo', $this->container->make('foo'));
+        $this->container->register('Titon\Test\Stub\Context\FooStub')->alias('foo');
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('Titon\Test\Stub\Context\FooStub'));
+        $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
     }
 
     public function testNestedDependencyResolution()
     {
-        $test = $this->container->make('Titon\Context\Bar');
+        $test = $this->container->make('Titon\Test\Stub\Context\BarStub');
         $this->assertEquals('Alex Phillips', $test->getFoo()->getName());
     }
 
     public function testCallableResolution()
     {
-        $this->assertEquals('Alex Phillips', $this->container->make('Titon\Context\FooBar'));
+        $this->assertEquals('Alex Phillips', $this->container->make('Titon\Test\Stub\Context\foo_stub_func'));
     }
 
     public function testClosureDependencyResolution()
     {
-        $bar = $this->container->make(function (Foo $foo) {
-            return new Bar($foo);
+        $bar = $this->container->make(function(FooStub $foo) {
+            return new BarStub($foo);
         });
 
         $this->assertEquals('Alex Phillips', $bar->getFoo()->getName());
@@ -154,96 +151,20 @@ class DepositoryTest extends TestCase
 
     public function testMakeSingleton()
     {
-        $this->container->register('Titon\Context\Foo');
-        $this->assertNotSame($this->container->make('Titon\Context\Foo'), $this->container->make('Titon\Context\Foo'));
+        $this->container->register('Titon\Test\Stub\Context\FooStub');
+        $this->assertNotSame($this->container->make('Titon\Test\Stub\Context\FooStub'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
 
-        $this->container->makeSingleton('Titon\Context\Foo');
-        $this->assertSame($this->container->make('Titon\Context\Foo'), $this->container->make('Titon\Context\Foo'));
+        $this->container->makeSingleton('Titon\Test\Stub\Context\FooStub');
+        $this->assertSame($this->container->make('Titon\Test\Stub\Context\FooStub'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
     public function testServiceProviders()
     {
-        $this->container->addServiceProvider('Titon\Context\SomeServiceProvider');
-        $this->assertEquals(new Foo(), $this->container->make('Titon\Context\Foo'));
-        $this->assertEquals(new Foo(), $this->container->make('foo'));
+        $this->container->addServiceProvider('Titon\Test\Stub\Context\FooServiceProviderStub');
+        $this->assertEquals(new FooStub(), $this->container->make('Titon\Test\Stub\Context\FooStub'));
+        $this->assertEquals(new FooStub(), $this->container->make('foo'));
 
-        $this->container->addServiceProvider('Titon\Context\AnotherServiceProvider');
-        $this->assertSame($this->container->make('bar'), $this->container->make('Titon\Context\Bar'));
-    }
-}
-
-class Foo
-{
-    public $name;
-
-    private $bar;
-
-    public function __construct($name = 'Alex Phillips')
-    {
-        $this->name = $name;
-    }
-
-    public static function factory($name = 'Alex Phillips')
-    {
-        return new Foo($name);
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    public function setName($name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    public function setBar(Bar $bar)
-    {
-        $this->bar = $bar;
-    }
-}
-
-class Bar
-{
-    private $foo;
-
-    public function __construct(Foo $foo)
-    {
-        $this->foo = $foo;
-    }
-
-    public function getFoo()
-    {
-        return $this->foo;
-    }
-
-    public function setFoo($foo)
-    {
-        $this->foo = $foo;
-    }
-}
-
-function FooBar(Foo $foo) {
-    return $foo->getName();
-}
-
-class SomeServiceProvider extends AbstractServiceProvider {
-
-    protected ClassList $provides = Vector {
-        'Titon\Context\Foo'
-    };
-
-    public function register() {
-        $this->depository->register('foo', 'Titon\Context\Foo');
-    }
-}
-
-class AnotherServiceProvider extends AbstractServiceProvider {
-
-    public function register() {
-        $this->depository->singleton('bar', 'Titon\Context\Bar')->with('Titon\Context\Foo');
+        $this->container->addServiceProvider('Titon\Test\Stub\Context\BarServiceProviderStub');
+        $this->assertSame($this->container->make('bar'), $this->container->make('Titon\Test\Stub\Context\BarStub'));
     }
 }

--- a/tests/Titon/Context/DepositoryTest.hh
+++ b/tests/Titon/Context/DepositoryTest.hh
@@ -37,11 +37,7 @@ class DepositoryTest extends TestCase
 
     public function testRegisterClosure()
     {
-        $this->container->register('foo', function(){
-            $foo = new FooStub('Foo');
-
-            return $foo;
-        });
+        $this->container->register('foo', () ==> new FooStub('Foo'));
 
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertEquals('Foo', $this->container->make('foo')->getName());
@@ -142,9 +138,7 @@ class DepositoryTest extends TestCase
 
     public function testClosureDependencyResolution()
     {
-        $bar = $this->container->make(function(FooStub $foo): void {
-            return new BarStub($foo);
-        });
+        $bar = $this->container->make((FooStub $foo) ==> new BarStub($foo));
 
         $this->assertEquals('Alex Phillips', $bar->getFoo()->getName());
     }

--- a/tests/Titon/Context/DepositoryTest.hh
+++ b/tests/Titon/Context/DepositoryTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Context;
 
 use Titon\Test\Stub\Context\BarStub;
@@ -10,15 +10,13 @@ use Titon\Test\TestCase;
  */
 class DepositoryTest extends TestCase
 {
-    protected function setUp()
-    {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->container = new Depository();
     }
 
-    public function testRegisterClassName()
-    {
+    public function testRegisterClassName(): void {
         $this->container->register('foo', 'Titon\Test\Stub\Context\FooStub');
 
         $this->assertTrue($this->container->isRegistered('foo'));
@@ -27,24 +25,21 @@ class DepositoryTest extends TestCase
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
-    public function testRegisterInstance()
-    {
+    public function testRegisterInstance(): void {
         $this->container->register('foo', new FooStub());
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertTrue($this->container->isSingleton('foo'));
         $this->assertSame($this->container->make('foo'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
-    public function testRegisterClosure()
-    {
+    public function testRegisterClosure(): void {
         $this->container->register('foo', () ==> new FooStub('Foo'));
 
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertEquals('Foo', $this->container->make('foo')->getName());
     }
 
-    public function testRegisterCallable()
-    {
+    public function testRegisterCallable(): void {
         $this->container->register('foo', ['Titon\Test\Stub\Context\FooStub', 'factory']);
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
 
@@ -52,15 +47,13 @@ class DepositoryTest extends TestCase
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('Foo'));
     }
 
-    public function testAutoDependencyResolution()
-    {
+    public function testAutoDependencyResolution(): void {
         $test = $this->container->make('Titon\Test\Stub\Context\BarStub');
         $this->assertInstanceOf('Titon\Test\Stub\Context\BarStub', $test);
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $test->getFoo());
     }
 
-    public function testSingletonNestedResolution()
-    {
+    public function testSingletonNestedResolution(): void {
         $this->container->singleton('foo', 'Titon\Test\Stub\Context\FooStub');
 
         $foo = $this->container->make('foo');
@@ -70,8 +63,7 @@ class DepositoryTest extends TestCase
         $this->assertSame($foo, $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
-    public function testMethodInjection()
-    {
+    public function testMethodInjection(): void {
         $this->container->register('foo', 'Titon\Test\Stub\Context\FooStub')->call('setName', 'Foo Bar');
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
         $this->assertEquals('Foo Bar', $this->container->make('foo')->getName());
@@ -83,14 +75,12 @@ class DepositoryTest extends TestCase
         $this->assertEquals('Alex Phillips', $this->container->make('foo')->getName());
     }
 
-    public function testMethodChaining()
-    {
+    public function testMethodChaining(): void {
         $test = $this->container->make('Titon\Test\Stub\Context\BarStub')->getFoo();
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $test);
     }
 
-    public function testConstructorInjection()
-    {
+    public function testConstructorInjection(): void {
         $this->container->register('bar', 'Titon\Test\Stub\Context\BarStub')->with('Titon\Test\Stub\Context\FooStub');
         $this->assertInstanceOf('Titon\Test\Stub\Context\BarStub', $this->container->make('bar'));
 
@@ -101,16 +91,14 @@ class DepositoryTest extends TestCase
         $this->assertEquals($this->container->make('bar')->getFoo()->getName(), 'Foo Bar');
     }
 
-    public function testPassArgumentsAtMake()
-    {
+    public function testPassArgumentsAtMake(): void {
         $this->container->register('bar', 'Titon\Test\Stub\Context\BarStub');
         $test = $this->container->make('bar', new FooStub('Foo Bar'));
         $this->assertInstanceOf('Titon\Test\Stub\Context\BarStub', $test);
         $this->assertEquals('Foo Bar', $test->getFoo()->getName());
     }
 
-    public function testAliasing()
-    {
+    public function testAliasing(): void {
         $this->container->register('foo', 'Titon\Test\Stub\Context\FooStub', true);
         $this->container->alias('foobar', 'Titon\Test\Stub\Context\FooStub');
 
@@ -118,33 +106,28 @@ class DepositoryTest extends TestCase
         $this->assertSame($this->container->make('foobar'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
-    public function testAliasChaining()
-    {
+    public function testAliasChaining(): void {
         $this->container->register('Titon\Test\Stub\Context\FooStub')->alias('foo');
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('Titon\Test\Stub\Context\FooStub'));
         $this->assertInstanceOf('Titon\Test\Stub\Context\FooStub', $this->container->make('foo'));
     }
 
-    public function testNestedDependencyResolution()
-    {
+    public function testNestedDependencyResolution(): void {
         $test = $this->container->make('Titon\Test\Stub\Context\BarStub');
         $this->assertEquals('Alex Phillips', $test->getFoo()->getName());
     }
 
-    public function testCallableResolution()
-    {
+    public function testCallableResolution(): void {
         $this->assertEquals('Alex Phillips', $this->container->make('Titon\Test\Stub\Context\foo_stub_func'));
     }
 
-    public function testClosureDependencyResolution()
-    {
+    public function testClosureDependencyResolution(): void {
         $bar = $this->container->make((FooStub $foo) ==> new BarStub($foo));
 
         $this->assertEquals('Alex Phillips', $bar->getFoo()->getName());
     }
 
-    public function testMakeSingleton()
-    {
+    public function testMakeSingleton(): void {
         $this->container->register('Titon\Test\Stub\Context\FooStub');
         $this->assertNotSame($this->container->make('Titon\Test\Stub\Context\FooStub'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
 
@@ -152,8 +135,7 @@ class DepositoryTest extends TestCase
         $this->assertSame($this->container->make('Titon\Test\Stub\Context\FooStub'), $this->container->make('Titon\Test\Stub\Context\FooStub'));
     }
 
-    public function testServiceProviders()
-    {
+    public function testServiceProviders(): void {
         $this->container->addServiceProvider('Titon\Test\Stub\Context\FooServiceProviderStub');
         $this->assertEquals(new FooStub(), $this->container->make('Titon\Test\Stub\Context\FooStub'));
         $this->assertEquals(new FooStub(), $this->container->make('foo'));
@@ -161,4 +143,5 @@ class DepositoryTest extends TestCase
         $this->container->addServiceProvider('Titon\Test\Stub\Context\BarServiceProviderStub');
         $this->assertSame($this->container->make('bar'), $this->container->make('Titon\Test\Stub\Context\BarStub'));
     }
+
 }

--- a/tests/Titon/Controller/ActionTest.hh
+++ b/tests/Titon/Controller/ActionTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Controller;
 
 use Titon\Http\Server\Request;
@@ -8,7 +8,7 @@ use Titon\Utility\State\Server;
 
 class ActionTest extends TestCase {
 
-    public function testRun() {
+    public function testRun(): void {
         $controller = new ErrorController();
         $controller->setRequest(Request::createFromGlobals());
 
@@ -22,7 +22,7 @@ class ActionTest extends TestCase {
         $this->assertEquals('bar', $controller->foo);
     }
 
-    public function testRunWorksOnOtherHttpMethods() {
+    public function testRunWorksOnOtherHttpMethods(): void {
         $_SERVER['REQUEST_METHOD'] = 'HEAD';
         Server::initialize($_SERVER);
 

--- a/tests/Titon/Controller/ActionTest.hh
+++ b/tests/Titon/Controller/ActionTest.hh
@@ -3,34 +3,34 @@ namespace Titon\Controller;
 
 use Titon\Http\Server\Request;
 use Titon\Test\Stub\Controller\ActionStub;
+use Titon\Test\Stub\Controller\ControllerStub;
 use Titon\Test\TestCase;
 use Titon\Utility\State\Server;
 
 class ActionTest extends TestCase {
 
     public function testRun(): void {
-        $controller = new ErrorController();
+        $controller = new ControllerStub();
         $controller->setRequest(Request::createFromGlobals());
 
-        $this->assertObjectNotHasAttribute('foo', $controller);
+        $this->assertEquals('', $controller->value);
 
         $action = new ActionStub();
         $controller->runAction($action);
 
         $this->assertEquals($controller, $action->getController());
-        $this->assertObjectHasAttribute('foo', $controller);
-        $this->assertEquals('bar', $controller->foo);
+        $this->assertEquals('bar', $controller->value);
     }
 
     public function testRunWorksOnOtherHttpMethods(): void {
         $_SERVER['REQUEST_METHOD'] = 'HEAD';
         Server::initialize($_SERVER);
 
-        $controller = new ErrorController();
+        $controller = new ControllerStub();
         $controller->setRequest(Request::createFromGlobals());
         $controller->runAction(new ActionStub());
 
-        $this->assertEquals('baz', $controller->foo);
+        $this->assertEquals('baz', $controller->value);
     }
 
 }

--- a/tests/Titon/Controller/ActionTest.hh
+++ b/tests/Titon/Controller/ActionTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Controller;
 
 use Titon\Http\Server\Request;

--- a/tests/Titon/Controller/ActionTest.hh
+++ b/tests/Titon/Controller/ActionTest.hh
@@ -1,8 +1,8 @@
 <?hh
 namespace Titon\Controller;
 
-use Titon\Controller\Action\AbstractAction;
 use Titon\Http\Server\Request;
+use Titon\Test\Stub\Controller\ActionStub;
 use Titon\Test\TestCase;
 use Titon\Utility\State\Server;
 
@@ -31,34 +31,6 @@ class ActionTest extends TestCase {
         $controller->runAction(new ActionStub());
 
         $this->assertEquals('baz', $controller->foo);
-    }
-
-}
-
-class ActionStub extends AbstractAction {
-
-    public function get(): mixed {
-        $this->getController()->foo = 'bar';
-
-        return 'get';
-    }
-
-    public function post(): mixed {
-        return 'post';
-    }
-
-    public function delete(): mixed {
-        return 'delete';
-    }
-
-    public function put(): mixed {
-        return 'put';
-    }
-
-    public function head(): mixed {
-        $this->getController()->foo = 'baz';
-
-        return 'head';
     }
 
 }

--- a/tests/Titon/Controller/ControllerTest.hh
+++ b/tests/Titon/Controller/ControllerTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Controller;
 
 use Titon\Http\Exception\NotFoundException;
@@ -17,8 +17,7 @@ class ControllerTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             '/views/' => [
                 'private/' => [
                     'errors/' => [
@@ -38,7 +37,7 @@ class ControllerTest extends TestCase {
             ]
         ]);
 
-        $view = new EngineView($this->vfs->path('/views/'));
+        $view = new EngineView($this->vfs()->path('/views/'));
         $view->setEngine(new TemplateEngine());
 
         $this->object = new ControllerStub();
@@ -127,7 +126,7 @@ class ControllerTest extends TestCase {
 
     public function testGetSetView(): void {
         $stub = new ControllerStub();
-        $view = new EngineView($this->vfs->path('/views/'));
+        $view = new EngineView($this->vfs()->path('/views/'));
 
         $this->assertEquals(null, $stub->getView());
 

--- a/tests/Titon/Controller/ControllerTest.hh
+++ b/tests/Titon/Controller/ControllerTest.hh
@@ -4,12 +4,13 @@ namespace Titon\Controller;
 use Titon\Http\Exception\NotFoundException;
 use Titon\Http\Server\Request;
 use Titon\Http\Server\Response;
+use Titon\Test\Stub\Controller\ControllerStub;
 use Titon\Test\TestCase;
 use Titon\View\Engine\TemplateEngine;
 use Titon\View\EngineView;
 
 /**
- * @property \Titon\Controller\ControllerStub $object
+ * @property \Titon\Test\Stub\Controller\ControllerStub $object
  */
 class ControllerTest extends TestCase {
 
@@ -132,30 +133,6 @@ class ControllerTest extends TestCase {
 
         $stub->setView($view);
         $this->assertEquals($view, $stub->getView());
-    }
-
-}
-
-class ControllerStub extends AbstractController {
-
-    public function actionWithArgs(mixed $arg1, mixed $arg2 = 0): string {
-        return strval($arg1 + $arg2);
-    }
-
-    public function actionNoArgs(): string {
-        return 'actionNoArgs';
-    }
-
-    public function _actionPseudoPrivate(): string {
-        return 'wontBeCalled';
-    }
-
-    protected function actionProtected(): string {
-        return 'wontBeCalled';
-    }
-
-    private function actionPrivate(): string {
-        return 'wontBeCalled';
     }
 
 }

--- a/tests/Titon/Controller/ControllerTest.hh
+++ b/tests/Titon/Controller/ControllerTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Controller;
 
 use Titon\Http\Exception\NotFoundException;
@@ -14,7 +14,7 @@ use Titon\View\EngineView;
  */
 class ControllerTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -47,13 +47,13 @@ class ControllerTest extends TestCase {
         $this->object->setView($view);
     }
 
-    public function testBuildViewPath() {
+    public function testBuildViewPath(): void {
         $this->assertEquals('stub/index', $this->object->buildViewPath('index'));
         $this->assertEquals('stub/action-no-args', $this->object->buildViewPath('actionNoArgs'));
         $this->assertEquals('stub/action-with-args', $this->object->buildViewPath('actionWithArgs'));
     }
 
-    public function testDispatchTo() {
+    public function testDispatchTo(): void {
         $this->assertEquals('actionNoArgs', $this->object->dispatchTo('action-no-args', []));
         $this->assertEquals('actionNoArgs', $this->object->dispatchTo('actionNoArgs', []));
         $this->assertEquals('actionNoArgs', $this->object->dispatchTo('actionNoArgs', ['foo', 'bar']));
@@ -66,11 +66,11 @@ class ControllerTest extends TestCase {
     /**
      * @expectedException \Titon\Controller\Exception\InvalidActionException
      */
-    public function testDispatchToMissingAction() {
+    public function testDispatchToMissingAction(): void {
         $this->object->dispatchTo('noAction', []);
     }
 
-    public function testForwardTo() {
+    public function testForwardTo(): void {
         $this->object->forwardTo('actionNoArgs', []);
         $this->assertEquals('actionNoArgs', $this->object->getCurrentAction());
 
@@ -78,7 +78,7 @@ class ControllerTest extends TestCase {
         $this->assertEquals('actionWithArgs', $this->object->getCurrentAction());
     }
 
-    public function testGetActionAndArguments() {
+    public function testGetActionAndArguments(): void {
         $this->object->dispatchTo('actionNoArgs', []);
         $this->assertEquals('actionNoArgs', $this->object->getCurrentAction());
         $this->assertEquals([], $this->object->getCurrentArguments());
@@ -92,7 +92,7 @@ class ControllerTest extends TestCase {
         $this->assertEquals([], $this->object->getActionArguments('noAction'));
     }
 
-    public function testRenderErrorWithNoReporting() {
+    public function testRenderErrorWithNoReporting(): void {
         $old = error_reporting(0);
 
         $this->assertEquals('404: Not Found', $this->object->renderError(new NotFoundException('Not Found')));
@@ -101,7 +101,7 @@ class ControllerTest extends TestCase {
         error_reporting($old);
     }
 
-    public function testRenderErrorWithReporting() {
+    public function testRenderErrorWithReporting(): void {
         $old = error_reporting(E_ALL);
 
         $this->assertEquals('Message', $this->object->renderError(new \Exception('Message')));
@@ -110,7 +110,7 @@ class ControllerTest extends TestCase {
         error_reporting($old);
     }
 
-    public function testRenderView() {
+    public function testRenderView(): void {
         $this->assertEquals('stub:index', $this->object->renderView());
 
         $this->object->dispatchTo('actionNoArgs', []);
@@ -120,12 +120,12 @@ class ControllerTest extends TestCase {
     /**
      * @expectedException \Titon\View\Exception\MissingTemplateException
      */
-    public function testRenderViewMissingView() {
+    public function testRenderViewMissingView(): void {
         $this->object->dispatchTo('actionWithArgs', ['foo', 'bar']);
         $this->assertEquals('stub:action-with-args', $this->object->renderView());
     }
 
-    public function testGetSetView() {
+    public function testGetSetView(): void {
         $stub = new ControllerStub();
         $view = new EngineView($this->vfs->path('/views/'));
 

--- a/tests/Titon/Debug/Annotation/DeprecatedTest.hh
+++ b/tests/Titon/Debug/Annotation/DeprecatedTest.hh
@@ -1,11 +1,10 @@
 <?hh
 namespace Titon\Debug\Annotation;
 
-use Titon\Annotation\WiresAnnotations;
 use Titon\Debug\Debugger;
 use Titon\Debug\Logger;
+use Titon\Test\Stub\Debug\DeprecatedClassStub;
 use Titon\Test\TestCase;
-use DateTime;
 
 class DeprecatedTest extends TestCase {
 
@@ -23,20 +22,11 @@ class DeprecatedTest extends TestCase {
 
         $this->assertFileNotExists($this->vfs->path($path));
 
-        $stub = new DeprecatedStub();
+        $stub = new DeprecatedClassStub();
 
         $this->assertFileExists($this->vfs->path($path));
 
-        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Debug\Annotation\DeprecatedStub', '/') . ' is deprecated\. This is the error message\./', file_get_contents($this->vfs->path($path)));
+        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Test\Stub\Debug\DeprecatedClassStub', '/') . ' is deprecated\. This is the error message\./', file_get_contents($this->vfs->path($path)));
     }
 
-}
-
-<<Deprecated('This is the error message.')>>
-class DeprecatedStub {
-    use WiresAnnotations;
-
-    public function __construct() {
-        $this->wireClassAnnotation('Deprecated');
-    }
 }

--- a/tests/Titon/Debug/Annotation/DeprecatedTest.hh
+++ b/tests/Titon/Debug/Annotation/DeprecatedTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug\Annotation;
 
 use Titon\Debug\Debugger;
@@ -11,22 +11,21 @@ class DeprecatedTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/logs/');
+        $this->vfs()->createDirectory('/logs/');
 
-        Debugger::setLogger(new Logger($this->vfs->path('/logs/')));
+        Debugger::setLogger(new Logger($this->vfs()->path('/logs/')));
     }
 
     public function testMessageIsLoggedWhenClassIsInstantiated(): void {
         $path = '/logs/notice-' . date('Y-m-d') . '.log';
 
-        $this->assertFileNotExists($this->vfs->path($path));
+        $this->assertFileNotExists($this->vfs()->path($path));
 
         $stub = new DeprecatedClassStub();
 
-        $this->assertFileExists($this->vfs->path($path));
+        $this->assertFileExists($this->vfs()->path($path));
 
-        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Test\Stub\Debug\DeprecatedClassStub', '/') . ' is deprecated\. This is the error message\./', file_get_contents($this->vfs->path($path)));
+        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Test\Stub\Debug\DeprecatedClassStub', '/') . ' is deprecated\. This is the error message\./', file_get_contents($this->vfs()->path($path)));
     }
 
 }

--- a/tests/Titon/Debug/Annotation/DeprecatedTest.hh
+++ b/tests/Titon/Debug/Annotation/DeprecatedTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug\Annotation;
 
 use Titon\Debug\Debugger;
@@ -8,7 +8,7 @@ use Titon\Test\TestCase;
 
 class DeprecatedTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -17,7 +17,7 @@ class DeprecatedTest extends TestCase {
         Debugger::setLogger(new Logger($this->vfs->path('/logs/')));
     }
 
-    public function testMessageIsLoggedWhenClassIsInstantiated() {
+    public function testMessageIsLoggedWhenClassIsInstantiated(): void {
         $path = '/logs/notice-' . date('Y-m-d') . '.log';
 
         $this->assertFileNotExists($this->vfs->path($path));

--- a/tests/Titon/Debug/Annotation/MonitorTest.hh
+++ b/tests/Titon/Debug/Annotation/MonitorTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug\Annotation;
 
 use Titon\Debug\Debugger;
@@ -8,7 +8,7 @@ use Titon\Test\TestCase;
 
 class MonitorTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -17,7 +17,7 @@ class MonitorTest extends TestCase {
         Debugger::setLogger(new Logger($this->vfs->path('/logs/')));
     }
 
-    public function testCallbackIsTriggered() {
+    public function testCallbackIsTriggered(): void {
         $this->assertEquals('', MonitorClassStub::$triggered);
 
         $stub = new MonitorClassStub();
@@ -25,7 +25,7 @@ class MonitorTest extends TestCase {
         $this->assertEquals('Titon\Test\Stub\Debug\MonitorClassStub', MonitorClassStub::$triggered);
     }
 
-    public function testMessageIsLoggedWhenClassIsInstantiated() {
+    public function testMessageIsLoggedWhenClassIsInstantiated(): void {
         $path = '/logs/info-' . date('Y-m-d') . '.log';
 
         $this->assertFileNotExists($this->vfs->path($path));

--- a/tests/Titon/Debug/Annotation/MonitorTest.hh
+++ b/tests/Titon/Debug/Annotation/MonitorTest.hh
@@ -1,11 +1,10 @@
 <?hh
 namespace Titon\Debug\Annotation;
 
-use Titon\Annotation\WiresAnnotations;
 use Titon\Debug\Debugger;
 use Titon\Debug\Logger;
+use Titon\Test\Stub\Debug\MonitorClassStub;
 use Titon\Test\TestCase;
-use DateTime;
 
 class MonitorTest extends TestCase {
 
@@ -19,11 +18,11 @@ class MonitorTest extends TestCase {
     }
 
     public function testCallbackIsTriggered() {
-        $this->assertEquals('', MonitorStub::$triggered);
+        $this->assertEquals('', MonitorClassStub::$triggered);
 
-        $stub = new MonitorStub();
+        $stub = new MonitorClassStub();
 
-        $this->assertEquals('Titon\Debug\Annotation\MonitorStub', MonitorStub::$triggered);
+        $this->assertEquals('Titon\Test\Stub\Debug\MonitorClassStub', MonitorClassStub::$triggered);
     }
 
     public function testMessageIsLoggedWhenClassIsInstantiated() {
@@ -31,26 +30,11 @@ class MonitorTest extends TestCase {
 
         $this->assertFileNotExists($this->vfs->path($path));
 
-        $stub = new MonitorStub();
+        $stub = new MonitorClassStub();
 
         $this->assertFileExists($this->vfs->path($path));
 
-        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Debug\Annotation\MonitorStub', '/') . ' was instantiated in ' . preg_quote(TEST_DIR . '/Titon/Debug/Annotation/MonitorTest.hh', '/') . '/', file_get_contents($this->vfs->path($path)));
+        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Test\Stub\Debug\MonitorClassStub', '/') . ' was instantiated in ' . preg_quote(TEST_DIR . '/Titon/Debug/Annotation/MonitorTest.hh', '/') . '/', file_get_contents($this->vfs->path($path)));
     }
 
-}
-
-<<Monitor('Titon\Debug\Annotation\MonitorStub::testCallback')>>
-class MonitorStub {
-    use WiresAnnotations;
-
-    public static string $triggered = '';
-
-    public function __construct() {
-        $this->wireClassAnnotation('Monitor');
-    }
-
-    public static function testCallback<T>(T $class, string $method = ''): void {
-        static::$triggered = get_class($class);
-    }
 }

--- a/tests/Titon/Debug/Annotation/MonitorTest.hh
+++ b/tests/Titon/Debug/Annotation/MonitorTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug\Annotation;
 
 use Titon\Debug\Debugger;
@@ -11,10 +11,9 @@ class MonitorTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/logs/');
+        $this->vfs()->createDirectory('/logs/');
 
-        Debugger::setLogger(new Logger($this->vfs->path('/logs/')));
+        Debugger::setLogger(new Logger($this->vfs()->path('/logs/')));
     }
 
     public function testCallbackIsTriggered(): void {
@@ -28,13 +27,13 @@ class MonitorTest extends TestCase {
     public function testMessageIsLoggedWhenClassIsInstantiated(): void {
         $path = '/logs/info-' . date('Y-m-d') . '.log';
 
-        $this->assertFileNotExists($this->vfs->path($path));
+        $this->assertFileNotExists($this->vfs()->path($path));
 
         $stub = new MonitorClassStub();
 
-        $this->assertFileExists($this->vfs->path($path));
+        $this->assertFileExists($this->vfs()->path($path));
 
-        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Test\Stub\Debug\MonitorClassStub', '/') . ' was instantiated in ' . preg_quote(TEST_DIR . '/Titon/Debug/Annotation/MonitorTest.hh', '/') . '/', file_get_contents($this->vfs->path($path)));
+        $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] ' . preg_quote('Titon\Test\Stub\Debug\MonitorClassStub', '/') . ' was instantiated in ' . preg_quote(TEST_DIR . '/Titon/Debug/Annotation/MonitorTest.hh', '/') . '/', file_get_contents($this->vfs()->path($path)));
     }
 
 }

--- a/tests/Titon/Debug/BenchmarkTest.hh
+++ b/tests/Titon/Debug/BenchmarkTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Debug/BenchmarkTest.hh
+++ b/tests/Titon/Debug/BenchmarkTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug;
 
 use Titon\Test\TestCase;
 
 class BenchmarkTest extends TestCase {
 
-    public function testBenchmarking() {
+    public function testBenchmarking(): void {
         Benchmark::start('test');
 
         $benchmark = Benchmark::get('test');
@@ -30,7 +30,7 @@ class BenchmarkTest extends TestCase {
     /**
      * @expectedException \Titon\Debug\Exception\MissingBenchmarkException
      */
-    public function testGetInvalidKey() {
+    public function testGetInvalidKey(): void {
         Benchmark::get('fake');
     }
 

--- a/tests/Titon/Debug/DebuggerTest.hh
+++ b/tests/Titon/Debug/DebuggerTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug;
 
 use Titon\Debug\Dumper\CliDumper;
@@ -11,11 +11,10 @@ class DebuggerTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/logs/');
+        $this->vfs()->createDirectory('/logs/');
 
         Debugger::enable();
-        Debugger::setLogger(new Logger($this->vfs->path('/logs/')));
+        Debugger::setLogger(new Logger($this->vfs()->path('/logs/')));
 
         set_error_handler(class_meth('Titon\Debug\Debugger', 'handleError'));
         set_exception_handler(class_meth('Titon\Debug\Debugger', 'handleException'));
@@ -58,7 +57,7 @@ class DebuggerTest extends TestCase {
     }
 
     public function testGetSetLogger(): void {
-        $logger = new Logger($this->vfs->path('/logs/'));
+        $logger = new Logger($this->vfs()->path('/logs/'));
 
         Debugger::setLogger($logger);
 
@@ -99,38 +98,38 @@ class DebuggerTest extends TestCase {
     public function testHandleErrorTriggeredNoReporting(): void {
         Debugger::disable();
 
-        $this->assertFileNotExists($this->vfs->path('/logs/warning-' . date('Y-m-d') . '.log'));
+        $this->assertFileNotExists($this->vfs()->path('/logs/warning-' . date('Y-m-d') . '.log'));
 
         ob_start();
         strpos();
         $actual = ob_get_clean();
 
         $this->assertEquals('', $actual);
-        $this->assertFileExists($this->vfs->path('/logs/warning-' . date('Y-m-d') . '.log'));
+        $this->assertFileExists($this->vfs()->path('/logs/warning-' . date('Y-m-d') . '.log'));
     }
 
     /**
      * @expectedException \HH\InvariantException
      */
     public function testHandleInvariant(): void {
-        $this->assertFileNotExists($this->vfs->path('/logs/info-' . date('Y-m-d') . '.log'));
+        $this->assertFileNotExists($this->vfs()->path('/logs/info-' . date('Y-m-d') . '.log'));
 
         invariant_violation('Something failed!', 'foo', 'bar');
 
-        $this->assertFileExists($this->vfs->path('/logs/info-' . date('Y-m-d') . '.log'));
+        $this->assertFileExists($this->vfs()->path('/logs/info-' . date('Y-m-d') . '.log'));
     }
 
     public function testLogException(): void {
         $date = date('Y-m-d');
 
-        $this->assertFileNotExists($this->vfs->path('/logs/error-' . $date . '.log'));
-        $this->assertFileNotExists($this->vfs->path('/logs/notice-' . $date . '.log'));
+        $this->assertFileNotExists($this->vfs()->path('/logs/error-' . $date . '.log'));
+        $this->assertFileNotExists($this->vfs()->path('/logs/notice-' . $date . '.log'));
 
         Debugger::logException(new ErrorException('Message', E_ERROR));
         Debugger::logException(new ErrorException('Message', E_USER_NOTICE));
 
-        $this->assertFileExists($this->vfs->path('/logs/error-' . $date . '.log'));
-        $this->assertFileExists($this->vfs->path('/logs/notice-' . $date . '.log'));
+        $this->assertFileExists($this->vfs()->path('/logs/error-' . $date . '.log'));
+        $this->assertFileExists($this->vfs()->path('/logs/notice-' . $date . '.log'));
     }
 
     public function testMapErrorCode(): void {

--- a/tests/Titon/Debug/DebuggerTest.hh
+++ b/tests/Titon/Debug/DebuggerTest.hh
@@ -50,7 +50,7 @@ class DebuggerTest extends TestCase {
     }
 
     public function testGetSetHandler(): void {
-        $handler = function(): void {};
+        $handler = () ==> {};
 
         Debugger::setHandler($handler);
 
@@ -148,7 +148,8 @@ class DebuggerTest extends TestCase {
         $this->assertEquals('array', Debugger::parseType([]));
         $this->assertEquals('object', Debugger::parseType(new \stdClass()));
         $this->assertEquals('null', Debugger::parseType(null));
-        $this->assertEquals('callable', Debugger::parseType(function(): void {}));
+        $this->assertEquals('callable', Debugger::parseType(function() {}));
+        $this->assertEquals('callable', Debugger::parseType(() ==> {}));
     }
 
     public function testParseValue(): void {

--- a/tests/Titon/Debug/DebuggerTest.hh
+++ b/tests/Titon/Debug/DebuggerTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug;
 
 use Titon\Debug\Dumper\CliDumper;
@@ -8,7 +8,7 @@ use \ErrorException;
 
 class DebuggerTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -21,7 +21,7 @@ class DebuggerTest extends TestCase {
         set_exception_handler(class_meth('Titon\Debug\Debugger', 'handleException'));
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         parent::tearDown();
 
         // Reset back to old handlers
@@ -29,19 +29,19 @@ class DebuggerTest extends TestCase {
         set_exception_handler(null);
     }
 
-    public function testExport() {
+    public function testExport(): void {
         $this->assertEquals(123, Debugger::export(123));
         $this->assertEquals("[\n\t0 => 123,\n]", Debugger::export([123]));
         $this->assertEquals("array(\n\t0 => 123,\n)", Debugger::export([123], false));
     }
 
-    public function testGetError() {
+    public function testGetError(): void {
         $this->assertEquals('Error', Debugger::getError(E_ERROR));
         $this->assertEquals('Core Warning', Debugger::getError(E_CORE_WARNING));
         $this->assertEquals('Unknown Error', Debugger::getError(-123));
     }
 
-    public function testGetSetDumper() {
+    public function testGetSetDumper(): void {
         $dumper = new CliDumper();
 
         Debugger::setDumper($dumper);
@@ -49,15 +49,15 @@ class DebuggerTest extends TestCase {
         $this->assertEquals($dumper, Debugger::getDumper());
     }
 
-    public function testGetSetHandler() {
-        $handler = function() {};
+    public function testGetSetHandler(): void {
+        $handler = function(): void {};
 
         Debugger::setHandler($handler);
 
         $this->assertEquals($handler, Debugger::getHandler());
     }
 
-    public function testGetSetLogger() {
+    public function testGetSetLogger(): void {
         $logger = new Logger($this->vfs->path('/logs/'));
 
         Debugger::setLogger($logger);
@@ -65,7 +65,7 @@ class DebuggerTest extends TestCase {
         $this->assertEquals($logger, Debugger::getLogger());
     }
 
-    public function testHandleError() {
+    public function testHandleError(): void {
         ob_start();
         Debugger::handleError(E_WARNING, 'Message');
         $actual = ob_get_clean();
@@ -76,11 +76,11 @@ class DebuggerTest extends TestCase {
     /**
      * @expectedException \ErrorException
      */
-    public function testHandleErrorThrowsErrors() {
+    public function testHandleErrorThrowsErrors(): void {
         Debugger::handleError(E_ERROR, 'Message');
     }
 
-    public function testHandleErrorDoesntThrowsNotice() {
+    public function testHandleErrorDoesntThrowsNotice(): void {
         ob_start();
         Debugger::handleError(E_NOTICE, 'Message');
         $actual = ob_get_clean();
@@ -88,7 +88,7 @@ class DebuggerTest extends TestCase {
         $this->assertRegExp('/^ErrorException - Message/', $actual);
     }
 
-    public function testHandleErrorTriggered() {
+    public function testHandleErrorTriggered(): void {
         ob_start();
         strpos();
         $actual = ob_get_clean();
@@ -96,7 +96,7 @@ class DebuggerTest extends TestCase {
         $this->assertRegExp('/^ErrorException/', $actual);
     }
 
-    public function testHandleErrorTriggeredNoReporting() {
+    public function testHandleErrorTriggeredNoReporting(): void {
         Debugger::disable();
 
         $this->assertFileNotExists($this->vfs->path('/logs/warning-' . date('Y-m-d') . '.log'));
@@ -112,7 +112,7 @@ class DebuggerTest extends TestCase {
     /**
      * @expectedException \HH\InvariantException
      */
-    public function testHandleInvariant() {
+    public function testHandleInvariant(): void {
         $this->assertFileNotExists($this->vfs->path('/logs/info-' . date('Y-m-d') . '.log'));
 
         invariant_violation('Something failed!', 'foo', 'bar');
@@ -120,7 +120,7 @@ class DebuggerTest extends TestCase {
         $this->assertFileExists($this->vfs->path('/logs/info-' . date('Y-m-d') . '.log'));
     }
 
-    public function testLogException() {
+    public function testLogException(): void {
         $date = date('Y-m-d');
 
         $this->assertFileNotExists($this->vfs->path('/logs/error-' . $date . '.log'));
@@ -133,7 +133,7 @@ class DebuggerTest extends TestCase {
         $this->assertFileExists($this->vfs->path('/logs/notice-' . $date . '.log'));
     }
 
-    public function testMapErrorCode() {
+    public function testMapErrorCode(): void {
         $this->assertEquals(shape('error' => 'User Error', 'level' => 'error'), Debugger::mapErrorCode(E_USER_ERROR));
         $this->assertEquals(shape('error' => 'Core Warning', 'level' => 'warning'), Debugger::mapErrorCode(E_CORE_WARNING));
         $this->assertEquals(shape('error' => 'InvalidArgumentException', 'level' => 'debug'), Debugger::mapErrorCode(new \InvalidArgumentException()));
@@ -141,17 +141,17 @@ class DebuggerTest extends TestCase {
         $this->assertEquals(shape('error' => 'Strict Notice', 'level' => 'info'), Debugger::mapErrorCode(new ErrorException('Message', E_STRICT)));
     }
 
-    public function testParseType() {
+    public function testParseType(): void {
         $this->assertEquals('string', Debugger::parseType('foobar'));
         $this->assertEquals('integer', Debugger::parseType(123));
         $this->assertEquals('boolean', Debugger::parseType(true));
         $this->assertEquals('array', Debugger::parseType([]));
         $this->assertEquals('object', Debugger::parseType(new \stdClass()));
         $this->assertEquals('null', Debugger::parseType(null));
-        $this->assertEquals('callable', Debugger::parseType(function() {}));
+        $this->assertEquals('callable', Debugger::parseType(function(): void {}));
     }
 
-    public function testParseValue() {
+    public function testParseValue(): void {
         $this->assertEquals(12345, Debugger::parseValue('12345'));
         $this->assertEquals('true', Debugger::parseValue(true));
         $this->assertEquals('null', Debugger::parseValue(null));

--- a/tests/Titon/Debug/DebuggerTest.hh
+++ b/tests/Titon/Debug/DebuggerTest.hh
@@ -88,6 +88,7 @@ class DebuggerTest extends TestCase {
     }
 
     public function testHandleErrorTriggered(): void {
+        // UNSAFE
         ob_start();
         strpos();
         $actual = ob_get_clean();
@@ -96,6 +97,7 @@ class DebuggerTest extends TestCase {
     }
 
     public function testHandleErrorTriggeredNoReporting(): void {
+        // UNSAFE
         Debugger::disable();
 
         $this->assertFileNotExists($this->vfs()->path('/logs/warning-' . date('Y-m-d') . '.log'));

--- a/tests/Titon/Debug/Dumper/CliDumperTest.hh
+++ b/tests/Titon/Debug/Dumper/CliDumperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug\Dumper;
 
 use Titon\Debug\Exception\FatalErrorException;

--- a/tests/Titon/Debug/Dumper/CliDumperTest.hh
+++ b/tests/Titon/Debug/Dumper/CliDumperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug\Dumper;
 
 use Titon\Debug\Exception\FatalErrorException;
@@ -10,32 +10,32 @@ use Exception;
  */
 class CliDumperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new CliDumper();
     }
 
-    public function testBacktrace() {
+    public function testBacktrace(): void {
         $line = explode(PHP_EOL, $this->object->backtrace())[0];
 
         $this->assertEquals('#01: Titon\Debug\Dumper\CliDumper->backtrace() - [tests]Titon/Debug/Dumper/CliDumperTest.hh:20', $line);
     }
 
-    public function testBacktraceWithException() {
+    public function testBacktraceWithException(): void {
         $line = explode(PHP_EOL, $this->object->backtrace(new Exception('Systems critical!')))[0];
 
         $this->assertEquals('#01: Titon\Debug\Dumper\CliDumperTest->testBacktraceWithException() - [internal]:0', $line);
     }
 
-    public function testDebug() {
+    public function testDebug(): void {
         $this->assertEquals(
             '[tests]Titon/Debug/Dumper/CliDumperTest.hh:35' . PHP_EOL .
             '---------------------------------------------' . PHP_EOL .
             'foo', $this->object->debug('foo'));
     }
 
-    public function testDebugWithMultipleVariables() {
+    public function testDebugWithMultipleVariables(): void {
         $this->assertEquals(
             '[tests]Titon/Debug/Dumper/CliDumperTest.hh:44' . PHP_EOL .
             '---------------------------------------------' . PHP_EOL .
@@ -44,14 +44,14 @@ class CliDumperTest extends TestCase {
             '123', $this->object->debug('foo', 123));
     }
 
-    public function testDump() {
+    public function testDump(): void {
         $this->assertEquals(
             '[tests]Titon/Debug/Dumper/CliDumperTest.hh:51' . PHP_EOL .
             '---------------------------------------------' . PHP_EOL .
             'string(3) "foo"', $this->object->dump('foo'));
     }
 
-    public function testDumpWithMultipleVariables() {
+    public function testDumpWithMultipleVariables(): void {
         $this->assertEquals(
             '[tests]Titon/Debug/Dumper/CliDumperTest.hh:60' . PHP_EOL .
             '---------------------------------------------' . PHP_EOL .
@@ -60,7 +60,7 @@ class CliDumperTest extends TestCase {
             'int(123)', $this->object->dump('foo', 123));
     }
 
-    public function testInspect() {
+    public function testInspect(): void {
         $line = explode(PHP_EOL, $this->object->inspect(new FatalErrorException('Systems critical!')))[0];
 
         $this->assertEquals('Titon\Debug\Exception\FatalErrorException - Systems critical!', $line);

--- a/tests/Titon/Debug/Dumper/HtmlDumperTest.hh
+++ b/tests/Titon/Debug/Dumper/HtmlDumperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug\Dumper;
 
 use Titon\Debug\Exception\FatalErrorException;
@@ -9,25 +9,25 @@ use Titon\Test\TestCase;
  */
 class HtmlDumperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new HtmlDumper();
     }
 
-    public function testBacktrace() {
+    public function testBacktrace(): void {
         $this->assertRegExp('/^<div class="titon-backtrace">/', trim($this->object->backtrace()));
     }
 
-    public function testDebug() {
+    public function testDebug(): void {
         $this->assertRegExp('/^<div class="titon-debug">/', $this->object->debug(1));
     }
 
-    public function testDump() {
+    public function testDump(): void {
         $this->assertRegExp('/^<div class="titon-dump">/', $this->object->dump(1));
     }
 
-    public function testInspect() {
+    public function testInspect(): void {
         $this->assertRegExp('/^<div class="titon-inspect">/', $this->object->inspect(new FatalErrorException('Systems critical!')));
     }
 

--- a/tests/Titon/Debug/Dumper/HtmlDumperTest.hh
+++ b/tests/Titon/Debug/Dumper/HtmlDumperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug\Dumper;
 
 use Titon\Debug\Exception\FatalErrorException;

--- a/tests/Titon/Debug/GlobalFunctionTest.hh
+++ b/tests/Titon/Debug/GlobalFunctionTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug;
 
 use Titon\Debug\Exception\FatalErrorException;

--- a/tests/Titon/Debug/GlobalFunctionTest.hh
+++ b/tests/Titon/Debug/GlobalFunctionTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug;
 
 use Titon\Debug\Exception\FatalErrorException;
@@ -6,7 +6,7 @@ use Titon\Test\TestCase;
 
 class GlobalFunctionTest extends TestCase {
 
-    public function testBacktrace() {
+    public function testBacktrace(): void {
         ob_start();
         \backtrace();
         $actual = ob_get_clean();
@@ -14,7 +14,7 @@ class GlobalFunctionTest extends TestCase {
         $this->assertRegExp('/^#01/', $actual);
     }
 
-    public function testBacktraceNoReporting() {
+    public function testBacktraceNoReporting(): void {
         Debugger::disable();
 
         ob_start();
@@ -26,7 +26,7 @@ class GlobalFunctionTest extends TestCase {
         Debugger::enable();
     }
 
-    public function testDebug() {
+    public function testDebug(): void {
         ob_start();
         \debug(1);
         $actual = ob_get_clean();
@@ -34,7 +34,7 @@ class GlobalFunctionTest extends TestCase {
         $this->assertRegExp('/^\[src\]/', $actual);
     }
 
-    public function testDebugNoReporting() {
+    public function testDebugNoReporting(): void {
         Debugger::disable();
 
         ob_start();
@@ -46,7 +46,7 @@ class GlobalFunctionTest extends TestCase {
         Debugger::enable();
     }
 
-    public function testDump() {
+    public function testDump(): void {
         ob_start();
         \dump(1);
         $actual = ob_get_clean();
@@ -54,7 +54,7 @@ class GlobalFunctionTest extends TestCase {
         $this->assertRegExp('/^\[src\]/', $actual);
     }
 
-    public function testDumpNoReporting() {
+    public function testDumpNoReporting(): void {
         Debugger::disable();
 
         ob_start();
@@ -66,7 +66,7 @@ class GlobalFunctionTest extends TestCase {
         Debugger::enable();
     }
 
-    public function testInspect() {
+    public function testInspect(): void {
         ob_start();
         \inspect(new FatalErrorException('Systems critical!'));
         $actual = ob_get_clean();
@@ -74,7 +74,7 @@ class GlobalFunctionTest extends TestCase {
         $this->assertRegExp('/^Titon\\\\Debug\\\\Exception\\\\FatalErrorException/', $actual);
     }
 
-    public function testInspectNoReporting() {
+    public function testInspectNoReporting(): void {
         Debugger::disable();
 
         ob_start();
@@ -86,7 +86,7 @@ class GlobalFunctionTest extends TestCase {
         Debugger::enable();
     }
 
-    public function testExport() {
+    public function testExport(): void {
         ob_start();
         \export('foo');
         $actual = ob_get_clean();
@@ -94,7 +94,7 @@ class GlobalFunctionTest extends TestCase {
         $this->assertEquals("'foo'", $actual);
     }
 
-    public function testExportNoReporting() {
+    public function testExportNoReporting(): void {
         Debugger::disable();
 
         ob_start();

--- a/tests/Titon/Debug/LoggerTest.hh
+++ b/tests/Titon/Debug/LoggerTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Debug;
 
 use Titon\Test\TestCase;
@@ -10,38 +10,37 @@ class LoggerTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/logs/');
+        $this->vfs()->createDirectory('/logs/');
     }
 
     /**
      * @expectedException \Titon\Debug\Exception\InvalidDirectoryException
      */
     public function testErrorOnInvalidDir(): void {
-        new Logger($this->vfs->path('/logs-missing/'));
+        new Logger($this->vfs()->path('/logs-missing/'));
     }
 
     /**
      * @expectedException \Titon\Debug\Exception\UnwritableDirectoryException
      */
     public function testErrorOnUnwritableDir(): void {
-        $this->vfs->createDirectory('/logs-unwritable/', false, 0555);
+        $this->vfs()->createDirectory('/logs-unwritable/', false, 0555);
 
-        new Logger($this->vfs->path('/logs-unwritable/'));
+        new Logger($this->vfs()->path('/logs-unwritable/'));
     }
 
     public function testLog(): void {
-        $logger = new Logger($this->vfs->path('/logs/'));
+        $logger = new Logger($this->vfs()->path('/logs/'));
         $date = date('Y-m-d');
 
-        $this->assertFileNotExists($this->vfs->path('/logs/error-' . $date . '.log'));
-        $this->assertFileNotExists($this->vfs->path('/logs/notice-' . $date . '.log'));
+        $this->assertFileNotExists($this->vfs()->path('/logs/error-' . $date . '.log'));
+        $this->assertFileNotExists($this->vfs()->path('/logs/notice-' . $date . '.log'));
 
         $logger->log(Logger::ERROR, 'Message');
         $logger->log(Logger::NOTICE, 'Message');
 
-        $this->assertFileExists($this->vfs->path('/logs/error-' . $date . '.log'));
-        $this->assertFileExists($this->vfs->path('/logs/notice-' . $date . '.log'));
+        $this->assertFileExists($this->vfs()->path('/logs/error-' . $date . '.log'));
+        $this->assertFileExists($this->vfs()->path('/logs/notice-' . $date . '.log'));
     }
 
     public function testCreateMessage(): void {

--- a/tests/Titon/Debug/LoggerTest.hh
+++ b/tests/Titon/Debug/LoggerTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Debug;
 
 use Titon\Test\TestCase;
@@ -7,7 +7,7 @@ use \DateTime;
 
 class LoggerTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -17,20 +17,20 @@ class LoggerTest extends TestCase {
     /**
      * @expectedException \Titon\Debug\Exception\InvalidDirectoryException
      */
-    public function testErrorOnInvalidDir() {
+    public function testErrorOnInvalidDir(): void {
         new Logger($this->vfs->path('/logs-missing/'));
     }
 
     /**
      * @expectedException \Titon\Debug\Exception\UnwritableDirectoryException
      */
-    public function testErrorOnUnwritableDir() {
+    public function testErrorOnUnwritableDir(): void {
         $this->vfs->createDirectory('/logs-unwritable/', false, 0555);
 
         new Logger($this->vfs->path('/logs-unwritable/'));
     }
 
-    public function testLog() {
+    public function testLog(): void {
         $logger = new Logger($this->vfs->path('/logs/'));
         $date = date('Y-m-d');
 
@@ -44,7 +44,7 @@ class LoggerTest extends TestCase {
         $this->assertFileExists($this->vfs->path('/logs/notice-' . $date . '.log'));
     }
 
-    public function testCreateMessage() {
+    public function testCreateMessage(): void {
         $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] Message \[\/\]/' . PHP_EOL, Logger::createMessage(Logger::DEBUG, 'Message'));
         $this->assertRegExp('/^\[' . self::DATE_RFC3339_REGEX . '\] Message \[\/custom\/url\]/' . PHP_EOL, Logger::createMessage(Logger::DEBUG, 'Message', ['url' => '/custom/url']));
 

--- a/tests/Titon/Environment/EnvironmentTest.hh
+++ b/tests/Titon/Environment/EnvironmentTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Environment;
 
 use Titon\Test\Stub\Environment\BootstrapperStub;

--- a/tests/Titon/Environment/EnvironmentTest.hh
+++ b/tests/Titon/Environment/EnvironmentTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Environment;
 
 use Titon\Test\Stub\Environment\BootstrapperStub;
@@ -11,7 +11,7 @@ use Titon\Utility\State\Server as ServerGlobal;
  */
 class EnvironmentTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new EnvironmentStub();
@@ -22,7 +22,7 @@ class EnvironmentTest extends TestCase {
         $this->object->setFallback('dev');
     }
 
-    public function testBootstrappers() {
+    public function testBootstrappers(): void {
         $this->assertEquals(1, count($this->object->getBootstrappers()));
 
         $bs = new BootstrapperStub();
@@ -32,7 +32,7 @@ class EnvironmentTest extends TestCase {
         $this->assertEquals($bs, $this->object->getBootstrappers()[1]);
     }
 
-    public function testCurrent() {
+    public function testCurrent(): void {
         // dev
         $_SERVER['HTTP_HOST'] = 'dev';
 
@@ -81,7 +81,7 @@ class EnvironmentTest extends TestCase {
         $this->assertEquals('dev', $this->object->current()->getKey());
     }
 
-    public function testSetFallback() {
+    public function testSetFallback(): void {
         $this->object->setFallback('dev');
 
         $_SERVER['HTTP_HOST'] = 'fake_environment';
@@ -95,15 +95,15 @@ class EnvironmentTest extends TestCase {
     /**
      * @expectedException \Titon\Environment\Exception\MissingHostException
      */
-    public function testSetFallbackMissingHost() {
+    public function testSetFallbackMissingHost(): void {
         $this->object->setFallback('fakeEnv');
     }
 
-    public function testGetHosts() {
+    public function testGetHosts(): void {
         $this->assertEquals(3, count($this->object->getHosts()));
     }
 
-    public function testBootstrapping() {
+    public function testBootstrapping(): void {
         $_SERVER['HTTP_HOST'] = 'dev';
 
         $this->object->initialize();
@@ -115,21 +115,21 @@ class EnvironmentTest extends TestCase {
         $this->assertEquals('prod', BootstrapperStub::$loaded);
     }
 
-    public function testBootstrappingFallback() {
+    public function testBootstrappingFallback(): void {
         $_SERVER['HTTP_HOST'] = 'qa';
 
         $this->object->initialize();
         $this->assertEquals('dev', BootstrapperStub::$loaded); // Since dev is the fallback
     }
 
-    public function testInitializeNoHosts() {
+    public function testInitializeNoHosts(): void {
         $env = new EnvironmentStub();
         $env->initialize();
 
         $this->assertEquals(null, $env->current());
     }
 
-    public function testIs() {
+    public function testIs(): void {
         // dev
         $_SERVER['HTTP_HOST'] = 'dev';
 
@@ -181,7 +181,7 @@ class EnvironmentTest extends TestCase {
         $this->assertFalse($this->object->is('staging'));
     }
 
-    public function testIsMachine() {
+    public function testIsMachine(): void {
         if (getenv('TRAVIS')) {
             $this->markTestSkipped('Can\'t test host names within travis as they are too different per box');
         }
@@ -192,7 +192,7 @@ class EnvironmentTest extends TestCase {
         $this->assertTrue($env->isMachine('tit*'));
     }
 
-    public function testIsLocalhost() {
+    public function testIsLocalhost(): void {
         $_SERVER['HTTP_HOST'] = 'domain.com';
         $_SERVER['REMOTE_ADDR'] = '127.33.123.54';
         ServerGlobal::initialize($_SERVER);
@@ -216,7 +216,7 @@ class EnvironmentTest extends TestCase {
         $this->assertTrue($this->object->isLocalhost());
     }
 
-    public function testIsDevelopment() {
+    public function testIsDevelopment(): void {
         $_SERVER['HTTP_HOST'] = 'dev';
         ServerGlobal::initialize($_SERVER);
 
@@ -227,7 +227,7 @@ class EnvironmentTest extends TestCase {
         $this->assertFalse($this->object->isStaging());
     }
 
-    public function testIsProduction() {
+    public function testIsProduction(): void {
         $_SERVER['HTTP_HOST'] = 'prod';
 
         $this->object->initialize();
@@ -237,7 +237,7 @@ class EnvironmentTest extends TestCase {
         $this->assertFalse($this->object->isStaging());
     }
 
-    public function testIsQA() {
+    public function testIsQA(): void {
         $this->object->addHost('qa', new Host(Server::QA, ['qa', '123.456.0.666']));
 
         $_SERVER['HTTP_HOST'] = 'qa';
@@ -249,7 +249,7 @@ class EnvironmentTest extends TestCase {
         $this->assertFalse($this->object->isStaging());
     }
 
-    public function testIsStaging() {
+    public function testIsStaging(): void {
         $_SERVER['HTTP_HOST'] = 'staging';
 
         $this->object->initialize();
@@ -259,7 +259,7 @@ class EnvironmentTest extends TestCase {
         $this->assertTrue($this->object->isStaging());
     }
 
-    public function testVarLoading() {
+    public function testVarLoading(): void {
         $_SERVER['HTTP_HOST'] = 'dev';
 
         $env = new EnvironmentStub(TEMP_DIR . '/environment/');
@@ -275,7 +275,7 @@ class EnvironmentTest extends TestCase {
         $this->assertEquals('', $env->getVariable('bar'));
     }
 
-    public function testVarLoadingInheritance() {
+    public function testVarLoadingInheritance(): void {
         $_SERVER['HTTP_HOST'] = 'prod';
 
         $env = new EnvironmentStub(TEMP_DIR . '/environment/');

--- a/tests/Titon/Environment/EnvironmentTest.hh
+++ b/tests/Titon/Environment/EnvironmentTest.hh
@@ -1,11 +1,13 @@
 <?hh
 namespace Titon\Environment;
 
+use Titon\Test\Stub\Environment\BootstrapperStub;
+use Titon\Test\Stub\Environment\EnvironmentStub;
 use Titon\Test\TestCase;
 use Titon\Utility\State\Server as ServerGlobal;
 
 /**
- * @property \Titon\Environment\EnvironmentStub $object
+ * @property \Titon\Environment\Environment $object
  */
 class EnvironmentTest extends TestCase {
 
@@ -284,34 +286,6 @@ class EnvironmentTest extends TestCase {
         $this->assertEquals('bar', $env->getVariable('foo'));
         $this->assertEquals('qux', $env->getVariable('baz'));
         $this->assertEquals('', $env->getVariable('bar'));
-    }
-
-}
-
-class EnvironmentStub extends Environment {
-
-    // Use host/IP for testing
-    public function isMachine(string $name): bool {
-        $host = null;
-
-        if (!empty($_SERVER['HTTP_HOST'])) {
-            $host = $_SERVER['HTTP_HOST'];
-
-        } else if (!empty($_SERVER['SERVER_ADDR'])) {
-            $host = $_SERVER['SERVER_ADDR'];
-        }
-
-        return (bool) preg_match('/^' . preg_quote($name, '/') . '/i', $host);
-    }
-
-}
-
-class BootstrapperStub implements Bootstrapper {
-
-    public static string $loaded = '';
-
-    public function bootstrap(Host $host) {
-        static::$loaded = $host->getKey();
     }
 
 }

--- a/tests/Titon/Environment/HostTest.hh
+++ b/tests/Titon/Environment/HostTest.hh
@@ -1,18 +1,18 @@
-<?hh
+<?hh // strict
 namespace Titon\Environment;
 
 use Titon\Test\TestCase;
 
 class HostTest extends TestCase {
 
-    public function testGet() {
+    public function testGet(): void {
         $host = new Host(Server::DEV, ['dev', '123.0.0.0']);
 
         $this->assertEquals(Vector {'dev', '123.0.0.0'}, $host->getHostnames());
         $this->assertEquals(Server::DEV, $host->getType());
     }
 
-    public function testGetSetKey() {
+    public function testGetSetKey(): void {
         $host = new Host(Server::DEV, Vector {'dev', '123.0.0.0'});
         $this->assertEquals('', $host->getKey());
 
@@ -20,7 +20,7 @@ class HostTest extends TestCase {
         $this->assertEquals('prod', $host->getKey());
     }
 
-    public function testIsDevelopment() {
+    public function testIsDevelopment(): void {
         $host = new Host(Server::DEV, '127.0.0.1');
 
         $this->assertTrue($host->isDevelopment());
@@ -28,7 +28,7 @@ class HostTest extends TestCase {
         $this->assertFalse($host->isProduction());
     }
 
-    public function testIsStaging() {
+    public function testIsStaging(): void {
         $host = new Host(Server::STAGING, '127.0.0.1');
 
         $this->assertFalse($host->isDevelopment());
@@ -36,7 +36,7 @@ class HostTest extends TestCase {
         $this->assertFalse($host->isProduction());
     }
 
-    public function testIsProduction() {
+    public function testIsProduction(): void {
         $host = new Host(Server::PROD, '127.0.0.1');
 
         $this->assertFalse($host->isDevelopment());

--- a/tests/Titon/Environment/HostTest.hh
+++ b/tests/Titon/Environment/HostTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Environment;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Event/Annotation/ObserverTest.hh
+++ b/tests/Titon/Event/Annotation/ObserverTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Event\Annotation;
 
 use Titon\Event\Observer;
@@ -7,7 +7,7 @@ use Titon\Test\TestCase;
 
 class ObserverTest extends TestCase {
 
-    public function testObserversSubscribeToEvents() {
+    public function testObserversSubscribeToEvents(): void {
         $stub = new ObserverClassStub();
 
         $this->assertEquals(Vector {

--- a/tests/Titon/Event/Annotation/ObserverTest.hh
+++ b/tests/Titon/Event/Annotation/ObserverTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Event\Annotation;
 
 use Titon\Event\Observer;

--- a/tests/Titon/Event/Annotation/ObserverTest.hh
+++ b/tests/Titon/Event/Annotation/ObserverTest.hh
@@ -1,58 +1,32 @@
 <?hh
 namespace Titon\Event\Annotation;
 
-use Titon\Annotation\WiresAnnotations;
-use Titon\Event\EmitsEvents;
-use Titon\Event\Observer as Ob;
-use Titon\Event\Subject;
+use Titon\Event\Observer;
+use Titon\Test\Stub\Event\ObserverClassStub;
 use Titon\Test\TestCase;
 
 class ObserverTest extends TestCase {
 
     public function testObserversSubscribeToEvents() {
-        $stub = new ObserverStub();
+        $stub = new ObserverClassStub();
 
         $this->assertEquals(Vector {
-            new Ob(inst_meth($stub, 'defaultObserver'), 100, false),
+            new Observer(inst_meth($stub, 'defaultObserver'), 100, false),
         }, $stub->getEmitter()->getObservers('event.foo'));
 
         $this->assertEquals(Vector {
-            new Ob(inst_meth($stub, 'priorityObserver'), 5, false),
+            new Observer(inst_meth($stub, 'priorityObserver'), 5, false),
         }, $stub->getEmitter()->getObservers('event.bar'));
 
         $this->assertEquals(Vector {
-            new Ob(inst_meth($stub, 'onceObserver'), 100, true),
+            new Observer(inst_meth($stub, 'onceObserver'), 100, true),
         }, $stub->getEmitter()->getObservers('event.baz'));
 
         $this->assertEquals(Vector {
-            new Ob(inst_meth($stub, 'asyncObserver'), 100, false),
+            new Observer(inst_meth($stub, 'asyncObserver'), 100, false),
         }, $stub->getEmitter()->getObservers('event.qux'));
 
         $this->assertTrue($stub->getEmitter()->getObservers('event.qux')[0]->isAsync());
     }
-
-}
-
-class ObserverStub implements Subject {
-    use EmitsEvents, WiresAnnotations;
-
-    public function __construct() {
-        $this->wireMethodAnnotation('defaultObserver', 'Observer');
-        $this->wireMethodAnnotation('priorityObserver', 'Observer');
-        $this->wireMethodAnnotation('onceObserver', 'Observer');
-        $this->wireMethodAnnotation('asyncObserver', 'Observer');
-    }
-
-    <<Observer('event.foo')>>
-    public function defaultObserver(Event $event): void {}
-
-    <<Observer('event.bar', 5)>>
-    public function priorityObserver(Event $event): void {}
-
-    <<Observer('event.baz', 0, true)>>
-    public function onceObserver(Event $event): void {}
-
-    <<Observer('event.qux')>>
-    public async function asyncObserver(Event $event): Awaitable<mixed> {}
 
 }

--- a/tests/Titon/Event/EmitterTest.hh
+++ b/tests/Titon/Event/EmitterTest.hh
@@ -1,6 +1,7 @@
 <?hh
 namespace Titon\Event;
 
+use Titon\Test\Stub\Event\ListenerStub;
 use Titon\Test\TestCase;
 
 /**
@@ -58,8 +59,8 @@ class EmitterTest extends TestCase {
         $this->assertEquals(Vector {
             '{closure}',
             '{closure}',
-            'Titon\Event\ListenerStub::noop2',
-            'Titon\Event\ListenerStub::noop3'
+            'Titon\Test\Stub\Event\ListenerStub::noop2',
+            'Titon\Test\Stub\Event\ListenerStub::noop3'
         }, $this->object->getCallStack('event.test'));
     }
 
@@ -177,8 +178,8 @@ class EmitterTest extends TestCase {
         $this->object->listen($listener);
 
         $this->assertEquals(Vector {
-            'Titon\Event\ListenerStub::noop2',
-            'Titon\Event\ListenerStub::noop1'
+            'Titon\Test\Stub\Event\ListenerStub::noop2',
+            'Titon\Test\Stub\Event\ListenerStub::noop1'
         }, $this->object->getCallStack('event.test1'));
 
         // Remove using the instance
@@ -292,57 +293,6 @@ class EmitterTest extends TestCase {
 
         $this->assertEquals(6, count($list));
         $this->assertNotEquals([1, 2, 3, 1, 2, 3], $list);
-    }
-
-}
-
-class ListenerStub implements Listener {
-
-    public function subscribeToEvents(): ListenerMap {
-        return Map {
-            'event.test1' => Vector {
-                'noop1',
-                Map {'method' => 'noop2', 'priority' => 45}
-            },
-            'event.test2' => 'noop1',
-            'event.test3' => Map {'method' => 'noop2', 'priority' => 15}
-        };
-    }
-
-    public function noop1(Event $e): void {}
-
-    public function noop2(Event $e): void {}
-
-    public function noop3(Event $e, $object1, $object2): void {
-        $object2->foo = 'bar';
-    }
-
-    public function counter(Event $e, &$count): void {
-        $count++;
-    }
-
-    public async function asyncNoop1(Event $e, &$list): Awaitable<mixed> {
-        await SleepWaitHandle::create(rand(100, 1000) * 1000);
-
-        $list[] = 1;
-
-        return true;
-    }
-
-    public async function asyncNoop2(Event $e, &$list): Awaitable<mixed> {
-        await SleepWaitHandle::create(rand(100, 500) * 1000);
-
-        $list[] = 2;
-
-        return true;
-    }
-
-    public async function asyncNoop3(Event $e, &$list): Awaitable<mixed> {
-        await SleepWaitHandle::create(rand(1, 500) * 1000);
-
-        $list[] = 3;
-
-        return true;
     }
 
 }

--- a/tests/Titon/Event/EmitterTest.hh
+++ b/tests/Titon/Event/EmitterTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Event;
 
 use Titon\Test\Stub\Event\ListenerStub;
@@ -9,15 +9,15 @@ use Titon\Test\TestCase;
  */
 class EmitterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new Emitter();
     }
 
-    public function testFlush() {
-        $ob1 = function(Event $event) { };
-        $ob2 = function(Event $event) { };
+    public function testFlush(): void {
+        $ob1 = function(Event $event): void { };
+        $ob2 = function(Event $event): void { };
 
         $this->object->subscribe('event.test1', $ob1);
         $this->object->subscribe('event.test2', $ob2);
@@ -31,8 +31,8 @@ class EmitterTest extends TestCase {
         $this->assertEquals(Vector {}, $this->object->getEventKeys());
     }
 
-    public function testGetObservers() {
-        $ob1 = function(Event $event) { };
+    public function testGetObservers(): void {
+        $ob1 = function(Event $event): void { };
         $ob2 = [new ListenerStub(), 'noop1'];
 
         $this->object->subscribe('event.test', $ob1, 20);
@@ -45,10 +45,10 @@ class EmitterTest extends TestCase {
         }, $this->object->getObservers('event.test'));
     }
 
-    public function testGetCallStack() {
-        $ob1 = function(Event $event) { };
+    public function testGetCallStack(): void {
+        $ob1 = function(Event $event): void { };
         $ob2 = [new ListenerStub(), 'noop2'];
-        $ob3 = function(Event $event) { };
+        $ob3 = function(Event $event): void { };
         $ob4 = [new ListenerStub(), 'noop3'];
 
         $this->object->subscribe('event.test', $ob1, 20);
@@ -64,19 +64,19 @@ class EmitterTest extends TestCase {
         }, $this->object->getCallStack('event.test'));
     }
 
-    public function testGetEventKeys() {
+    public function testGetEventKeys(): void {
         $this->assertEquals(Vector {}, $this->object->getEventKeys());
 
-        $this->object->subscribe('event.test1', function(Event $event) { });
-        $this->object->subscribe('event.test2', function(Event $event) { });
+        $this->object->subscribe('event.test1', function(Event $event): void { });
+        $this->object->subscribe('event.test2', function(Event $event): void { });
 
         $this->assertEquals(Vector {'event.test1', 'event.test2'}, $this->object->getEventKeys());
     }
 
-    public function testGetSortedObservers() {
-        $ob1 = function(Event $event) { };
+    public function testGetSortedObservers(): void {
+        $ob1 = function(Event $event): void { };
         $ob2 = [new ListenerStub(), 'noop1'];
-        $ob3 = function(Event $event) { };
+        $ob3 = function(Event $event): void { };
 
         $this->object->subscribe('event.test', $ob1, 20);
         $this->object->subscribe('event.test', $ob2, 15);
@@ -97,15 +97,15 @@ class EmitterTest extends TestCase {
         }, $this->object->getSortedObservers('event.test'));
     }
 
-    public function testHasObservers() {
+    public function testHasObservers(): void {
         $this->assertFalse($this->object->hasObservers('event.test'));
 
-        $this->object->subscribe('event.test', function(Event $event) { });
+        $this->object->subscribe('event.test', function(Event $event): void { });
 
         $this->assertTrue($this->object->hasObservers('event.test'));
     }
 
-    public function testAsyncGetObservers() {
+    public function testAsyncGetObservers(): void {
         $stub = new ListenerStub();
 
         $this->object->subscribe('event.test', [$stub, 'noop1']);
@@ -118,12 +118,12 @@ class EmitterTest extends TestCase {
         $this->assertTrue($observers[1]->isAsync());
     }
 
-    public function testExit() {
+    public function testExit(): void {
         $n = 0;
-        $ob1 = function(Event $event, &$i) { $i++; };
-        $ob2 = function(Event $event, &$i) { $i++; return true; };
-        $ob3 = function(Event $event, &$i) { $i++; return false; };
-        $ob4 = function(Event $event, &$i) { $i++; };
+        $ob1 = function(Event $event, &$i): void { $i++; };
+        $ob2 = function(Event $event, &$i): void { $i++; return true; };
+        $ob3 = function(Event $event, &$i): void { $i++; return false; };
+        $ob4 = function(Event $event, &$i): void { $i++; };
 
         $this->object->subscribe('event.test', $ob1);
         $this->object->subscribe('event.test', $ob2);
@@ -135,11 +135,11 @@ class EmitterTest extends TestCase {
         $this->assertEquals(3, $n);
     }
 
-    public function testData() {
-        $ob1 = function(Event $event) { $event->setData('key', $event->getData('key') + 1); };
-        $ob2 = function(Event $event) { $event->setData('key', $event->getData('key') + 1); };
-        $ob3 = function(Event $event) { $event->setData('key', $event->getData('key') + 1); };
-        $ob4 = function(Event $event) { $event->setData('key', $event->getData('key') + 1); };
+    public function testData(): void {
+        $ob1 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
+        $ob2 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
+        $ob3 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
+        $ob4 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
 
         $this->object->subscribe('event.test', $ob1);
         $this->object->subscribe('event.test', $ob2);
@@ -152,9 +152,9 @@ class EmitterTest extends TestCase {
         $this->assertEquals(Map {'key' => 4}, $event->getData());
     }
 
-    public function testSubscribeAndUnsubscribe() {
-        $ob1 = function(Event $event) { };
-        $ob2 = function(Event $event) { };
+    public function testSubscribeAndUnsubscribe(): void {
+        $ob1 = function(Event $event): void { };
+        $ob2 = function(Event $event): void { };
 
         $this->object->subscribe('event.test', $ob1);
         $this->object->subscribe('event.test', $ob2);
@@ -172,7 +172,7 @@ class EmitterTest extends TestCase {
         }, $this->object->getObservers('event.test'));
     }
 
-    public function testListenAndUnlisten() {
+    public function testListenAndUnlisten(): void {
         $listener = new ListenerStub();
 
         $this->object->listen($listener);
@@ -190,9 +190,9 @@ class EmitterTest extends TestCase {
         $this->assertEquals(Vector {}, $this->object->getCallStack('event.test1'));
     }
 
-    public function testEmit() {
-        $ob1 = function(Event $event) { };
-        $ob2 = function(Event $event) { $event->stop(); };
+    public function testEmit(): void {
+        $ob1 = function(Event $event): void { };
+        $ob2 = function(Event $event): void { $event->stop(); };
         $ob3 = new ListenerStub();
 
         $this->object->subscribe('event.test', $ob1);
@@ -205,17 +205,17 @@ class EmitterTest extends TestCase {
         $this->assertEquals(1, $event->getIndex());
     }
 
-    public function testEmitNoObservers() {
+    public function testEmitNoObservers(): void {
         $event = $this->object->emit('fake.event', []);
 
         $this->assertInstanceOf('Titon\Event\Event', $event);
         $this->assertEquals(Vector {}, $event->getCallStack());
     }
 
-    public function testEmitParams() {
+    public function testEmitParams(): void {
         $ob1 = new ListenerStub();
-        $ob2 = function(Event $event, &$int, $object) { $int++; };
-        $ob3 = function(Event $event, &$int, $object) { $int += 5; };
+        $ob2 = function(Event $event, &$int, $object): void { $int++; };
+        $ob3 = function(Event $event, &$int, $object): void { $int += 5; };
 
         $this->object->subscribe('event.test', [$ob1, 'noop3']);
         $this->object->subscribe('event.test', $ob2);
@@ -231,7 +231,7 @@ class EmitterTest extends TestCase {
         $this->assertEquals(6, $int);
     }
 
-    public function testEmitReturnState() {
+    public function testEmitReturnState(): void {
         $count = 0;
         $ob1 = function(Event $event) use (&$count) { $count++; }; // Void, will continue
         $ob2 = function(Event $event) use (&$count) { $count++; return true; }; // True, will continue
@@ -249,9 +249,9 @@ class EmitterTest extends TestCase {
         $this->assertEquals(['foo' => 'bar'], $event->getState());
     }
 
-    public function testEmitMany() {
-        $ob1 = function(Event $event) { };
-        $ob2 = function(Event $event) { $event->stop(); };
+    public function testEmitMany(): void {
+        $ob1 = function(Event $event): void { };
+        $ob2 = function(Event $event): void { $event->stop(); };
         $ob3 = new ListenerStub();
 
         $this->object->subscribe('event.test', $ob1);
@@ -263,9 +263,9 @@ class EmitterTest extends TestCase {
         $this->assertEquals(2, count($events));
     }
 
-    public function testEmitManyWildcard() {
-        $ob1 = function(Event $event) { };
-        $ob2 = function(Event $event) { $event->stop(); };
+    public function testEmitManyWildcard(): void {
+        $ob1 = function(Event $event): void { };
+        $ob2 = function(Event $event): void { $event->stop(); };
         $ob3 = new ListenerStub();
 
         $this->object->subscribe('event.cb1', $ob1);
@@ -276,7 +276,7 @@ class EmitterTest extends TestCase {
         $this->assertEquals(5, count($events));
     }
 
-    public function testEmitAsyncs() {
+    public function testEmitAsyncs(): void {
         $stub = new ListenerStub();
         $list = [];
 

--- a/tests/Titon/Event/EmitterTest.hh
+++ b/tests/Titon/Event/EmitterTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Event;
 
 use Titon\Test\Stub\Event\ListenerStub;

--- a/tests/Titon/Event/EmitterTest.hh
+++ b/tests/Titon/Event/EmitterTest.hh
@@ -16,8 +16,8 @@ class EmitterTest extends TestCase {
     }
 
     public function testFlush(): void {
-        $ob1 = function(Event $event): void { };
-        $ob2 = function(Event $event): void { };
+        $ob1 = ($event) ==> { };
+        $ob2 = ($event) ==> { };
 
         $this->object->subscribe('event.test1', $ob1);
         $this->object->subscribe('event.test2', $ob2);
@@ -32,7 +32,7 @@ class EmitterTest extends TestCase {
     }
 
     public function testGetObservers(): void {
-        $ob1 = function(Event $event): void { };
+        $ob1 = ($event) ==> { };
         $ob2 = [new ListenerStub(), 'noop1'];
 
         $this->object->subscribe('event.test', $ob1, 20);
@@ -46,9 +46,9 @@ class EmitterTest extends TestCase {
     }
 
     public function testGetCallStack(): void {
-        $ob1 = function(Event $event): void { };
+        $ob1 = ($event) ==> { };
         $ob2 = [new ListenerStub(), 'noop2'];
-        $ob3 = function(Event $event): void { };
+        $ob3 = ($event) ==> { };
         $ob4 = [new ListenerStub(), 'noop3'];
 
         $this->object->subscribe('event.test', $ob1, 20);
@@ -67,16 +67,16 @@ class EmitterTest extends TestCase {
     public function testGetEventKeys(): void {
         $this->assertEquals(Vector {}, $this->object->getEventKeys());
 
-        $this->object->subscribe('event.test1', function(Event $event): void { });
-        $this->object->subscribe('event.test2', function(Event $event): void { });
+        $this->object->subscribe('event.test1', ($event) ==> { });
+        $this->object->subscribe('event.test2', ($event) ==> { });
 
         $this->assertEquals(Vector {'event.test1', 'event.test2'}, $this->object->getEventKeys());
     }
 
     public function testGetSortedObservers(): void {
-        $ob1 = function(Event $event): void { };
+        $ob1 = ($event) ==> { };
         $ob2 = [new ListenerStub(), 'noop1'];
-        $ob3 = function(Event $event): void { };
+        $ob3 = ($event) ==> { };
 
         $this->object->subscribe('event.test', $ob1, 20);
         $this->object->subscribe('event.test', $ob2, 15);
@@ -100,7 +100,7 @@ class EmitterTest extends TestCase {
     public function testHasObservers(): void {
         $this->assertFalse($this->object->hasObservers('event.test'));
 
-        $this->object->subscribe('event.test', function(Event $event): void { });
+        $this->object->subscribe('event.test', ($event) ==> { });
 
         $this->assertTrue($this->object->hasObservers('event.test'));
     }
@@ -120,10 +120,10 @@ class EmitterTest extends TestCase {
 
     public function testExit(): void {
         $n = 0;
-        $ob1 = function(Event $event, &$i): void { $i++; };
-        $ob2 = function(Event $event, &$i): void { $i++; return true; };
-        $ob3 = function(Event $event, &$i): void { $i++; return false; };
-        $ob4 = function(Event $event, &$i): void { $i++; };
+        $ob1 = function(Event $event, &$i) { $i++; };
+        $ob2 = function(Event $event, &$i) { $i++; return true; };
+        $ob3 = function(Event $event, &$i) { $i++; return false; };
+        $ob4 = function(Event $event, &$i) { $i++; };
 
         $this->object->subscribe('event.test', $ob1);
         $this->object->subscribe('event.test', $ob2);
@@ -136,10 +136,10 @@ class EmitterTest extends TestCase {
     }
 
     public function testData(): void {
-        $ob1 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
-        $ob2 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
-        $ob3 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
-        $ob4 = function(Event $event): void { $event->setData('key', $event->getData('key') + 1); };
+        $ob1 = ($event) ==> { $event->setData('key', $event->getData('key') + 1); };
+        $ob2 = ($event) ==> { $event->setData('key', $event->getData('key') + 1); };
+        $ob3 = ($event) ==> { $event->setData('key', $event->getData('key') + 1); };
+        $ob4 = ($event) ==> { $event->setData('key', $event->getData('key') + 1); };
 
         $this->object->subscribe('event.test', $ob1);
         $this->object->subscribe('event.test', $ob2);
@@ -153,8 +153,8 @@ class EmitterTest extends TestCase {
     }
 
     public function testSubscribeAndUnsubscribe(): void {
-        $ob1 = function(Event $event): void { };
-        $ob2 = function(Event $event): void { };
+        $ob1 = ($event) ==> { };
+        $ob2 = ($event) ==> { };
 
         $this->object->subscribe('event.test', $ob1);
         $this->object->subscribe('event.test', $ob2);
@@ -191,8 +191,8 @@ class EmitterTest extends TestCase {
     }
 
     public function testEmit(): void {
-        $ob1 = function(Event $event): void { };
-        $ob2 = function(Event $event): void { $event->stop(); };
+        $ob1 = ($event) ==> { };
+        $ob2 = ($event) ==> { $event->stop(); };
         $ob3 = new ListenerStub();
 
         $this->object->subscribe('event.test', $ob1);
@@ -214,8 +214,8 @@ class EmitterTest extends TestCase {
 
     public function testEmitParams(): void {
         $ob1 = new ListenerStub();
-        $ob2 = function(Event $event, &$int, $object): void { $int++; };
-        $ob3 = function(Event $event, &$int, $object): void { $int += 5; };
+        $ob2 = function(Event $event, &$int, $object) { $int++; };
+        $ob3 = function(Event $event, &$int, $object) { $int += 5; };
 
         $this->object->subscribe('event.test', [$ob1, 'noop3']);
         $this->object->subscribe('event.test', $ob2);
@@ -233,10 +233,10 @@ class EmitterTest extends TestCase {
 
     public function testEmitReturnState(): void {
         $count = 0;
-        $ob1 = function(Event $event) use (&$count) { $count++; }; // Void, will continue
-        $ob2 = function(Event $event) use (&$count) { $count++; return true; }; // True, will continue
-        $ob3 = function(Event $event) use (&$count) { $count++; return ['foo' => 'bar']; }; // Has a value, will stop
-        $ob4 = function(Event $event) use (&$count) { $count++; return 'foobar'; }; // Will not be reached
+        $ob1 = function($event) use (&$count) { $count++; }; // Void, will continue
+        $ob2 = function($event) use (&$count) { $count++; return true; }; // True, will continue
+        $ob3 = function($event) use (&$count) { $count++; return ['foo' => 'bar']; }; // Has a value, will stop
+        $ob4 = function($event) use (&$count) { $count++; return 'foobar'; }; // Will not be reached
 
         $this->object->subscribe('event.test', $ob1);
         $this->object->subscribe('event.test', $ob2);
@@ -250,8 +250,8 @@ class EmitterTest extends TestCase {
     }
 
     public function testEmitMany(): void {
-        $ob1 = function(Event $event): void { };
-        $ob2 = function(Event $event): void { $event->stop(); };
+        $ob1 = ($event) ==> { };
+        $ob2 = ($event) ==> { $event->stop(); };
         $ob3 = new ListenerStub();
 
         $this->object->subscribe('event.test', $ob1);
@@ -264,8 +264,8 @@ class EmitterTest extends TestCase {
     }
 
     public function testEmitManyWildcard(): void {
-        $ob1 = function(Event $event): void { };
-        $ob2 = function(Event $event): void { $event->stop(); };
+        $ob1 = ($event) ==> { };
+        $ob2 = ($event) ==> { $event->stop(); };
         $ob3 = new ListenerStub();
 
         $this->object->subscribe('event.cb1', $ob1);

--- a/tests/Titon/Event/EventTest.hh
+++ b/tests/Titon/Event/EventTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Event;
 
 use Titon\Test\TestCase;
@@ -10,7 +10,7 @@ class EventTest extends TestCase {
 
     protected $time;
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->time = time();
@@ -22,7 +22,7 @@ class EventTest extends TestCase {
         });
     }
 
-    public function testGetCallStack() {
+    public function testGetCallStack(): void {
         $this->assertEquals(Vector {
             'ClassName::method3',
             'ClassName::method1',
@@ -30,7 +30,7 @@ class EventTest extends TestCase {
         }, $this->object->getCallStack());
     }
 
-    public function testGetIndexAndNext() {
+    public function testGetIndexAndNext(): void {
         $this->assertEquals(0, $this->object->getIndex());
 
         $this->object->next();
@@ -43,18 +43,18 @@ class EventTest extends TestCase {
         $this->assertEquals(2, $this->object->getIndex());
     }
 
-    public function testIsStoppedAndStop() {
+    public function testIsStoppedAndStop(): void {
         $this->assertFalse($this->object->isStopped());
 
         $this->object->stop();
         $this->assertTrue($this->object->isStopped());
     }
 
-    public function testGetKey() {
+    public function testGetKey(): void {
         $this->assertEquals('event.test.key', $this->object->getKey());
     }
 
-    public function testGetTime() {
+    public function testGetTime(): void {
         $this->assertEquals($this->time, $this->object->getTime());
     }
 

--- a/tests/Titon/Event/EventTest.hh
+++ b/tests/Titon/Event/EventTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Event;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Event/SubjectTest.hh
+++ b/tests/Titon/Event/SubjectTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Event;
 
 use Titon\Test\Stub\Event\ListenerStub;

--- a/tests/Titon/Event/SubjectTest.hh
+++ b/tests/Titon/Event/SubjectTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Event;
 
 use Titon\Test\Stub\Event\ListenerStub;
@@ -10,17 +10,17 @@ use Titon\Test\TestCase;
  */
 class SubjectTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new SubjectStub();
     }
 
-    public function testEmit() {
+    public function testEmit(): void {
         $this->assertInstanceOf('Titon\Event\Event', $this->object->emit('event.test', []));
     }
 
-    public function testEmitMany() {
+    public function testEmitMany(): void {
         $events = $this->object->emitMany('event.foo event.bar', []);
 
         $this->assertEquals(2, count($events));
@@ -28,8 +28,8 @@ class SubjectTest extends TestCase {
         $this->assertInstanceOf('Titon\Event\Event', $events['event.bar']);
     }
 
-    public function testOnAndOff() {
-        $callback = function(Event $event) { };
+    public function testOnAndOff(): void {
+        $callback = function(Event $event): void { };
         $listener = new ListenerStub();
 
         $this->object->on('event.test1', $callback);
@@ -47,12 +47,12 @@ class SubjectTest extends TestCase {
         $this->assertEquals(Vector {}, $this->object->getEmitter()->getObservers('event.test1'));
     }
 
-    public function testOnce() {
+    public function testOnce(): void {
         $count = 0;
 
-        $ob1 = function(Event $event, &$c) { $c++; };
+        $ob1 = function(Event $event, &$c): void { $c++; };
         $ob2 = [new ListenerStub(), 'counter'];
-        $ob3 = function(Event $event, &$c) { $c++; };
+        $ob3 = function(Event $event, &$c): void { $c++; };
         $ob4 = [new ListenerStub(), 'counter'];
 
         $this->object->once('event.test', $ob1, 20);

--- a/tests/Titon/Event/SubjectTest.hh
+++ b/tests/Titon/Event/SubjectTest.hh
@@ -1,10 +1,12 @@
 <?hh
 namespace Titon\Event;
 
+use Titon\Test\Stub\Event\ListenerStub;
+use Titon\Test\Stub\Event\SubjectStub;
 use Titon\Test\TestCase;
 
 /**
- * @property \Titon\Event\SubjectStub $object
+ * @property \Titon\Test\Stub\Event\SubjectStub $object
  */
 class SubjectTest extends TestCase {
 
@@ -67,8 +69,4 @@ class SubjectTest extends TestCase {
         $this->assertEquals(6, $count);
     }
 
-}
-
-class SubjectStub implements Subject {
-    use EmitsEvents;
 }

--- a/tests/Titon/Event/SubjectTest.hh
+++ b/tests/Titon/Event/SubjectTest.hh
@@ -29,7 +29,7 @@ class SubjectTest extends TestCase {
     }
 
     public function testOnAndOff(): void {
-        $callback = function(Event $event): void { };
+        $callback = ($event) ==> { };
         $listener = new ListenerStub();
 
         $this->object->on('event.test1', $callback);
@@ -50,9 +50,9 @@ class SubjectTest extends TestCase {
     public function testOnce(): void {
         $count = 0;
 
-        $ob1 = function(Event $event, &$c): void { $c++; };
+        $ob1 = function(Event $event, &$c) { $c++; };
         $ob2 = [new ListenerStub(), 'counter'];
-        $ob3 = function(Event $event, &$c): void { $c++; };
+        $ob3 = function(Event $event, &$c) { $c++; };
         $ob4 = [new ListenerStub(), 'counter'];
 
         $this->object->once('event.test', $ob1, 20);

--- a/tests/Titon/Http/Bag/CookieBagTest.hh
+++ b/tests/Titon/Http/Bag/CookieBagTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Bag;
 
 use Titon\Http\Cookie;

--- a/tests/Titon/Http/Bag/CookieBagTest.hh
+++ b/tests/Titon/Http/Bag/CookieBagTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Bag;
 
 use Titon\Http\Cookie;
@@ -6,7 +6,7 @@ use Titon\Test\TestCase;
 
 class CookieBagTest extends TestCase {
 
-    public function testMapItemsAreConvertedToClasses() {
+    public function testMapItemsAreConvertedToClasses(): void {
         $bag = new CookieBag(Map {
             'foo' => '123',
             'bar' => '456',

--- a/tests/Titon/Http/Bag/HeaderBagTest.hh
+++ b/tests/Titon/Http/Bag/HeaderBagTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Bag;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Http/Bag/HeaderBagTest.hh
+++ b/tests/Titon/Http/Bag/HeaderBagTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Bag;
 
 use Titon\Test\TestCase;
@@ -8,13 +8,13 @@ use Titon\Test\TestCase;
  */
 class HeaderBagTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new HeaderBag();
     }
 
-    public function testKeyFormatsCorrectly() {
+    public function testKeyFormatsCorrectly(): void {
         $this->assertEquals('Content-Length', $this->object->key('CONTENT_LENGTH'));
         $this->assertEquals('Content-Type', $this->object->key('Content-TYPE'));
         $this->assertEquals('Location', $this->object->key('location'));

--- a/tests/Titon/Http/CookieTest.hh
+++ b/tests/Titon/Http/CookieTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Http/CookieTest.hh
+++ b/tests/Titon/Http/CookieTest.hh
@@ -8,7 +8,7 @@ class CookieTest extends TestCase {
     public function testSetupState(): void {
         $cookie = new Cookie('foo', 'bar', '+10 minutes', '/baz', 'domain.com');
 
-        $this->assertEquals('foo=5hxAThObwiiTyh0mhfxIKw%3D%3D; Expires=' . gmdate('D, d M Y H:i:s T', strtotime('+10 minutes')) . '; Path=/baz; Domain=domain.com; HttpOnly', (string) $cookie);
+        $this->assertEquals('foo=5hxAThObwiiTyh0mhfxIKw%3D%3D; Expires=' . gmdate('D, d M Y H:i:s T', $cookie->getExpires()) . '; Path=/baz; Domain=domain.com; HttpOnly', (string) $cookie);
     }
 
     public function testValueCanBeEncryptedAndDecrypted(): void {
@@ -28,7 +28,7 @@ class CookieTest extends TestCase {
         $cookie->setExpires('-10 minutes');
         $cookie->setSecure(true);
 
-        $this->assertEquals('foo=deleted; Expires=' . gmdate('D, d M Y H:i:s T', strtotime('-10 minutes')) . '; Path=/; Secure; HttpOnly', (string) $cookie);
+        $this->assertEquals('foo=deleted; Expires=' . gmdate('D, d M Y H:i:s T', $cookie->getExpires()) . '; Path=/; Secure; HttpOnly', (string) $cookie);
     }
 
     /**

--- a/tests/Titon/Http/CookieTest.hh
+++ b/tests/Titon/Http/CookieTest.hh
@@ -1,17 +1,17 @@
-<?hh
+<?hh // strict
 namespace Titon\Http;
 
 use Titon\Test\TestCase;
 
 class CookieTest extends TestCase {
 
-    public function testSetupState() {
+    public function testSetupState(): void {
         $cookie = new Cookie('foo', 'bar', '+10 minutes', '/baz', 'domain.com');
 
         $this->assertEquals('foo=5hxAThObwiiTyh0mhfxIKw%3D%3D; Expires=' . gmdate('D, d M Y H:i:s T', strtotime('+10 minutes')) . '; Path=/baz; Domain=domain.com; HttpOnly', (string) $cookie);
     }
 
-    public function testValueCanBeEncryptedAndDecrypted() {
+    public function testValueCanBeEncryptedAndDecrypted(): void {
         $cookie = new Cookie('foo', 'bar');
 
         $this->assertEquals('bar', $cookie->getValue());
@@ -23,7 +23,7 @@ class CookieTest extends TestCase {
         $this->assertEquals('bar', $cookie->getDecryptedValue());
     }
 
-    public function testFlagsAlterOutputString() {
+    public function testFlagsAlterOutputString(): void {
         $cookie = new Cookie('foo', 'bar');
         $cookie->setExpires('-10 minutes');
         $cookie->setSecure(true);
@@ -34,7 +34,7 @@ class CookieTest extends TestCase {
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testNameFailsOnInvalidCharacters() {
+    public function testNameFailsOnInvalidCharacters(): void {
         new Cookie('foo;bar', '');
     }
 

--- a/tests/Titon/Http/HttpTest.hh
+++ b/tests/Titon/Http/HttpTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Http;
 
 use Titon\Test\TestCase;
 
 class HttpTest extends TestCase {
 
-    public function testGetHeaderTypes() {
+    public function testGetHeaderTypes(): void {
         $this->assertEquals(Vector {
             'Accept',
             'Accept-Charset',
@@ -69,7 +69,7 @@ class HttpTest extends TestCase {
         }, Http::getHeaderTypes());
     }
 
-    public function testGetMethodTypes() {
+    public function testGetMethodTypes(): void {
         $this->assertEquals(Vector {
             'GET',
             'POST',
@@ -82,7 +82,7 @@ class HttpTest extends TestCase {
         }, Http::getMethodTypes());
     }
 
-    public function testGetStatusCodes() {
+    public function testGetStatusCodes(): void {
         $this->assertEquals(Map {
             100 => 'Continue',
             101 => 'Switching Protocols',
@@ -139,14 +139,14 @@ class HttpTest extends TestCase {
         }, Http::getStatusCodes());
     }
 
-    public function testGetStatusCode() {
+    public function testGetStatusCode(): void {
         $this->assertEquals('OK', Http::getStatusCode(200));
     }
 
     /**
      * @expectedException \Titon\Http\Exception\InvalidStatusException
      */
-    public function testGetStatusCodeInvalidCode() {
+    public function testGetStatusCodeInvalidCode(): void {
         Http::getStatusCode(999);
     }
 

--- a/tests/Titon/Http/HttpTest.hh
+++ b/tests/Titon/Http/HttpTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Http/MimeTest.hh
+++ b/tests/Titon/Http/MimeTest.hh
@@ -1,15 +1,15 @@
-<?hh
+<?hh // strict
 namespace Titon\Http;
 
 use Titon\Test\TestCase;
 
 class MimeTest extends TestCase {
 
-    public function testGetAll() {
+    public function testGetAll(): void {
         $this->assertEquals(907, count(Mime::getAll()));
     }
 
-    public function testGetAllByType() {
+    public function testGetAllByType(): void {
         $this->assertEquals(661, count(Mime::getAllByType(Mime::APPLICATION)));
         $this->assertEquals(42, count(Mime::getAllByType(Mime::AUDIO)));
         $this->assertEquals(54, count(Mime::getAllByType(Mime::IMAGE)));
@@ -18,13 +18,13 @@ class MimeTest extends TestCase {
         $this->assertEquals(77, count(Mime::getAllByType(Mime::TEXT)));
     }
 
-    public function testGetExtByType() {
+    public function testGetExtByType(): void {
         $this->assertEquals(Vector {'jpe', 'jpeg', 'jpg'}, Mime::getExtByType('image/jpeg'));
         $this->assertEquals(Vector {'m1v', 'm2v', 'mpe', 'mpeg', 'mpg'}, Mime::getExtByType('video/mpeg'));
         $this->assertEquals(Vector {'htc', 'htm', 'html'}, Mime::getExtByType('text/html'));
     }
 
-    public function testGetTypeByExt() {
+    public function testGetTypeByExt(): void {
         $this->assertEquals('image/gif', Mime::getTypeByExt('gif'));
         $this->assertEquals('text/html', Mime::getTypeByExt('html'));
     }
@@ -32,7 +32,7 @@ class MimeTest extends TestCase {
     /**
      * @expectedException \Titon\Http\Exception\InvalidExtensionException
      */
-    public function testGetTypeByExtInvalidExt() {
+    public function testGetTypeByExtInvalidExt(): void {
         Mime::getTypeByExt('image/gif', Mime::getTypeByExt('gf'));
     }
 

--- a/tests/Titon/Http/MimeTest.hh
+++ b/tests/Titon/Http/MimeTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Http/Server/DownloadResponseTest.hh
+++ b/tests/Titon/Http/Server/DownloadResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -10,30 +10,29 @@ class DownloadResponseTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/http/');
-        $this->vfs->createFile('/http/download.txt', 'This will be downloaded! Let\'s fluff this file with even more data to increase the file size.');
+        $this->vfs()->createDirectory('/http/');
+        $this->vfs()->createFile('/http/download.txt', 'This will be downloaded! Let\'s fluff this file with even more data to increase the file size.');
     }
 
     /**
      * @expectedException \Titon\Common\Exception\MissingFileException
      */
     public function testMissingFileErrors(): void {
-        new DownloadResponse($this->vfs->path('/http/download-missing.txt'));
+        new DownloadResponse($this->vfs()->path('/http/download-missing.txt'));
     }
 
     /**
      * @expectedException \Titon\Http\Exception\InvalidFileException
      */
     public function testUnwritableFileErrors(): void {
-        $this->vfs->createFile('/http/download-unwritable.txt', '')->chmod(0300);
+        $this->vfs()->createFile('/http/download-unwritable.txt', '')->chmod(0300);
 
-        new DownloadResponse($this->vfs->path('/http/download-unwritable.txt'));
+        new DownloadResponse($this->vfs()->path('/http/download-unwritable.txt'));
     }
 
     public function testSend(): void {
         $time = time();
-        $response = new DownloadResponse($this->vfs->path('/http/download.txt'));
+        $response = new DownloadResponse($this->vfs()->path('/http/download.txt'));
         $response->prepare(Request::createFromGlobals());
         $response->date($time);
 
@@ -56,10 +55,10 @@ class DownloadResponseTest extends TestCase {
     }
 
     public function testSendNoType(): void {
-        $this->vfs->createFile('/http/download', 'This will be downloaded! Let\'s fluff this file with even more data to increase the file size.');
+        $this->vfs()->createFile('/http/download', 'This will be downloaded! Let\'s fluff this file with even more data to increase the file size.');
 
         $time = time();
-        $response = new DownloadResponse($this->vfs->path('/http/download'));
+        $response = new DownloadResponse($this->vfs()->path('/http/download'));
         $response->prepare(Request::createFromGlobals());
         $response->date($time);
 
@@ -83,7 +82,7 @@ class DownloadResponseTest extends TestCase {
 
     public function testSendConfig(): void {
         $time = time();
-        $response = Response::download($this->vfs->path('/http/download.txt'), 'custom-filename.txt', true, true);
+        $response = Response::download($this->vfs()->path('/http/download.txt'), 'custom-filename.txt', true, true);
         $response->prepare(Request::createFromGlobals());
         $response->date($time);
 
@@ -99,7 +98,7 @@ class DownloadResponseTest extends TestCase {
             'Content-Disposition' => ['attachment; filename="custom-filename.txt"'],
             'Accept-Ranges' => ['bytes'],
             'Content-Transfer-Encoding' => ['binary'],
-            'Last-Modified' => [gmdate(Http::DATE_FORMAT, filemtime($this->vfs->path('/http/download.txt')))],
+            'Last-Modified' => [gmdate(Http::DATE_FORMAT, filemtime($this->vfs()->path('/http/download.txt')))],
             'ETag' => ['"3cefcf43cb525cb668db0cb67cccc41a8f90a727"'],
             'Content-Length' => [93],
         ], $response->getHeaders());
@@ -111,7 +110,7 @@ class DownloadResponseTest extends TestCase {
         $_SERVER['HTTP_RANGE'] = 'bytes=0-5';
         Server::initialize($_SERVER);
 
-        $response = new DownloadResponse($this->vfs->path('/http/download.txt'));
+        $response = new DownloadResponse($this->vfs()->path('/http/download.txt'));
         $response->prepare(Request::createFromGlobals());
 
         ob_start();
@@ -127,7 +126,7 @@ class DownloadResponseTest extends TestCase {
         $_SERVER['HTTP_RANGE'] = 'bytes=5-3';
         Server::initialize($_SERVER);
 
-        $response = new DownloadResponse($this->vfs->path('/http/download.txt'));
+        $response = new DownloadResponse($this->vfs()->path('/http/download.txt'));
         $response->prepare(Request::createFromGlobals());
 
         ob_start();
@@ -143,10 +142,13 @@ class DownloadResponseTest extends TestCase {
         $_SERVER['HTTP_RANGE'] = 'bytes=0-19';
         Server::initialize($_SERVER);
 
-        $path = $this->vfs->path('/http/download.txt');
+        $path = $this->vfs()->path('/http/download.txt');
 
         $response = new DownloadResponse($path);
         $response->prepare(Request::createFromGlobals());
+        $request = $response->getRequest();
+
+        invariant($request instanceof Request, 'Must be a Request.');
 
         // Valid starting range
         $response->setFileRange($path);
@@ -156,7 +158,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('bytes 0-19/93', $response->getHeader('Content-Range'));
 
         // No starting range
-        $response->getRequest()->headers->set('Range', ['bytes=-35']);
+        $request->headers->set('Range', ['bytes=-35']);
         $response->setFileRange($path);
 
         $this->assertEquals(206, $response->getStatusCode());
@@ -164,7 +166,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('bytes 0-35/93', $response->getHeader('Content-Range'));
 
         // No ending range
-        $response->getRequest()->headers->set('Range', ['bytes=45-']);
+        $request->headers->set('Range', ['bytes=45-']);
         $response->setFileRange($path);
 
         $this->assertEquals(206, $response->getStatusCode());
@@ -172,7 +174,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('bytes 45-92/93', $response->getHeader('Content-Range'));
 
         // Valid ending range
-        $response->getRequest()->headers->set('Range', ['bytes=33-92']);
+        $request->headers->set('Range', ['bytes=33-92']);
         $response->setFileRange($path);
 
         $this->assertEquals(206, $response->getStatusCode());
@@ -180,7 +182,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('bytes 33-92/93', $response->getHeader('Content-Range'));
 
         // No ranges at all
-        $response->getRequest()->headers->set('Range', ['bytes=-']);
+        $request->headers->set('Range', ['bytes=-']);
         $response->setFileRange($path);
 
         $this->assertEquals(206, $response->getStatusCode());
@@ -188,12 +190,12 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('bytes 0-92/93', $response->getHeader('Content-Range'));
 
         // Invalid ranges
-        $response->getRequest()->headers->set('Range', ['bytes=100-0']);
+        $request->headers->set('Range', ['bytes=100-0']);
         $response->setFileRange($path);
 
         $this->assertEquals(416, $response->getStatusCode());
 
-        $response->getRequest()->headers->set('Range', ['bytes=0-125']);
+        $request->headers->set('Range', ['bytes=0-125']);
         $response->setFileRange($path);
 
         $this->assertEquals(416, $response->getStatusCode());
@@ -205,7 +207,7 @@ class DownloadResponseTest extends TestCase {
         $_SERVER['HTTP_ETAG'] = 'ETAG';
         Server::initialize($_SERVER);
 
-        $path = $this->vfs->path('/http/download.txt');
+        $path = $this->vfs()->path('/http/download.txt');
 
         $response = new DownloadResponse($path);
         $response->prepare(Request::createFromGlobals());

--- a/tests/Titon/Http/Server/DownloadResponseTest.hh
+++ b/tests/Titon/Http/Server/DownloadResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -7,7 +7,7 @@ use Titon\Utility\State\Server;
 
 class DownloadResponseTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -18,20 +18,20 @@ class DownloadResponseTest extends TestCase {
     /**
      * @expectedException \Titon\Common\Exception\MissingFileException
      */
-    public function testMissingFileErrors() {
+    public function testMissingFileErrors(): void {
         new DownloadResponse($this->vfs->path('/http/download-missing.txt'));
     }
 
     /**
      * @expectedException \Titon\Http\Exception\InvalidFileException
      */
-    public function testUnwritableFileErrors() {
+    public function testUnwritableFileErrors(): void {
         $this->vfs->createFile('/http/download-unwritable.txt', '')->chmod(0300);
 
         new DownloadResponse($this->vfs->path('/http/download-unwritable.txt'));
     }
 
-    public function testSend() {
+    public function testSend(): void {
         $time = time();
         $response = new DownloadResponse($this->vfs->path('/http/download.txt'));
         $response->prepare(Request::createFromGlobals());
@@ -55,7 +55,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('This will be downloaded! Let\'s fluff this file with even more data to increase the file size.', $body);
     }
 
-    public function testSendNoType() {
+    public function testSendNoType(): void {
         $this->vfs->createFile('/http/download', 'This will be downloaded! Let\'s fluff this file with even more data to increase the file size.');
 
         $time = time();
@@ -81,7 +81,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('This will be downloaded! Let\'s fluff this file with even more data to increase the file size.', $body);
     }
 
-    public function testSendConfig() {
+    public function testSendConfig(): void {
         $time = time();
         $response = Response::download($this->vfs->path('/http/download.txt'), 'custom-filename.txt', true, true);
         $response->prepare(Request::createFromGlobals());
@@ -107,7 +107,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('This will be downloaded! Let\'s fluff this file with even more data to increase the file size.', $body);
     }
 
-    public function testFileRange() {
+    public function testFileRange(): void {
         $_SERVER['HTTP_RANGE'] = 'bytes=0-5';
         Server::initialize($_SERVER);
 
@@ -123,7 +123,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals('bytes 0-5/93', $response->getHeader('Content-Range'));
     }
 
-    public function testInvalidFileRange() {
+    public function testInvalidFileRange(): void {
         $_SERVER['HTTP_RANGE'] = 'bytes=5-3';
         Server::initialize($_SERVER);
 
@@ -139,7 +139,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals(null, $response->getHeader('Content-Range'));
     }
 
-    public function testSetFileRange() {
+    public function testSetFileRange(): void {
         $_SERVER['HTTP_RANGE'] = 'bytes=0-19';
         Server::initialize($_SERVER);
 
@@ -199,7 +199,7 @@ class DownloadResponseTest extends TestCase {
         $this->assertEquals(416, $response->getStatusCode());
     }
 
-    public function testSetFileRangeIfRange() {
+    public function testSetFileRangeIfRange(): void {
         $_SERVER['HTTP_RANGE'] = 'bytes=0-19';
         $_SERVER['HTTP_IF_RANGE'] = 'ETAG';
         $_SERVER['HTTP_ETAG'] = 'ETAG';

--- a/tests/Titon/Http/Server/JsonResponseTest.hh
+++ b/tests/Titon/Http/Server/JsonResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -6,7 +6,7 @@ use Titon\Test\TestCase;
 
 class JsonResponseTest extends TestCase {
 
-    public function testSend() {
+    public function testSend(): void {
         $time = time();
         $response = new JsonResponse(['foo' => 'bar']);
         $response->debug();
@@ -27,7 +27,7 @@ class JsonResponseTest extends TestCase {
         $this->assertEquals('{"foo":"bar"}', $body);
     }
 
-    public function testSendCallback() {
+    public function testSendCallback(): void {
         $time = time();
         $response = new JsonResponse(['foo' => 'bar']);
         $response->debug();
@@ -49,7 +49,7 @@ class JsonResponseTest extends TestCase {
         $this->assertEquals('Vendor.API.method({"foo":"bar"});', $body);
     }
 
-    public function testFlags() {
+    public function testFlags(): void {
         $time = time();
         $response = new JsonResponse(['Carets <>', 'Quotes ""', 'Ampersand &'], 200, JSON_HEX_QUOT);
         $response->debug();

--- a/tests/Titon/Http/Server/JsonResponseTest.hh
+++ b/tests/Titon/Http/Server/JsonResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;

--- a/tests/Titon/Http/Server/RedirectResponseTest.hh
+++ b/tests/Titon/Http/Server/RedirectResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -6,7 +6,7 @@ use Titon\Test\TestCase;
 
 class RedirectResponseTest extends TestCase {
 
-    public function testSend() {
+    public function testSend(): void {
         $time = time();
         $response = new RedirectResponse('/new/url');
         $response->debug();
@@ -36,7 +36,7 @@ class RedirectResponseTest extends TestCase {
     /**
      * @expectedException \Titon\Http\Exception\MalformedResponseException
      */
-    public function testSendErrorsNoUrl() {
+    public function testSendErrorsNoUrl(): void {
         $response = new RedirectResponse('');
         $response->send();
     }

--- a/tests/Titon/Http/Server/RedirectResponseTest.hh
+++ b/tests/Titon/Http/Server/RedirectResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;

--- a/tests/Titon/Http/Server/RedirectorTest.hh
+++ b/tests/Titon/Http/Server/RedirectorTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -7,19 +7,19 @@ use Titon\Utility\State\Server;
 
 class RedirectorTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         Redirector::$exit = false;
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         parent::tearDown();
 
         Redirector::$exit = true;
     }
 
-    public function testBack() {
+    public function testBack(): void {
         $_SERVER['HTTP_REFERER'] = '/new/url';
         Server::initialize($_SERVER);
 
@@ -34,7 +34,7 @@ class RedirectorTest extends TestCase {
         ], $response->getHeaders());
     }
 
-    public function testHome() {
+    public function testHome(): void {
         $time = time();
         $response = Redirector::home();
         $response->date($time);
@@ -46,7 +46,7 @@ class RedirectorTest extends TestCase {
         ], $response->getHeaders());
     }
 
-    public function testRefresh() {
+    public function testRefresh(): void {
         $_SERVER['PATH_INFO'] = '/current/url';
         Server::initialize($_SERVER);
 
@@ -61,9 +61,9 @@ class RedirectorTest extends TestCase {
         ], $response->getHeaders());
     }
 
-    public function testTo() {
+    public function testTo(): void {
         $time = time();
-        $response = Redirector::to('/custom/url', 300, function(Response $response) {
+        $response = Redirector::to('/custom/url', 300, function(Response $response): void {
             $response->setHeader('X-Test', 'Foobar');
         });
         $response->date($time);

--- a/tests/Titon/Http/Server/RedirectorTest.hh
+++ b/tests/Titon/Http/Server/RedirectorTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;

--- a/tests/Titon/Http/Server/RedirectorTest.hh
+++ b/tests/Titon/Http/Server/RedirectorTest.hh
@@ -63,7 +63,7 @@ class RedirectorTest extends TestCase {
 
     public function testTo(): void {
         $time = time();
-        $response = Redirector::to('/custom/url', 300, function(Response $response): void {
+        $response = Redirector::to('/custom/url', 300, ($response) ==> {
             $response->setHeader('X-Test', 'Foobar');
         });
         $response->date($time);

--- a/tests/Titon/Http/Server/RequestTest.hh
+++ b/tests/Titon/Http/Server/RequestTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -15,7 +15,7 @@ use Titon\Utility\State\Server;
  */
 class RequestTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $_GET = [
@@ -109,7 +109,7 @@ class RequestTest extends TestCase {
         $this->object = Request::createFromGlobals();
     }
 
-    public function testInitialize() {
+    public function testInitialize(): void {
         $this->assertEquals(Map {
             'key' => 'value',
             'Model' => Map {
@@ -168,7 +168,7 @@ class RequestTest extends TestCase {
         }, $this->object->files->all());
     }
 
-    public function testClone() {
+    public function testClone(): void {
         $clone = clone $this->object;
 
         $this->assertEquals($clone->attributes, $this->object->attributes);
@@ -180,7 +180,7 @@ class RequestTest extends TestCase {
         $this->assertEquals($clone->server, $this->object->server);
     }
 
-    public function testAccepts() {
+    public function testAccepts(): void {
         $this->object->headers->set('Accept', ['text/xml,application/xml;q=0.9,application/xhtml+xml,text/html,text/plain,image/png']);
 
         $this->assertEquals(shape('value' =>'text/html', 'quality' => 1), $this->object->accepts('html'));
@@ -200,7 +200,7 @@ class RequestTest extends TestCase {
         $this->assertEquals(null, $this->object->accepts('application/json'));
     }
 
-    public function testAcceptsCharset() {
+    public function testAcceptsCharset(): void {
         $this->object->headers->set('Accept-Charset', ['UTF-8']);
 
         $this->assertEquals(shape('value' =>'utf-8', 'quality' => 1), $this->object->acceptsCharset('utf-8'));
@@ -211,14 +211,14 @@ class RequestTest extends TestCase {
         $this->assertEquals(shape('value' =>'iso-8859-1', 'quality' => 1), $this->object->acceptsCharset('iso-8859-1'));
     }
 
-    public function testAcceptsEncoding() {
+    public function testAcceptsEncoding(): void {
         $this->object->headers->set('Accept-Encoding', ['compress;q=0.5, gzip;q=1.0']);
 
         $this->assertEquals(shape('value' =>'gzip', 'quality' => 1), $this->object->acceptsEncoding('gzip'));
         $this->assertEquals(null, $this->object->acceptsEncoding('identity'));
     }
 
-    public function testAcceptsLanguage() {
+    public function testAcceptsLanguage(): void {
         $this->object->headers->set('Accept-Language', ['en-us,en;q=0.8,fr-fr;q=0.5,fr;q=0.3']);
 
         $this->assertEquals(shape('value' =>'en-us', 'quality' => 1), $this->object->acceptsLanguage('en-US'));
@@ -227,7 +227,7 @@ class RequestTest extends TestCase {
         $this->assertEquals(null, $this->object->acceptsLanguage('DE'));
     }
 
-    public function testGetAttribute() {
+    public function testGetAttribute(): void {
         $this->assertEquals(null, $this->object->getAttribute('foo'));
         $this->assertEquals('bar', $this->object->getAttribute('foo', 'bar'));
 
@@ -235,7 +235,7 @@ class RequestTest extends TestCase {
         $this->assertEquals('baz', $this->object->getAttribute('foo'));
     }
 
-    public function testGetAttributes() {
+    public function testGetAttributes(): void {
         $this->object->setAttribute('foo', 'bar');
         $this->object->setAttribute('baz', 'qux');
 
@@ -245,7 +245,7 @@ class RequestTest extends TestCase {
         ], $this->object->getAttributes());
     }
 
-    public function testGetBodyParams() {
+    public function testGetBodyParams(): void {
         $this->assertEquals([
             'key' => 'value',
             'Model' => [
@@ -254,7 +254,7 @@ class RequestTest extends TestCase {
         ], $this->object->getBodyParams());
     }
 
-    public function testGetClientIp() {
+    public function testGetClientIp(): void {
         $this->object->server->set('REMOTE_ADDR', '192.168.1.2');
         $this->object->server->set('HTTP_CLIENT_IP', '192.168.1.1');
 
@@ -273,25 +273,25 @@ class RequestTest extends TestCase {
         $this->assertEquals('192.168.1.1', $this->object->getClientIP());
     }
 
-    public function testGetCookie() {
+    public function testGetCookie(): void {
         $this->assertEquals(null, $this->object->getCookie('key'));
         $this->assertEquals(new Cookie('foo', '5hxAThObwiiTyh0mhfxIKw%3D%3D'), $this->object->getCookie('foo'));
         $this->assertEquals('bar', $this->object->getCookie('foo')->getDecryptedValue());
     }
 
-    public function testGetCookies() {
+    public function testGetCookies(): void {
         $this->assertEquals(Map {
             'foo' => new Cookie('foo', '5hxAThObwiiTyh0mhfxIKw%3D%3D') // Object version
         }, $this->object->getCookies());
     }
 
-    public function testGetCookieParams() {
+    public function testGetCookieParams(): void {
         $this->assertEquals([
             'foo' => 'bar' // Unencrypted version
         ], $this->object->getCookieParams());
     }
 
-    public function testGetFileParams() {
+    public function testGetFileParams(): void {
         $this->assertEquals(4, count($this->object->getFileParams()));
         $this->assertEquals([
             'two' => [
@@ -306,7 +306,7 @@ class RequestTest extends TestCase {
         ], $this->object->getFileParams()['three']);
     }
 
-    public function testGetHeader() {
+    public function testGetHeader(): void {
         $this->assertEquals('', $this->object->getHeader('Accept-Charset'));
         $this->object->headers->set('Accept-Charset', ['utf-8', 'utf-16']);
 
@@ -314,7 +314,7 @@ class RequestTest extends TestCase {
         $this->assertEquals(['utf-8', 'utf-16'], $this->object->getHeaderAsArray('Accept-Charset'));
     }
 
-    public function testGetHost() {
+    public function testGetHost(): void {
         $this->object->server->set('HTTP_HOST', 'titon.io');
         $this->assertEquals('titon.io', $this->object->getHost());
 
@@ -336,11 +336,11 @@ class RequestTest extends TestCase {
         $this->assertEquals('74.232.443.122', $this->object->getHost());
     }
 
-    public function testGetMethod() {
+    public function testGetMethod(): void {
         $this->assertEquals('PUT', $this->object->getMethod()); // set in $_POST
     }
 
-    public function testGetMethodOverride() {
+    public function testGetMethodOverride(): void {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SERVER['HTTP_X_METHOD_OVERRIDE'] = 'DELETE';
 
@@ -349,14 +349,14 @@ class RequestTest extends TestCase {
         $this->assertEquals('DELETE', Request::createFromGlobals()->getMethod());
     }
 
-    public function testGetProtocolVersion() {
+    public function testGetProtocolVersion(): void {
         $this->assertEquals('1.1', $this->object->getProtocolVersion());
 
         $this->object->server->set('SERVER_PROTOCOL', '1.0');
         $this->assertEquals('1.0', $this->object->getProtocolVersion());
     }
 
-    public function testGetPort() {
+    public function testGetPort(): void {
         $this->object->server->set('HTTP_HOST', 'titon.io');
         $this->assertEquals(80, $this->object->getPort());
 
@@ -393,7 +393,7 @@ class RequestTest extends TestCase {
         $this->assertEquals(88, $this->object->getPort());
     }
 
-    public function testGetQueryParams() {
+    public function testGetQueryParams(): void {
         $this->assertEquals([
             'key' => 'value',
             'Model' => [
@@ -402,7 +402,7 @@ class RequestTest extends TestCase {
         ], $this->object->getQueryParams());
     }
 
-    public function testGetReferrer() {
+    public function testGetReferrer(): void {
         $this->object->server->set('HTTP_REFERER', '');
         $this->assertEquals('/', $this->object->getReferrer());
 
@@ -413,23 +413,23 @@ class RequestTest extends TestCase {
         $this->assertEquals('/module/controller', $this->object->getReferrer());
     }
 
-    public function testGetScheme() {
+    public function testGetScheme(): void {
         $this->assertEquals('http', $this->object->getScheme());
 
         $this->object->server->set('HTTPS', 'on');
         $this->assertEquals('https', $this->object->getScheme());
     }
 
-    public function testGetServerIp() {
+    public function testGetServerIp(): void {
         $this->object->server->set('SERVER_ADDR', '127.0.0.1');
         $this->assertEquals('127.0.0.1', $this->object->getServerIP());
     }
 
-    public function testGetServerParams() {
+    public function testGetServerParams(): void {
         $this->assertGreaterThan(0, count($this->object->getServerParams())); // Too many values to explicitly test
     }
 
-    public function testGetUrl() {
+    public function testGetUrl(): void {
         $this->object->server->add(Map {
             'SCRIPT_FILENAME' => '/var/www/titon/app/web/index.php',
             'DOCUMENT_ROOT' => '/var/www/titon/app/web',
@@ -451,7 +451,7 @@ class RequestTest extends TestCase {
         $this->assertEquals('/en/some/path/', $this->object->getUrl()); // PHP_SELF
     }
 
-    public function testGetUrlBaseFolder() {
+    public function testGetUrlBaseFolder(): void {
         $this->object->server->add(Map {
             'SCRIPT_FILENAME' => '/var/www/titon/app/web/root/index.php',
             'DOCUMENT_ROOT' => '/var/www/titon/app/web',
@@ -473,19 +473,19 @@ class RequestTest extends TestCase {
         $this->assertEquals('/root/en/some/path/', $this->object->getUrl()); // PHP_SELF
     }
 
-    public function testGetUserAgent() {
+    public function testGetUserAgent(): void {
         $this->object->server->set('HTTP_USER_AGENT', 'Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0');
         $this->assertEquals('Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0', $this->object->getUserAgent());
     }
 
-    public function testHasHeader() {
+    public function testHasHeader(): void {
         $this->assertFalse($this->object->hasHeader('Accept-Charset'));
 
         $this->object->headers->set('Accept-Charset', ['utf-8']);
         $this->assertTrue($this->object->hasHeader('Accept-Charset'));
     }
 
-    public function testIsAjax() {
+    public function testIsAjax(): void {
         $this->object->server->set('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
         $this->assertTrue($this->object->isAJAX());
 
@@ -493,7 +493,7 @@ class RequestTest extends TestCase {
         $this->assertFalse($this->object->isAJAX());
     }
 
-    public function testIsMethods() {
+    public function testIsMethods(): void {
         $this->assertTrue($this->object->isPut()); // Set in $_POST
 
         $this->object->setMethod('get');
@@ -509,7 +509,7 @@ class RequestTest extends TestCase {
         $this->assertTrue($this->object->isMethod('put'));
     }
 
-    public function testIsFlash() {
+    public function testIsFlash(): void {
         $this->object->server->set('HTTP_USER_AGENT', '');
         $this->assertFalse($this->object->isFlash());
 
@@ -520,7 +520,7 @@ class RequestTest extends TestCase {
         $this->assertTrue($this->object->isFlash());
     }
 
-    public function testIsMobile() {
+    public function testIsMobile(): void {
         $this->object->server->set('HTTP_USER_AGENT', '');
         $this->assertFalse($this->object->isMobile());
 
@@ -540,7 +540,7 @@ class RequestTest extends TestCase {
         $this->assertTrue($this->object->isMobile());
     }
 
-    public function testIsSecure() {
+    public function testIsSecure(): void {
         $this->object->server->set('HTTPS', 'off');
         $this->object->server->set('SERVER_PORT', 80);
 
@@ -570,7 +570,7 @@ class RequestTest extends TestCase {
         $this->assertTrue($this->object->isSecure());
     }
 
-    public function testSetAttribute() {
+    public function testSetAttribute(): void {
         $this->object->setAttribute('foo', 'bar');
         $this->assertEquals('bar', $this->object->getAttribute('foo'));
 
@@ -578,7 +578,7 @@ class RequestTest extends TestCase {
         $this->assertEquals('baz', $this->object->getAttribute('foo'));
     }
 
-    public function testSetAttributes() {
+    public function testSetAttributes(): void {
         $this->object->setAttributes([
             'foo' => 'bar',
             'baz' => 'qux'
@@ -590,7 +590,7 @@ class RequestTest extends TestCase {
         ], $this->object->getAttributes());
     }
 
-    public function testSetMethod() {
+    public function testSetMethod(): void {
         $this->assertEquals('PUT', $this->object->getMethod());
 
         $this->object->setMethod('delete');
@@ -600,18 +600,18 @@ class RequestTest extends TestCase {
     /**
      * @expectedException \Titon\Http\Exception\InvalidMethodException
      */
-    public function testSetMethodInvalidMethod() {
+    public function testSetMethodInvalidMethod(): void {
         $this->object->setMethod('FOO');
     }
 
-    public function testSetUrl() {
+    public function testSetUrl(): void {
         $this->assertEquals('/', $this->object->getUrl());
 
         $this->object->setUrl('/foo');
         $this->assertEquals('/foo', $this->object->getUrl());
     }
 
-    public function testTrustProxyToggle() {
+    public function testTrustProxyToggle(): void {
         $this->object->trustProxies();
         $this->assertTrue($this->object->isTrustingProxies());
 

--- a/tests/Titon/Http/Server/RequestTest.hh
+++ b/tests/Titon/Http/Server/RequestTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;

--- a/tests/Titon/Http/Server/ResponseTest.hh
+++ b/tests/Titon/Http/Server/ResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -227,10 +227,9 @@ class ResponseTest extends TestCase {
     }
 
     public function testDownload(): void {
-        $this->setupVFS();
-        $this->vfs->createFile('/download.txt');
+        $this->vfs()->createFile('/download.txt');
 
-        $this->assertInstanceOf('Titon\Http\Server\DownloadResponse', Response::download($this->vfs->path('/download.txt')));
+        $this->assertInstanceOf('Titon\Http\Server\DownloadResponse', Response::download($this->vfs()->path('/download.txt')));
     }
 
     public function testEtag(): void {

--- a/tests/Titon/Http/Server/ResponseTest.hh
+++ b/tests/Titon/Http/Server/ResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -13,7 +13,7 @@ class ResponseTest extends TestCase {
 
     protected $time;
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-us,en;q=0.5';
@@ -25,7 +25,7 @@ class ResponseTest extends TestCase {
         $this->object->date($this->time);
     }
 
-    public function testAcceptRanges() {
+    public function testAcceptRanges(): void {
         $this->object->acceptRanges();
         $this->assertEquals('bytes', $this->object->getHeader('Accept-Ranges'));
 
@@ -36,14 +36,14 @@ class ResponseTest extends TestCase {
         $this->assertEquals('custom', $this->object->getHeader('Accept-Ranges'));
     }
 
-    public function testAddHeader() {
+    public function testAddHeader(): void {
         $this->object->addHeader('Accept-Charset', 'utf-8');
         $this->object->addHeader('Accept-Charset', 'utf-16');
 
         $this->assertEquals(['utf-8', 'utf-16'], $this->object->getHeaderAsArray('Accept-Charset'));
     }
 
-    public function testAddHeaders() {
+    public function testAddHeaders(): void {
         $this->object->addHeader('Accept-Charset', 'utf-8');
         $this->object->addHeader('Accept-Language', 'en');
         $this->object->addHeaders([
@@ -55,7 +55,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals(['en', 'fr'], $this->object->getHeaderAsArray('Accept-Language'));
     }
 
-    public function testAge() {
+    public function testAge(): void {
         $this->object->age(120);
         $this->assertEquals('120', $this->object->getHeader('Age'));
 
@@ -63,7 +63,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('3600', $this->object->getHeader('Age'));
     }
 
-    public function testAllow() {
+    public function testAllow(): void {
         $this->object->allow(Vector {'get'});
         $this->assertEquals('GET', $this->object->getHeader('Allow'));
 
@@ -71,7 +71,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('POST, PUT', $this->object->getHeader('Allow'));
     }
 
-    public function testCache() {
+    public function testCache(): void {
         $this->object->cache('none');
         $this->assertEquals('no-cache, no-store, must-revalidate, proxy-revalidate', $this->object->getHeader('Cache-Control'));
 
@@ -97,11 +97,11 @@ class ResponseTest extends TestCase {
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testCacheInvalidDirective() {
+    public function testCacheInvalidDirective(): void {
         $this->object->cache('foobar');
     }
 
-    public function testCacheControl() {
+    public function testCacheControl(): void {
         $this->object->cacheControl(Map {'public' => true});
         $this->assertEquals('public', $this->object->getHeader('Cache-Control'));
 
@@ -115,7 +115,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('private="foobar", max-age=123', $this->object->getHeader('Cache-Control'));
     }
 
-    public function testConnection() {
+    public function testConnection(): void {
         $this->object->connection(true);
         $this->assertEquals('keep-alive', $this->object->getHeader('Connection'));
 
@@ -126,7 +126,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('custom', $this->object->getHeader('Connection'));
     }
 
-    public function testContentDisposition() {
+    public function testContentDisposition(): void {
         $this->object->contentDisposition('file.png');
         $this->assertEquals('attachment; filename="file.png"', $this->object->getHeader('Content-Disposition'));
 
@@ -137,11 +137,11 @@ class ResponseTest extends TestCase {
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testContentDispositionInvalidType() {
+    public function testContentDispositionInvalidType(): void {
         $this->object->contentDisposition('file.png', 'foobar');
     }
 
-    public function testContentEncoding() {
+    public function testContentEncoding(): void {
         $this->object->contentEncoding('gzip');
         $this->assertEquals('gzip', $this->object->getHeader('Content-Encoding'));
 
@@ -149,7 +149,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('gzip, compress', $this->object->getHeader('Content-Encoding'));
     }
 
-    public function testContentLanguage() {
+    public function testContentLanguage(): void {
         $this->object->contentLanguage('');
         $this->assertEquals('', $this->object->getHeader('Content-Language'));
 
@@ -160,7 +160,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('en, en-us', $this->object->getHeader('Content-Language'));
     }
 
-    public function testContentLocation() {
+    public function testContentLocation(): void {
         $this->object->contentLocation('');
         $this->assertEquals('', $this->object->getHeader('Content-Location'));
 
@@ -168,7 +168,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('/file.txt', $this->object->getHeader('Content-Location'));
     }
 
-    public function testContentLength() {
+    public function testContentLength(): void {
         $this->object->contentLength(1234);
         $this->assertEquals('1234', $this->object->getHeader('Content-Length'));
 
@@ -176,13 +176,13 @@ class ResponseTest extends TestCase {
         $this->assertEquals('2147483648', $this->object->getHeader('Content-Length'));
     }
 
-    public function testContentLength300Status() {
+    public function testContentLength300Status(): void {
         $this->object->setStatus(302);
         $this->object->contentLength(1234);
         $this->assertEquals('', $this->object->getHeader('Content-Length'));
     }
 
-    public function testContentMD5() {
+    public function testContentMD5(): void {
         $this->object->contentMD5('AHASHHERE');
         $this->assertEquals('AHASHHERE', $this->object->getHeader('Content-MD5'));
 
@@ -192,12 +192,12 @@ class ResponseTest extends TestCase {
         $this->assertEquals('hBotaJrYa9FhFEdFPCLG/A==', $this->object->getHeader('Content-MD5'));
     }
 
-    public function testContentRange() {
+    public function testContentRange(): void {
         $this->object->contentRange(0, 50, 100);
         $this->assertEquals('bytes 0-50/100', $this->object->getHeader('Content-Range'));
     }
 
-    public function testContentType() {
+    public function testContentType(): void {
         $this->object->contentType('html');
         $this->assertEquals('text/html; charset=UTF-8', $this->object->getHeader('Content-Type'));
 
@@ -208,7 +208,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('application/xhtml+xml', $this->object->getHeader('Content-Type'));
     }
 
-    public function testContentType300Status() {
+    public function testContentType300Status(): void {
         $this->object->setStatus(304);
         $this->object->contentType('xhtml');
         $this->assertEquals('text/html; charset=UTF-8', $this->object->getHeader('Content-Type'));
@@ -217,23 +217,23 @@ class ResponseTest extends TestCase {
     /**
      * @expectedException \Titon\Http\Exception\InvalidExtensionException
      */
-    public function testContentTypeInvalidType() {
+    public function testContentTypeInvalidType(): void {
         $this->object->contentType('fake');
     }
 
-    public function testDate() {
+    public function testDate(): void {
         $this->object->date('+12 hours');
         $this->assertEquals(Format::http('+12 hours'), $this->object->getHeader('Date'));
     }
 
-    public function testDownload() {
+    public function testDownload(): void {
         $this->setupVFS();
         $this->vfs->createFile('/download.txt');
 
         $this->assertInstanceOf('Titon\Http\Server\DownloadResponse', Response::download($this->vfs->path('/download.txt')));
     }
 
-    public function testEtag() {
+    public function testEtag(): void {
         $this->object->etag('FooBar');
         $this->assertEquals('"FooBar"', $this->object->getHeader('ETag'));
 
@@ -241,12 +241,12 @@ class ResponseTest extends TestCase {
         $this->assertEquals('W/"FooBar"', $this->object->getHeader('ETag'));
     }
 
-    public function testExpires() {
+    public function testExpires(): void {
         $this->object->expires('+12 hours');
         $this->assertEquals(Format::http('+12 hours'), $this->object->getHeader('Expires'));
     }
 
-    public function testGetHeaders() {
+    public function testGetHeaders(): void {
         $this->assertEquals([
             'Date' => [gmdate(Http::DATE_FORMAT, $this->time)],
             'Connection' => ['keep-alive'],
@@ -265,29 +265,29 @@ class ResponseTest extends TestCase {
         ], $this->object->getHeaders());
     }
 
-    public function testGetProtocolVersion() {
+    public function testGetProtocolVersion(): void {
         $this->assertEquals('1.1', $this->object->getProtocolVersion());
     }
 
-    public function testGetReasonPhrase() {
+    public function testGetReasonPhrase(): void {
         $this->object->setStatus(400);
         $this->assertEquals('Bad Request', $this->object->getReasonPhrase());
     }
 
-    public function testGetStatusCode() {
+    public function testGetStatusCode(): void {
         $this->assertEquals(200, $this->object->getStatusCode());
     }
 
-    public function testJson() {
+    public function testJson(): void {
         $this->assertInstanceOf('Titon\Http\Server\JsonResponse', Response::json(['foo' => 'bar']));
     }
 
-    public function testLastModified() {
+    public function testLastModified(): void {
         $this->object->lastModified('+12 hours');
         $this->assertEquals(Format::http('+12 hours'), $this->object->getHeader('Last-Modified'));
     }
 
-    public function testLocation() {
+    public function testLocation(): void {
         $this->object->location('/local/url');
         $this->assertEquals('/local/url', $this->object->getHeader('Location'));
 
@@ -295,14 +295,14 @@ class ResponseTest extends TestCase {
         $this->assertEquals('http://google.com', $this->object->getHeader('Location'));
     }
 
-    public function testNoCache() {
+    public function testNoCache(): void {
         $this->object->noCache();
         $this->assertEquals(Format::http('-1 year'), $this->object->getHeader('Expires'));
         $this->assertEquals(Format::http(time()), $this->object->getHeader('Last-Modified'));
         $this->assertEquals('no-cache, no-store, must-revalidate, proxy-revalidate', $this->object->getHeader('Cache-Control'));
     }
 
-    public function testNotModified() {
+    public function testNotModified(): void {
         $this->object->contentType('html')->notModified();
         $this->assertEquals([
             'Date' => [gmdate(Http::DATE_FORMAT, $this->time)],
@@ -311,18 +311,18 @@ class ResponseTest extends TestCase {
         ], $this->object->getHeaders());
     }
 
-    public function testRedirect() {
+    public function testRedirect(): void {
         $this->assertInstanceOf('Titon\Http\Server\RedirectResponse', Response::redirect('/'));
     }
 
-    public function testRemoveCookie() {
+    public function testRemoveCookie(): void {
         $time = time();
         $this->object->removeCookie('foo');
 
         $this->assertEquals('foo=deleted; Expires=' . gmdate(Http::DATE_FORMAT, $time) . '; Path=/; HttpOnly', $this->object->getHeader('Set-Cookie'));
     }
 
-    public function testRemoveHeader() {
+    public function testRemoveHeader(): void {
         $this->object->setHeader('Content-Type', 'text/html');
         $this->assertTrue($this->object->hasHeader('Content-Type'));
 
@@ -330,7 +330,7 @@ class ResponseTest extends TestCase {
         $this->assertFalse($this->object->hasHeader('Content-Type'));
     }
 
-    public function testRemoveHeaders() {
+    public function testRemoveHeaders(): void {
         $this->object->setHeader('Content-Type', 'text/html');
         $this->object->setHeader('Content-Length', 100);
 
@@ -349,7 +349,7 @@ class ResponseTest extends TestCase {
         ], $this->object->getHeaders());
     }
 
-    public function testRetryAfter() {
+    public function testRetryAfter(): void {
         $this->object->retryAfter(120);
         $this->assertEquals('120', $this->object->getHeader('Retry-After'));
 
@@ -357,7 +357,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals(Format::http('+1 hour'), $this->object->getHeader('Retry-After'));
     }
 
-    public function testSendBody() {
+    public function testSendBody(): void {
         $this->object->setBody(new MemoryStream('body'));
 
         ob_start();
@@ -367,17 +367,17 @@ class ResponseTest extends TestCase {
         $this->assertEquals('body', $body);
     }
 
-    public function testSendBodyAndHeaders() {
+    public function testSendBodyAndHeaders(): void {
         $this->object->body(new MemoryStream('<html><body>body</body></html>'));
         $this->assertEquals('<html><body>body</body></html>', $this->object->send());
     }
 
-    public function testSetHeader() {
+    public function testSetHeader(): void {
         $this->object->setHeader('X-Framework', 'Titon');
         $this->assertEquals('Titon', $this->object->getHeader('X-Framework'));
     }
 
-    public function testSetHeaders() {
+    public function testSetHeaders(): void {
         $this->object->setHeaders([
             'X-Framework' => 'Titon',
             'X-Version' => '1.2.3'
@@ -387,23 +387,23 @@ class ResponseTest extends TestCase {
         $this->assertEquals('1.2.3', $this->object->getHeader('X-Version'));
     }
 
-    public function testSetCookie() {
+    public function testSetCookie(): void {
         $time = strtotime('+1 week');
         $this->object->setCookie('foo', 'bar', $time);
         $this->assertEquals('foo=5hxAThObwiiTyh0mhfxIKw%3D%3D; Expires=' . gmdate(Http::DATE_FORMAT, $time) . '; Path=/; HttpOnly', $this->object->getHeader('Set-Cookie'));
     }
 
-    public function testSetProtocolVersion() {
+    public function testSetProtocolVersion(): void {
         $this->object->setProtocolVersion('1.0');
         $this->assertEquals('1.0', $this->object->getProtocolVersion());
     }
 
-    public function testSetReasonPhrase() {
+    public function testSetReasonPhrase(): void {
         $this->object->setReasonPhrase('Foo Bar');
         $this->assertEquals('Foo Bar', $this->object->getReasonPhrase());
     }
 
-    public function testStatus() {
+    public function testStatus(): void {
         $this->object->statusCode(404);
         $this->assertEquals('404 Not Found', $this->object->getHeader('Status-Code'));
 
@@ -414,11 +414,11 @@ class ResponseTest extends TestCase {
     /**
      * @expectedException \Titon\Http\Exception\InvalidStatusException
      */
-    public function testStatusCodeInvalidCode() {
+    public function testStatusCodeInvalidCode(): void {
         $this->object->statusCode(666);
     }
 
-    public function testVary() {
+    public function testVary(): void {
         $this->object->vary('Accept');
         $this->assertEquals('Accept', $this->object->getHeader('Vary'));
 
@@ -426,7 +426,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('Accept, Cookie', $this->object->getHeader('Vary'));
     }
 
-    public function testWwwAuthenticate() {
+    public function testWwwAuthenticate(): void {
         $this->object->wwwAuthenticate('Basic');
         $this->assertEquals('Basic', $this->object->getHeader('WWW-Authenticate'));
 
@@ -434,7 +434,7 @@ class ResponseTest extends TestCase {
         $this->assertEquals('Digest', $this->object->getHeader('WWW-Authenticate'));
     }
 
-    public function testXml() {
+    public function testXml(): void {
         $this->assertInstanceOf('Titon\Http\Server\XmlResponse', Response::xml(['foo' => 'bar']));
     }
 

--- a/tests/Titon/Http/Server/XmlResponseTest.hh
+++ b/tests/Titon/Http/Server/XmlResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;
@@ -6,7 +6,7 @@ use Titon\Test\TestCase;
 
 class XmlResponseTest extends TestCase {
 
-    public function testSend() {
+    public function testSend(): void {
         $time = time();
         $response = new XmlResponse(['foo' => 'bar']);
         $response->debug();
@@ -32,7 +32,7 @@ class XmlResponseTest extends TestCase {
         , $body);
     }
 
-    public function testRoot() {
+    public function testRoot(): void {
         $time = time();
         $response = new XmlResponse(['foo' => 'bar'], 200, 'data');
         $response->debug();

--- a/tests/Titon/Http/Server/XmlResponseTest.hh
+++ b/tests/Titon/Http/Server/XmlResponseTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Server;
 
 use Titon\Http\Http;

--- a/tests/Titon/Http/Stream/FileStreamTest.hh
+++ b/tests/Titon/Http/Stream/FileStreamTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Stream;
 
 use Titon\Test\TestCase;
@@ -8,13 +8,13 @@ use Titon\Test\TestCase;
  */
 class FileStreamTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new FileStream(TEMP_DIR . '/type/barbarian.xml');
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         parent::tearDown();
 
         $this->object->close();
@@ -23,19 +23,19 @@ class FileStreamTest extends TestCase {
     /**
      * @expectedException \Titon\Common\Exception\MissingFileException
      */
-    public function testConstructorErrorsOnInvalidPath() {
+    public function testConstructorErrorsOnInvalidPath(): void {
         new FileStream('foo');
     }
 
-    public function testGetMode() {
+    public function testGetMode(): void {
         $this->assertEquals('r+b', $this->object->getMode());
     }
 
-    public function testGetSize() {
+    public function testGetSize(): void {
         $this->assertGreaterThan(1300, $this->object->getSize()); // Depending on the lookup method, this value can change
     }
 
-    public function testIsLocal() {
+    public function testIsLocal(): void {
         $this->assertTrue($this->object->isLocal());
     }
 

--- a/tests/Titon/Http/Stream/FileStreamTest.hh
+++ b/tests/Titon/Http/Stream/FileStreamTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Stream;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Http/Stream/MemoryStreamTest.hh
+++ b/tests/Titon/Http/Stream/MemoryStreamTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Stream;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Http/Stream/MemoryStreamTest.hh
+++ b/tests/Titon/Http/Stream/MemoryStreamTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Stream;
 
 use Titon\Test\TestCase;
@@ -8,23 +8,23 @@ use Titon\Test\TestCase;
  */
 class MemoryStreamTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new MemoryStream('foo');
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         parent::tearDown();
 
         $this->object->close();
     }
 
-    public function testToString() {
+    public function testToString(): void {
         $this->assertEquals('foo', (string) $this->object);
     }
 
-    public function testToStringRestoresSeek() {
+    public function testToStringRestoresSeek(): void {
         $this->object->seek(1);
 
         $this->assertEquals(1, $this->object->tell());
@@ -32,39 +32,39 @@ class MemoryStreamTest extends TestCase {
         $this->assertEquals(1, $this->object->tell());
     }
 
-    public function testClose() {
+    public function testClose(): void {
         $this->assertTrue($this->object->close());
         $this->assertFalse($this->object->close());
     }
 
-    public function testDetach() {
+    public function testDetach(): void {
         $this->assertTrue(is_resource($this->object->getStream()));
         $this->object->detach();
         $this->assertEquals(null, $this->object->getStream());
     }
 
-    public function testEof() {
+    public function testEof(): void {
         $this->assertFalse($this->object->eof());
         $this->object->read(3);
         $this->assertTrue($this->object->eof());
     }
 
-    public function testGetContents() {
+    public function testGetContents(): void {
         $this->assertEquals('foo', $this->object->getContents());
         $this->assertEquals('fo', $this->object->getContents(2));
     }
 
-    public function testGetSize() {
+    public function testGetSize(): void {
         $this->assertEquals(3, $this->object->getSize());
     }
 
-    public function testSizeIsConsistent() {
+    public function testSizeIsConsistent(): void {
         $this->assertEquals(3, $this->object->getSize());
         $this->object->write('bar');
         $this->assertEquals(6, $this->object->getSize());
     }
 
-    public function testRead() {
+    public function testRead(): void {
         $this->object->rewind();
         $this->assertEquals('fo', $this->object->read(2));
 
@@ -74,7 +74,7 @@ class MemoryStreamTest extends TestCase {
         $this->assertEquals('foo', $this->object->read(5));
     }
 
-    public function testSeekAndTell() {
+    public function testSeekAndTell(): void {
         $this->assertEquals(3, $this->object->tell());
 
         $this->object->seek(1);
@@ -84,7 +84,7 @@ class MemoryStreamTest extends TestCase {
         $this->assertEquals(5, $this->object->tell());
     }
 
-    public function testWrite() {
+    public function testWrite(): void {
         $this->assertEquals('foo', $this->object->getContents());
         $this->object->write('bar');
         $this->assertEquals('foobar', $this->object->getContents());

--- a/tests/Titon/Http/Stream/ResourceStreamTest.hh
+++ b/tests/Titon/Http/Stream/ResourceStreamTest.hh
@@ -1,11 +1,11 @@
-<?hh // strict
+<?hh
 namespace Titon\Http\Stream;
 
 use Titon\Test\TestCase;
 
 class ResourceStreamTest extends TestCase {
 
-    protected function makeStream($mode, $content = ''): void {
+    protected function makeStream(string $mode, string $content = ''): ResourceStream {
         $stream = new ResourceStream(fopen('php://memory', $mode));
 
         if ($content) {

--- a/tests/Titon/Http/Stream/ResourceStreamTest.hh
+++ b/tests/Titon/Http/Stream/ResourceStreamTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Http\Stream;
 
 use Titon\Test\TestCase;
 
 class ResourceStreamTest extends TestCase {
 
-    protected function makeStream($mode, $content = '') {
+    protected function makeStream($mode, $content = ''): void {
         $stream = new ResourceStream(fopen('php://memory', $mode));
 
         if ($content) {
@@ -15,36 +15,36 @@ class ResourceStreamTest extends TestCase {
         return $stream;
     }
 
-    public function testBuildCacheReadable() {
+    public function testBuildCacheReadable(): void {
         $this->assertTrue($this->makeStream('r')->isReadable());
         $this->assertFalse($this->makeStream('w')->isReadable());
         $this->assertFalse($this->makeStream('a')->isReadable());
         $this->assertFalse($this->makeStream('xb')->isReadable());
     }
 
-    public function testBuildCacheWritable() {
+    public function testBuildCacheWritable(): void {
         $this->assertTrue($this->makeStream('w')->isWritable());
         $this->assertTrue($this->makeStream('w+')->isWritable());
         $this->assertTrue($this->makeStream('w+b')->isWritable());
         $this->assertFalse($this->makeStream('r')->isWritable());
     }
 
-    public function testCloseOnDestruct() {
+    public function testCloseOnDestruct(): void {
         $handle = fopen('php://memory', 'r');
         $stream = new ResourceStream($handle);
         unset($stream);
         $this->assertFalse(is_resource($handle));
     }
 
-    public function testGetContentsNotReadableReturnsEmpty() {
+    public function testGetContentsNotReadableReturnsEmpty(): void {
         $this->assertEquals('', $this->makeStream('w', 'foo')->getContents());
     }
 
-    public function testReadReturnsNullNonReadable() {
+    public function testReadReturnsNullNonReadable(): void {
         $this->assertEquals(null, $this->makeStream('w', 'foo')->read(3));
     }
 
-    public function testWriteReturnsNullNonWritable() {
+    public function testWriteReturnsNullNonWritable(): void {
         $this->assertEquals(null, $this->makeStream('r')->write('foo'));
     }
 

--- a/tests/Titon/Io/BundleTest.hh
+++ b/tests/Titon/Io/BundleTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io;
 
 use Titon\Io\Bundle\ResourceBundle;
@@ -16,8 +16,7 @@ class BundleTest extends TestCase {
 
         $this->object = new ResourceBundle();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/bundle/');
+        $this->vfs()->createDirectory('/bundle/');
     }
 
     public function testAddPath(): void {
@@ -92,17 +91,17 @@ class BundleTest extends TestCase {
     }
 
     public function testLoadResource(): void {
-        $this->vfs->createDirectory('/bundle/foo');
-        $this->vfs->createFile('/bundle/foo/test.php', '<?php return ["foo" => "bar"];');
+        $this->vfs()->createDirectory('/bundle/foo');
+        $this->vfs()->createFile('/bundle/foo/test.php', '<?php return ["foo" => "bar"];');
 
-        $this->object->addPath('foo', $this->vfs->path('/bundle/foo/'));
+        $this->object->addPath('foo', $this->vfs()->path('/bundle/foo/'));
         $this->object->addReader(new PhpReader());
 
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->loadResource('foo', 'test'));
     }
 
     public function testLoadResourceFromMultiplePaths(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             '/bundle/foo1' => [
                 'test.php' => '<?php return ["foo" => "bar"];'
             ],
@@ -111,7 +110,7 @@ class BundleTest extends TestCase {
             ]
         ]);
 
-        $this->object->addPaths('foo', Vector {$this->vfs->path('/bundle/foo1/'), $this->vfs->path('/bundle/foo2/')});
+        $this->object->addPaths('foo', Vector {$this->vfs()->path('/bundle/foo1/'), $this->vfs()->path('/bundle/foo2/')});
         $this->object->addReader(new PhpReader());
 
         $this->assertEquals(Map {
@@ -121,7 +120,7 @@ class BundleTest extends TestCase {
     }
 
     public function testLoadResourceUsingMultipleReaders(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             '/bundle/foo1' => [
                 'test.php' => '<?php return ["foo" => "bar"];'
             ],
@@ -130,7 +129,7 @@ class BundleTest extends TestCase {
             ]
         ]);
 
-        $this->object->addPaths('foo', Vector {$this->vfs->path('/bundle/foo1/'), $this->vfs->path('/bundle/foo2/')});
+        $this->object->addPaths('foo', Vector {$this->vfs()->path('/bundle/foo1/'), $this->vfs()->path('/bundle/foo2/')});
         $this->object->addReader(new PhpReader());
         $this->object->addReader(new JsonReader());
 

--- a/tests/Titon/Io/BundleTest.hh
+++ b/tests/Titon/Io/BundleTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io;
 
 use Titon\Io\Bundle\ResourceBundle;
@@ -11,7 +11,7 @@ use Titon\Test\TestCase;
  */
 class BundleTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new ResourceBundle();
@@ -20,7 +20,7 @@ class BundleTest extends TestCase {
         $this->vfs->createDirectory('/bundle/');
     }
 
-    public function testAddPath() {
+    public function testAddPath(): void {
         $this->assertEquals(Map {}, $this->object->getPaths());
 
         $this->object->addPath('foo', '/some/path');
@@ -30,7 +30,7 @@ class BundleTest extends TestCase {
         }, $this->object->getPaths());
     }
 
-    public function testAddPaths() {
+    public function testAddPaths(): void {
         $this->assertEquals(Map {}, $this->object->getPaths());
 
         $this->object->addPaths('foo', Vector {'/some/path', '/another/path'});
@@ -42,7 +42,7 @@ class BundleTest extends TestCase {
         }, $this->object->getPaths());
     }
 
-    public function testAddReader() {
+    public function testAddReader(): void {
         $this->assertEquals(Map {}, $this->object->getReaders());
 
         $reader = new PhpReader();
@@ -51,7 +51,7 @@ class BundleTest extends TestCase {
         $this->assertEquals(Map {'php' => $reader}, $this->object->getReaders());
     }
 
-    public function testGetContents() {
+    public function testGetContents(): void {
         $this->object->addPath('test', TEMP_DIR . '/io');
 
         $paths = $this->object->getContents('test');
@@ -67,7 +67,7 @@ class BundleTest extends TestCase {
         }, $paths);
     }
 
-    public function testGetDomains() {
+    public function testGetDomains(): void {
         $this->assertEquals(Vector {}, $this->object->getDomains());
 
         $this->object->addPath('foo', '/some/path');
@@ -76,7 +76,7 @@ class BundleTest extends TestCase {
         $this->assertEquals(Vector {'foo', 'bar'}, $this->object->getDomains());
     }
 
-    public function testGetDomainPaths() {
+    public function testGetDomainPaths(): void {
         $this->object->addPaths('foo', Vector {'/some/path', '/another/path'});
         $this->object->addPaths('bar', Vector {'/one/more/path'});
 
@@ -87,11 +87,11 @@ class BundleTest extends TestCase {
     /**
      * @expectedException \Titon\Io\Exception\MissingDomainException
      */
-    public function testGetDomainPathsErrorsOnMissing() {
+    public function testGetDomainPathsErrorsOnMissing(): void {
         $this->object->getDomainPaths('baz');
     }
 
-    public function testLoadResource() {
+    public function testLoadResource(): void {
         $this->vfs->createDirectory('/bundle/foo');
         $this->vfs->createFile('/bundle/foo/test.php', '<?php return ["foo" => "bar"];');
 
@@ -101,7 +101,7 @@ class BundleTest extends TestCase {
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->loadResource('foo', 'test'));
     }
 
-    public function testLoadResourceFromMultiplePaths() {
+    public function testLoadResourceFromMultiplePaths(): void {
         $this->vfs->createStructure([
             '/bundle/foo1' => [
                 'test.php' => '<?php return ["foo" => "bar"];'
@@ -120,7 +120,7 @@ class BundleTest extends TestCase {
         }, $this->object->loadResource('foo', 'test'));
     }
 
-    public function testLoadResourceUsingMultipleReaders() {
+    public function testLoadResourceUsingMultipleReaders(): void {
         $this->vfs->createStructure([
             '/bundle/foo1' => [
                 'test.php' => '<?php return ["foo" => "bar"];'

--- a/tests/Titon/Io/FileTest.hh
+++ b/tests/Titon/Io/FileTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io;
 
 use Titon\Test\TestCase;
@@ -13,9 +13,8 @@ class FileTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->object = new File($this->vfs->path('file/base.html'), true, 0777);
-        $this->temp = new File($this->vfs->path('file/temp.html'), false);
+        $this->object = new File($this->vfs()->path('file/base.html'), true, 0777);
+        $this->temp = new File($this->vfs()->path('file/temp.html'), false);
     }
 
     /**
@@ -54,7 +53,7 @@ class FileTest extends TestCase {
         $this->assertEquals('html', $this->object->ext());
         $this->assertEquals('html', $this->object->ext());
 
-        $file = new File($this->vfs->path('file/test'), true);
+        $file = new File($this->vfs()->path('file/test'), true);
 
         $this->assertEquals('', $file->ext());
     }

--- a/tests/Titon/Io/FileTest.hh
+++ b/tests/Titon/Io/FileTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io;
 
 use Titon\Test\TestCase;
@@ -10,7 +10,7 @@ use VirtualFileSystem\FileSystem;
  */
 class FileTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -21,11 +21,11 @@ class FileTest extends TestCase {
     /**
      * @expectedException \Titon\Io\Exception\InvalidPathException
      */
-    public function testConstructThrowsNotFileException() {
+    public function testConstructThrowsNotFileException(): void {
         new File(TEMP_DIR);
     }
 
-    public function testAppendPrepend() {
+    public function testAppendPrepend(): void {
         $this->object->write('Content');
         $this->assertEquals('Content', $this->object->read());
 
@@ -36,12 +36,12 @@ class FileTest extends TestCase {
         $this->assertEquals('PrependContentAppend', $this->object->read());
     }
 
-    public function testBasename() {
+    public function testBasename(): void {
         $this->assertEquals('base.html', $this->object->basename());
         $this->assertEquals('temp.html', $this->temp->basename());
     }
 
-    public function testCreate() {
+    public function testCreate(): void {
         $this->assertTrue($this->object->exists());
         $this->assertFalse($this->object->create());
 
@@ -50,7 +50,7 @@ class FileTest extends TestCase {
         $this->assertTrue($this->temp->exists());
     }
 
-    public function testExt() {
+    public function testExt(): void {
         $this->assertEquals('html', $this->object->ext());
         $this->assertEquals('html', $this->object->ext());
 
@@ -59,7 +59,7 @@ class FileTest extends TestCase {
         $this->assertEquals('', $file->ext());
     }
 
-    public function testLockAndUnlock() {
+    public function testLockAndUnlock(): void {
         $this->object->open('r');
 
         $this->assertTrue($this->object->lock());
@@ -71,7 +71,7 @@ class FileTest extends TestCase {
         $this->object->close();
     }
 
-    public function testMd5() {
+    public function testMd5(): void {
         $this->assertEquals('d41d8cd98f00b204e9800998ecf8427e', $this->object->md5());
         $this->assertEquals(null, $this->temp->md5());
 
@@ -79,18 +79,18 @@ class FileTest extends TestCase {
         $this->assertEquals('92dbea223f446b8d480a8fd4984232e4', $this->object->md5());
     }
 
-    public function testMimeType() {
+    public function testMimeType(): void {
         $this->assertEquals('text/plain', (new File(TEMP_DIR . '/io/ini.ini'))->mimeType());
         $this->assertEquals('text/x-php', (new File(TEMP_DIR . '/io/php.php'))->mimeType());
         $this->assertEquals('application/xml', (new File(TEMP_DIR . '/io/xml.xml'))->mimeType());
     }
 
-    public function testName() {
+    public function testName(): void {
         $this->assertEquals('base', $this->object->name());
         $this->assertEquals('temp', $this->temp->name());
     }
 
-    public function testOpenClose() {
+    public function testOpenClose(): void {
         $this->assertFalse($this->object->close());
         $this->assertFalse($this->temp->close());
 
@@ -101,7 +101,7 @@ class FileTest extends TestCase {
         $this->assertFalse($this->temp->close());
     }
 
-    public function testPermissionReading() {
+    public function testPermissionReading(): void {
         $this->object->chmod(0777);
         $this->temp->chmod(0777);
 
@@ -125,7 +125,7 @@ class FileTest extends TestCase {
         $this->assertFalse($this->temp->writable());
     }
 
-    public function testReadWrite() {
+    public function testReadWrite(): void {
         $content = 'Lets add a bit of fat to you before reading.';
         $this->object->write($content);
 
@@ -136,7 +136,7 @@ class FileTest extends TestCase {
         $this->assertEquals('', $this->object->read());
     }
 
-    public function testSize() {
+    public function testSize(): void {
         $this->assertTrue($this->object->write('foobar'));
         $this->assertEquals(6, $this->object->size());
         $this->assertEquals(0, $this->temp->size());

--- a/tests/Titon/Io/FolderTest.hh
+++ b/tests/Titon/Io/FolderTest.hh
@@ -331,7 +331,7 @@ class FolderTest extends TestCase {
         $contents = $folder->files();
 
         $scheme = $this->vfs->scheme();
-        $paths = $contents->map(function(Node $value) use ($scheme)  {
+        $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
 
@@ -407,7 +407,7 @@ class FolderTest extends TestCase {
         $contents = $folder->folders();
 
         $scheme = $this->vfs->scheme();
-        $paths = $contents->map(function(Node $value) use ($scheme)  {
+        $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
 
@@ -629,7 +629,7 @@ class FolderTest extends TestCase {
         $contents = $folder->read();
 
         $scheme = $this->vfs->scheme();
-        $paths = $contents->map(function(Node $value) use ($scheme)  {
+        $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
 
@@ -668,7 +668,7 @@ class FolderTest extends TestCase {
         $contents = $folder->read(false, true);
 
         $scheme = $this->vfs->scheme();
-        $paths = $contents->map(function(Node $value) use ($scheme)  {
+        $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
 
@@ -710,7 +710,7 @@ class FolderTest extends TestCase {
         $contents = $folder->read(true);
 
         $scheme = $this->vfs->scheme();
-        $paths = $contents->map(function(Node $value) use ($scheme)  {
+        $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
 
@@ -749,7 +749,7 @@ class FolderTest extends TestCase {
         $contents = $folder->read(true, true);
 
         $scheme = $this->vfs->scheme();
-        $paths = $contents->map(function(Node $value) use ($scheme)  {
+        $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
 

--- a/tests/Titon/Io/FolderTest.hh
+++ b/tests/Titon/Io/FolderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io;
 
 use Titon\Test\TestCase;
@@ -18,7 +18,7 @@ class FolderTest extends TestCase {
     /** @type int */
     protected $groupid;
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->vfs = new FileSystem();
@@ -33,32 +33,32 @@ class FolderTest extends TestCase {
     /**
      * @expectedException \Titon\Io\Exception\InvalidPathException
      */
-    public function testConstructThrowsNotFolderException() {
+    public function testConstructThrowsNotFolderException(): void {
         new Folder(TEST_DIR . '/bootstrap.php');
     }
 
-    public function testAccessTime() {
+    public function testAccessTime(): void {
         $this->assertTrue(is_int($this->object->accessTime()));
         $this->assertEquals(0, $this->temp->accessTime());
     }
 
-    public function testBasename() {
+    public function testBasename(): void {
         $this->assertEquals('base', $this->object->basename());
         $this->assertEquals('temp', $this->temp->basename());
     }
 
-    public function testCd() {
+    public function testCd(): void {
         $this->assertEquals($this->vfs->path('base/'), $this->object->path());
         $this->object->cd($this->vfs->path('base-cd/'));
         $this->assertEquals($this->vfs->path('base-cd/'), $this->object->path());
     }
 
-    public function testChangeTime() {
+    public function testChangeTime(): void {
         $this->assertTrue(is_int($this->object->changeTime()));
         $this->assertEquals(0, $this->temp->changeTime());
     }
 
-    public function testChgrp() {
+    public function testChgrp(): void {
         $file = new Folder($this->vfs->path('base/chgrp'), true);
 
         $this->assertEquals($this->groupid, $file->group());
@@ -66,7 +66,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file->group());
     }
 
-    public function testChgrpLink() {
+    public function testChgrpLink(): void {
         $this->vfs->createDirectory('base/link');
         $this->vfs->createLink('base/chgrp-link', 'base/link');
 
@@ -78,11 +78,11 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file->group());
     }
 
-    public function testChgrpMissingFile() {
+    public function testChgrpMissingFile(): void {
         $this->assertFalse($this->temp->chgrp(666));
     }
 
-    public function testChgrpRecursive() {
+    public function testChgrpRecursive(): void {
         $folder = new Folder($this->vfs->path('base/chgrp'), true);
         $file1 = new File($this->vfs->path('base/chgrp/1'), true);
         $file2 = new Folder($this->vfs->path('base/chgrp/2'), true);
@@ -98,7 +98,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file2->group());
     }
 
-    public function testChmod() {
+    public function testChmod(): void {
         $file = new Folder($this->vfs->path('base/chmod'), true);
 
         $this->assertEquals(755, $file->permissions());
@@ -106,11 +106,11 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file->permissions());
     }
 
-    public function testChmodMissingFile() {
+    public function testChmodMissingFile(): void {
         $this->assertFalse($this->temp->chmod(0666));
     }
 
-    public function testChmodRecursive() {
+    public function testChmodRecursive(): void {
         $folder = new Folder($this->vfs->path('base/chmod'), true);
         $file1 = new File($this->vfs->path('base/chmod/1'), true);
         $file2 = new Folder($this->vfs->path('base/chmod/2'), true);
@@ -126,7 +126,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file2->permissions());
     }
 
-    public function testChown() {
+    public function testChown(): void {
         $file = new Folder($this->vfs->path('base/chown'), true);
 
         $this->assertEquals($this->userid, $file->owner());
@@ -134,7 +134,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file->owner());
     }
 
-    public function testChownLink() {
+    public function testChownLink(): void {
         $this->vfs->createDirectory('base/link');
         $this->vfs->createLink('base/chown-link', 'base/link');
 
@@ -146,11 +146,11 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file->owner());
     }
 
-    public function testChownMissingFile() {
+    public function testChownMissingFile(): void {
         $this->assertFalse($this->temp->chown(666));
     }
 
-    public function testChownRecursive() {
+    public function testChownRecursive(): void {
         $folder = new Folder($this->vfs->path('base/chown'), true);
         $file1 = new File($this->vfs->path('base/chown/1'), true);
         $file2 = new Folder($this->vfs->path('base/chown/2'), true);
@@ -166,7 +166,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(666, $file2->owner());
     }
 
-    public function testCreate() {
+    public function testCreate(): void {
         $this->assertTrue($this->object->exists());
         $this->assertFalse($this->object->create());
 
@@ -175,7 +175,7 @@ class FolderTest extends TestCase {
         $this->assertTrue($this->temp->exists());
     }
 
-    public function testCopy() {
+    public function testCopy(): void {
         $this->vfs->createStructure([
             'base/copy' => [
                 '1' => 'foo',
@@ -194,11 +194,11 @@ class FolderTest extends TestCase {
         $this->assertEquals('foo', file_get_contents($this->vfs->path('base/copy-to/2')));
     }
 
-    public function testCopyMissingFile() {
+    public function testCopyMissingFile(): void {
         $this->assertEquals(null, $this->temp->copy($this->vfs->path('base/copy-to')));
     }
 
-    public function testCopyOverwrite() {
+    public function testCopyOverwrite(): void {
         $this->vfs->createStructure([
             'base/copy' => [
                 '1' => 'foo',
@@ -223,7 +223,7 @@ class FolderTest extends TestCase {
         $this->assertEquals('foo', file_get_contents($this->vfs->path('base/copy-to/2')));
     }
 
-    public function testCopySkip() {
+    public function testCopySkip(): void {
         $this->vfs->createStructure([
             'base/copy' => [
                 '1' => 'foo',
@@ -252,7 +252,7 @@ class FolderTest extends TestCase {
         $this->assertEquals('bar', file_get_contents($this->vfs->path('base/copy-to/2')));
     }
 
-    public function testCopyMerge() {
+    public function testCopyMerge(): void {
         $this->vfs->createStructure([
             'base/copy' => [
                 '1' => 'foo',
@@ -290,19 +290,19 @@ class FolderTest extends TestCase {
         $this->assertEquals('foo', file_get_contents($this->vfs->path('base/copy-to/3/3-1')));
     }
 
-    public function testDelete() {
+    public function testDelete(): void {
         $this->assertTrue($this->object->delete());
         $this->assertFalse($this->temp->delete());
     }
 
-    public function testDir() {
+    public function testDir(): void {
         $folder = new Folder($this->vfs->path('base/child/dir'), true);
 
         $this->assertEquals($this->vfs->path('base/child/'), $folder->dir());
         $this->assertEquals($this->vfs->path('base/'), $folder->parent()->dir());
     }
 
-    public function testExists() {
+    public function testExists(): void {
         $this->assertTrue($this->object->exists());
         $this->assertFalse($this->temp->exists());
 
@@ -310,7 +310,7 @@ class FolderTest extends TestCase {
         $this->assertTrue($this->temp->exists());
     }
 
-    public function testFiles() {
+    public function testFiles(): void {
         $this->vfs->createStructure([
             'base/read' => [
                 '4' => 'd',
@@ -348,7 +348,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(Vector {}, $this->temp->read());
     }
 
-    public function testFind() {
+    public function testFind(): void {
         $this->markTestSkipped('Glob iteration does not work with PHP streams');
 
         $this->vfs->createStructure([
@@ -379,11 +379,11 @@ class FolderTest extends TestCase {
         $this->assertTrue(count($files) == 1);
     }
 
-    public function testFindMissingFile() {
+    public function testFindMissingFile(): void {
         $this->assertEquals(Vector {}, $this->temp->find('*'));
     }
 
-    public function testFolders() {
+    public function testFolders(): void {
         $this->vfs->createStructure([
             'base/read' => [
                 '4' => 'd',
@@ -420,12 +420,12 @@ class FolderTest extends TestCase {
         $this->assertEquals(Vector {}, $this->temp->read());
     }
 
-    public function testGroup() {
+    public function testGroup(): void {
         $this->assertEquals($this->groupid, $this->object->group());
         $this->assertEquals(null, $this->temp->group());
     }
 
-    public function testIsAbsolute() {
+    public function testIsAbsolute(): void {
         $linux = new Folder('/dir');
         $windows = new Folder('C:\dir');
         $relative = new Folder('../dir');
@@ -436,7 +436,7 @@ class FolderTest extends TestCase {
         $this->assertFalse($relative->isAbsolute());
     }
 
-    public function testIsRelative() {
+    public function testIsRelative(): void {
         $linux = new Folder('../dir');
         $windows = new Folder('..\dir');
         $absolute = new Folder('/dir');
@@ -447,12 +447,12 @@ class FolderTest extends TestCase {
         $this->assertFalse($absolute->isRelative());
     }
 
-    public function testModifyTime() {
+    public function testModifyTime(): void {
         $this->assertTrue(is_int($this->object->modifyTime()));
         $this->assertEquals(0, $this->temp->modifyTime());
     }
 
-    public function testMove() {
+    public function testMove(): void {
         $this->vfs->createStructure([
             'base/move' => [
                 '1' => 'foo',
@@ -472,11 +472,11 @@ class FolderTest extends TestCase {
         $this->assertFileExists($this->vfs->path('base/move-to'));
     }
 
-    public function testMoveMissingFile() {
+    public function testMoveMissingFile(): void {
         $this->assertFalse($this->temp->move($this->vfs->path('base/move-to')));
     }
 
-    public function testMoveExitsEarlySameLocation() {
+    public function testMoveExitsEarlySameLocation(): void {
         $folder = new Folder($this->vfs->path('base/move'), true);
 
         $this->assertTrue($folder->move($this->vfs->path('base/move')));
@@ -485,7 +485,7 @@ class FolderTest extends TestCase {
     /**
      * @expectedException \Titon\Io\Exception\ExistingFileException
      */
-    public function testMoveTargetExists() {
+    public function testMoveTargetExists(): void {
         $this->vfs->createStructure([
             'base/move' => [
                 '1' => 'foo',
@@ -500,7 +500,7 @@ class FolderTest extends TestCase {
         $folder->move($this->vfs->path('base/move-to'), false);
     }
 
-    public function testMoveOverwriteTargetFile() {
+    public function testMoveOverwriteTargetFile(): void {
         $this->vfs->createStructure([
             'base/move' => [
                 '1' => 'foo'
@@ -521,7 +521,7 @@ class FolderTest extends TestCase {
         $this->assertFalse(is_file($this->vfs->path('base/move-to')));
     }
 
-    public function testMoveOverwriteTargetFolder() {
+    public function testMoveOverwriteTargetFolder(): void {
         $this->vfs->createStructure([
             'base/move' => [
                 '1' => 'foo'
@@ -546,27 +546,27 @@ class FolderTest extends TestCase {
         $this->assertTrue(is_dir($this->vfs->path('base/move-to')));
     }
 
-    public function testName() {
+    public function testName(): void {
         $this->assertEquals('base', $this->object->name());
         $this->assertEquals('temp', $this->temp->name());
     }
 
-    public function testOwner() {
+    public function testOwner(): void {
         $this->assertEquals($this->userid, $this->object->owner());
         $this->assertEquals(null, $this->temp->owner());
     }
 
-    public function testPath() {
+    public function testPath(): void {
         $this->assertEquals($this->vfs->path('/base/'), $this->object->path());
         $this->assertEquals($this->vfs->path('/temp/'), $this->temp->path());
     }
 
-    public function testParent() {
+    public function testParent(): void {
         $this->assertInstanceOf('Titon\Io\Folder', $this->object->parent());
         $this->assertEquals($this->vfs->scheme() . ':/', $this->object->parent()->path());
     }
 
-    public function testPermissions() {
+    public function testPermissions(): void {
         $this->assertEquals('0755', $this->object->permissions());
         $this->assertEquals(null, $this->temp->permissions());
 
@@ -577,7 +577,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(null, $this->temp->permissions());
     }
 
-    public function testPermissionReading() {
+    public function testPermissionReading(): void {
         $this->markTestSkipped('This currently fails on HHVM 3.4.0, but works on nightlies');
 
         $this->object->chmod(0777);
@@ -603,12 +603,12 @@ class FolderTest extends TestCase {
         $this->assertFalse($this->temp->writable());
     }
 
-    public function testPwd() {
+    public function testPwd(): void {
         $this->assertEquals($this->vfs->path('base/'), $this->object->path());
         $this->assertEquals($this->vfs->path('temp/'), $this->temp->path());
     }
 
-    public function testRead() {
+    public function testRead(): void {
         $this->vfs->createStructure([
             'base/read' => [
                 '4' => 'd',
@@ -647,7 +647,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(Vector {}, $this->temp->read());
     }
 
-    public function testReadRecursive() {
+    public function testReadRecursive(): void {
         $this->vfs->createStructure([
             'base/read' => [
                 '4' => 'd',
@@ -689,7 +689,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(Vector {}, $this->temp->read());
     }
 
-    public function testReadSorting() {
+    public function testReadSorting(): void {
         $this->vfs->createStructure([
             'base/read' => [
                 '4' => 'd',
@@ -728,7 +728,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(Vector {}, $this->temp->read());
     }
 
-    public function testReadSortingRecursive() {
+    public function testReadSortingRecursive(): void {
         $this->vfs->createStructure([
             'base/read' => [
                 '4' => 'd',
@@ -770,7 +770,7 @@ class FolderTest extends TestCase {
         $this->assertEquals(Vector {}, $this->temp->read());
     }
 
-    public function testRename() {
+    public function testRename(): void {
         $file = new Folder($this->vfs->path('base/rename'), true);
 
         $this->assertEquals($this->vfs->path('base/rename/'), $file->path());
@@ -784,11 +784,11 @@ class FolderTest extends TestCase {
         $this->assertFileExists($this->vfs->path('base/rename-to'));
     }
 
-    public function testRenameMissingFile() {
+    public function testRenameMissingFile(): void {
         $this->assertFalse($this->temp->rename('temp-rename-to'));
     }
 
-    public function testRenameExitsEarlySameLocation() {
+    public function testRenameExitsEarlySameLocation(): void {
         $file = new Folder($this->vfs->path('base/rename'), true);
 
         $this->assertTrue($file->rename('rename'));
@@ -797,7 +797,7 @@ class FolderTest extends TestCase {
     /**
      * @expectedException \Titon\Io\Exception\ExistingFileException
      */
-    public function testRenameTargetExists() {
+    public function testRenameTargetExists(): void {
         $this->vfs->createStructure([
             'base/rename' => [
                 '1' => 'foo',
@@ -812,7 +812,7 @@ class FolderTest extends TestCase {
         $folder->rename('rename-to', false);
     }
 
-    public function testRenameOverwriteTargetFile() {
+    public function testRenameOverwriteTargetFile(): void {
         $this->vfs->createStructure([
             'base/rename' => [
                 '1' => 'foo'
@@ -833,7 +833,7 @@ class FolderTest extends TestCase {
         $this->assertFalse(is_file($this->vfs->path('base/rename-to')));
     }
 
-    public function testRenameOverwriteTargetFolder() {
+    public function testRenameOverwriteTargetFolder(): void {
         $this->vfs->createStructure([
             'base/rename' => [
                 '1' => 'foo'
@@ -858,14 +858,14 @@ class FolderTest extends TestCase {
         $this->assertTrue(is_dir($this->vfs->path('base/rename-to')));
     }
 
-    public function testRenameFormatName() {
+    public function testRenameFormatName(): void {
         $file = new Folder($this->vfs->path('base/rename'), true);
 
         $this->assertTrue($file->rename('SA# DM)8NS #$ 97py1n  6 d6as9 #%@ P'));
         $this->assertEquals('SA--DM-8NS----97py1n--6-d6as9-----P', $file->name());
     }
 
-    public function testReset() {
+    public function testReset(): void {
         $this->object->reset($this->vfs->path('reset-to'));
         $this->assertEquals($this->vfs->path('reset-to/'), $this->object->path());
     }
@@ -873,13 +873,13 @@ class FolderTest extends TestCase {
     /**
      * @expectedException \Titon\Io\Exception\InvalidPathException
      */
-    public function testResetFailsOnFile() {
+    public function testResetFailsOnFile(): void {
         $this->vfs->createFile('base/reset-to', 'foo');
 
         $this->object->reset($this->vfs->path('base/reset-to'));
     }
 
-    public function testSize() {
+    public function testSize(): void {
         $this->vfs->createStructure([
             'base/size' => [
                 '1' => 'a',

--- a/tests/Titon/Io/FolderTest.hh
+++ b/tests/Titon/Io/FolderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io;
 
 use Titon\Test\TestCase;
@@ -22,8 +22,8 @@ class FolderTest extends TestCase {
         parent::setUp();
 
         $this->vfs = new FileSystem();
-        $this->object = new Folder($this->vfs->path('base/'), true);
-        $this->temp = new Folder($this->vfs->path('temp/'), false);
+        $this->object = new Folder($this->vfs()->path('base/'), true);
+        $this->temp = new Folder($this->vfs()->path('temp/'), false);
 
         // Match VFS
         $this->userid = function_exists('posix_getuid') ? posix_getuid() : 0;
@@ -48,9 +48,9 @@ class FolderTest extends TestCase {
     }
 
     public function testCd(): void {
-        $this->assertEquals($this->vfs->path('base/'), $this->object->path());
-        $this->object->cd($this->vfs->path('base-cd/'));
-        $this->assertEquals($this->vfs->path('base-cd/'), $this->object->path());
+        $this->assertEquals($this->vfs()->path('base/'), $this->object->path());
+        $this->object->cd($this->vfs()->path('base-cd/'));
+        $this->assertEquals($this->vfs()->path('base-cd/'), $this->object->path());
     }
 
     public function testChangeTime(): void {
@@ -59,7 +59,7 @@ class FolderTest extends TestCase {
     }
 
     public function testChgrp(): void {
-        $file = new Folder($this->vfs->path('base/chgrp'), true);
+        $file = new Folder($this->vfs()->path('base/chgrp'), true);
 
         $this->assertEquals($this->groupid, $file->group());
         $this->assertTrue($file->chgrp(666));
@@ -67,10 +67,10 @@ class FolderTest extends TestCase {
     }
 
     public function testChgrpLink(): void {
-        $this->vfs->createDirectory('base/link');
-        $this->vfs->createLink('base/chgrp-link', 'base/link');
+        $this->vfs()->createDirectory('base/link');
+        $this->vfs()->createLink('base/chgrp-link', 'base/link');
 
-        $file = new Folder($this->vfs->path('base/chgrp-link'));
+        $file = new Folder($this->vfs()->path('base/chgrp-link'));
 
         $this->assertTrue(is_link($file->path()));
         $this->assertEquals($this->groupid, $file->group());
@@ -83,9 +83,9 @@ class FolderTest extends TestCase {
     }
 
     public function testChgrpRecursive(): void {
-        $folder = new Folder($this->vfs->path('base/chgrp'), true);
-        $file1 = new File($this->vfs->path('base/chgrp/1'), true);
-        $file2 = new Folder($this->vfs->path('base/chgrp/2'), true);
+        $folder = new Folder($this->vfs()->path('base/chgrp'), true);
+        $file1 = new File($this->vfs()->path('base/chgrp/1'), true);
+        $file2 = new Folder($this->vfs()->path('base/chgrp/2'), true);
 
         $this->assertEquals($this->groupid, $folder->group());
         $this->assertEquals($this->groupid, $file1->group());
@@ -99,7 +99,7 @@ class FolderTest extends TestCase {
     }
 
     public function testChmod(): void {
-        $file = new Folder($this->vfs->path('base/chmod'), true);
+        $file = new Folder($this->vfs()->path('base/chmod'), true);
 
         $this->assertEquals(755, $file->permissions());
         $this->assertTrue($file->chmod(0666));
@@ -111,9 +111,9 @@ class FolderTest extends TestCase {
     }
 
     public function testChmodRecursive(): void {
-        $folder = new Folder($this->vfs->path('base/chmod'), true);
-        $file1 = new File($this->vfs->path('base/chmod/1'), true);
-        $file2 = new Folder($this->vfs->path('base/chmod/2'), true);
+        $folder = new Folder($this->vfs()->path('base/chmod'), true);
+        $file1 = new File($this->vfs()->path('base/chmod/1'), true);
+        $file2 = new Folder($this->vfs()->path('base/chmod/2'), true);
 
         $this->assertEquals(755, $folder->permissions());
         $this->assertEquals(755, $file1->permissions());
@@ -127,7 +127,7 @@ class FolderTest extends TestCase {
     }
 
     public function testChown(): void {
-        $file = new Folder($this->vfs->path('base/chown'), true);
+        $file = new Folder($this->vfs()->path('base/chown'), true);
 
         $this->assertEquals($this->userid, $file->owner());
         $this->assertTrue($file->chown(666));
@@ -135,10 +135,10 @@ class FolderTest extends TestCase {
     }
 
     public function testChownLink(): void {
-        $this->vfs->createDirectory('base/link');
-        $this->vfs->createLink('base/chown-link', 'base/link');
+        $this->vfs()->createDirectory('base/link');
+        $this->vfs()->createLink('base/chown-link', 'base/link');
 
-        $file = new Folder($this->vfs->path('base/chown-link'));
+        $file = new Folder($this->vfs()->path('base/chown-link'));
 
         $this->assertTrue(is_link($file->path()));
         $this->assertEquals($this->userid, $file->owner());
@@ -151,9 +151,9 @@ class FolderTest extends TestCase {
     }
 
     public function testChownRecursive(): void {
-        $folder = new Folder($this->vfs->path('base/chown'), true);
-        $file1 = new File($this->vfs->path('base/chown/1'), true);
-        $file2 = new Folder($this->vfs->path('base/chown/2'), true);
+        $folder = new Folder($this->vfs()->path('base/chown'), true);
+        $file1 = new File($this->vfs()->path('base/chown/1'), true);
+        $file2 = new Folder($this->vfs()->path('base/chown/2'), true);
 
         $this->assertEquals($this->userid, $folder->owner());
         $this->assertEquals($this->userid, $file1->owner());
@@ -176,30 +176,30 @@ class FolderTest extends TestCase {
     }
 
     public function testCopy(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/copy' => [
                 '1' => 'foo',
                 '2' => 'foo'
             ]
         ]);
 
-        $this->assertFileNotExists($this->vfs->path('base/copy-to'));
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/1'));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to'));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/1'));
 
-        $baseFolder = new Folder($this->vfs->path('base/copy'));
-        $baseFolder->copy($this->vfs->path('base/copy-to'));
+        $baseFolder = new Folder($this->vfs()->path('base/copy'));
+        $baseFolder->copy($this->vfs()->path('base/copy-to'));
 
-        $this->assertFileExists($this->vfs->path('base/copy-to'));
-        $this->assertFileExists($this->vfs->path('base/copy-to/1'));
-        $this->assertEquals('foo', file_get_contents($this->vfs->path('base/copy-to/2')));
+        $this->assertFileExists($this->vfs()->path('base/copy-to'));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/1'));
+        $this->assertEquals('foo', file_get_contents($this->vfs()->path('base/copy-to/2')));
     }
 
     public function testCopyMissingFile(): void {
-        $this->assertEquals(null, $this->temp->copy($this->vfs->path('base/copy-to')));
+        $this->assertEquals(null, $this->temp->copy($this->vfs()->path('base/copy-to')));
     }
 
     public function testCopyOverwrite(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/copy' => [
                 '1' => 'foo',
                 '2' => 'foo'
@@ -212,19 +212,19 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/1'));
-        $this->assertFileExists($this->vfs->path('base/copy-to/3/3-1'));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/1'));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/3/3-1'));
 
-        $baseFolder = new Folder($this->vfs->path('base/copy'));
-        $baseFolder->copy($this->vfs->path('base/copy-to'), Folder::OVERWRITE);
+        $baseFolder = new Folder($this->vfs()->path('base/copy'));
+        $baseFolder->copy($this->vfs()->path('base/copy-to'), Folder::OVERWRITE);
 
-        $this->assertFileExists($this->vfs->path('base/copy-to/1'));
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/3/3-1'));
-        $this->assertEquals('foo', file_get_contents($this->vfs->path('base/copy-to/2')));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/1'));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/3/3-1'));
+        $this->assertEquals('foo', file_get_contents($this->vfs()->path('base/copy-to/2')));
     }
 
     public function testCopySkip(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/copy' => [
                 '1' => 'foo',
                 '2' => 'foo',
@@ -240,20 +240,20 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/1'));
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/4/4-3'));
-        $this->assertEquals('bar', file_get_contents($this->vfs->path('base/copy-to/2')));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/1'));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/4/4-3'));
+        $this->assertEquals('bar', file_get_contents($this->vfs()->path('base/copy-to/2')));
 
-        $baseFolder = new Folder($this->vfs->path('base/copy'));
-        $baseFolder->copy($this->vfs->path('base/copy-to'), Folder::SKIP);
+        $baseFolder = new Folder($this->vfs()->path('base/copy'));
+        $baseFolder->copy($this->vfs()->path('base/copy-to'), Folder::SKIP);
 
-        $this->assertFileExists($this->vfs->path('base/copy-to/1'));
-        $this->assertFileExists($this->vfs->path('base/copy-to/4/4-3'));
-        $this->assertEquals('bar', file_get_contents($this->vfs->path('base/copy-to/2')));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/1'));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/4/4-3'));
+        $this->assertEquals('bar', file_get_contents($this->vfs()->path('base/copy-to/2')));
     }
 
     public function testCopyMerge(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/copy' => [
                 '1' => 'foo',
                 '2' => 'foo',
@@ -273,21 +273,21 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/1'));
-        $this->assertFileExists($this->vfs->path('base/copy-to/3/3-1'));
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/3/3-2'));
-        $this->assertFileNotExists($this->vfs->path('base/copy-to/4/4-3'));
-        $this->assertEquals('bar', file_get_contents($this->vfs->path('base/copy-to/2')));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/1'));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/3/3-1'));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/3/3-2'));
+        $this->assertFileNotExists($this->vfs()->path('base/copy-to/4/4-3'));
+        $this->assertEquals('bar', file_get_contents($this->vfs()->path('base/copy-to/2')));
 
-        $baseFolder = new Folder($this->vfs->path('base/copy'));
-        $baseFolder->copy($this->vfs->path('base/copy-to'), Folder::MERGE);
+        $baseFolder = new Folder($this->vfs()->path('base/copy'));
+        $baseFolder->copy($this->vfs()->path('base/copy-to'), Folder::MERGE);
 
-        $this->assertFileExists($this->vfs->path('base/copy-to/1'));
-        $this->assertFileExists($this->vfs->path('base/copy-to/3/3-1'));
-        $this->assertFileExists($this->vfs->path('base/copy-to/3/3-2'));
-        $this->assertFileExists($this->vfs->path('base/copy-to/4/4-3'));
-        $this->assertEquals('foo', file_get_contents($this->vfs->path('base/copy-to/2')));
-        $this->assertEquals('foo', file_get_contents($this->vfs->path('base/copy-to/3/3-1')));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/1'));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/3/3-1'));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/3/3-2'));
+        $this->assertFileExists($this->vfs()->path('base/copy-to/4/4-3'));
+        $this->assertEquals('foo', file_get_contents($this->vfs()->path('base/copy-to/2')));
+        $this->assertEquals('foo', file_get_contents($this->vfs()->path('base/copy-to/3/3-1')));
     }
 
     public function testDelete(): void {
@@ -296,10 +296,10 @@ class FolderTest extends TestCase {
     }
 
     public function testDir(): void {
-        $folder = new Folder($this->vfs->path('base/child/dir'), true);
+        $folder = new Folder($this->vfs()->path('base/child/dir'), true);
 
-        $this->assertEquals($this->vfs->path('base/child/'), $folder->dir());
-        $this->assertEquals($this->vfs->path('base/'), $folder->parent()->dir());
+        $this->assertEquals($this->vfs()->path('base/child/'), $folder->dir());
+        $this->assertEquals($this->vfs()->path('base/'), $folder->parent()?->dir());
     }
 
     public function testExists(): void {
@@ -311,7 +311,7 @@ class FolderTest extends TestCase {
     }
 
     public function testFiles(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/read' => [
                 '4' => 'd',
                 '5' => 'e',
@@ -327,10 +327,10 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/read'));
+        $folder = new Folder($this->vfs()->path('base/read'));
         $contents = $folder->files();
 
-        $scheme = $this->vfs->scheme();
+        $scheme = $this->vfs()->scheme();
         $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
@@ -351,7 +351,7 @@ class FolderTest extends TestCase {
     public function testFind(): void {
         $this->markTestSkipped('Glob iteration does not work with PHP streams');
 
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/find' => [
                 'foo.php' => 'a',
                 'bar.php' => 'b',
@@ -364,7 +364,7 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $object = new Folder($this->vfs->path('base/find'));
+        $object = new Folder($this->vfs()->path('base/find'));
 
         $files = $object->find('*.php');
         $this->assertTrue(count($files) >= 3);
@@ -384,7 +384,7 @@ class FolderTest extends TestCase {
     }
 
     public function testFolders(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/read' => [
                 '4' => 'd',
                 '5' => 'e',
@@ -403,10 +403,10 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/read'));
+        $folder = new Folder($this->vfs()->path('base/read'));
         $contents = $folder->folders();
 
-        $scheme = $this->vfs->scheme();
+        $scheme = $this->vfs()->scheme();
         $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
@@ -453,40 +453,40 @@ class FolderTest extends TestCase {
     }
 
     public function testMove(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/move' => [
                 '1' => 'foo',
                 '2' => 'bar'
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/move'));
+        $folder = new Folder($this->vfs()->path('base/move'));
 
-        $this->assertFileExists($this->vfs->path('base/move'));
-        $this->assertFileNotExists($this->vfs->path('base/move-to'));
+        $this->assertFileExists($this->vfs()->path('base/move'));
+        $this->assertFileNotExists($this->vfs()->path('base/move-to'));
 
-        $folder->move($this->vfs->path('base/move-to'));
+        $folder->move($this->vfs()->path('base/move-to'));
 
-        $this->assertEquals($this->vfs->path('base/move-to/'), $folder->path());
-        $this->assertFileNotExists($this->vfs->path('base/move'));
-        $this->assertFileExists($this->vfs->path('base/move-to'));
+        $this->assertEquals($this->vfs()->path('base/move-to/'), $folder->path());
+        $this->assertFileNotExists($this->vfs()->path('base/move'));
+        $this->assertFileExists($this->vfs()->path('base/move-to'));
     }
 
     public function testMoveMissingFile(): void {
-        $this->assertFalse($this->temp->move($this->vfs->path('base/move-to')));
+        $this->assertFalse($this->temp->move($this->vfs()->path('base/move-to')));
     }
 
     public function testMoveExitsEarlySameLocation(): void {
-        $folder = new Folder($this->vfs->path('base/move'), true);
+        $folder = new Folder($this->vfs()->path('base/move'), true);
 
-        $this->assertTrue($folder->move($this->vfs->path('base/move')));
+        $this->assertTrue($folder->move($this->vfs()->path('base/move')));
     }
 
     /**
      * @expectedException \Titon\Io\Exception\ExistingFileException
      */
     public function testMoveTargetExists(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/move' => [
                 '1' => 'foo',
                 '2' => 'foo'
@@ -496,33 +496,33 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/move'));
-        $folder->move($this->vfs->path('base/move-to'), false);
+        $folder = new Folder($this->vfs()->path('base/move'));
+        $folder->move($this->vfs()->path('base/move-to'), false);
     }
 
     public function testMoveOverwriteTargetFile(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/move' => [
                 '1' => 'foo'
             ],
             'base/move-to' => 'bar'
         ]);
 
-        $file = new Folder($this->vfs->path('base/move'));
+        $file = new Folder($this->vfs()->path('base/move'));
 
-        $this->assertFileExists($this->vfs->path('base/move'));
-        $this->assertFileExists($this->vfs->path('base/move-to'));
-        $this->assertTrue(is_file($this->vfs->path('base/move-to')));
+        $this->assertFileExists($this->vfs()->path('base/move'));
+        $this->assertFileExists($this->vfs()->path('base/move-to'));
+        $this->assertTrue(is_file($this->vfs()->path('base/move-to')));
 
-        $file->move($this->vfs->path('base/move-to'), true);
+        $file->move($this->vfs()->path('base/move-to'), true);
 
-        $this->assertFileNotExists($this->vfs->path('base/move'));
-        $this->assertFileExists($this->vfs->path('base/move-to'));
-        $this->assertFalse(is_file($this->vfs->path('base/move-to')));
+        $this->assertFileNotExists($this->vfs()->path('base/move'));
+        $this->assertFileExists($this->vfs()->path('base/move-to'));
+        $this->assertFalse(is_file($this->vfs()->path('base/move-to')));
     }
 
     public function testMoveOverwriteTargetFolder(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/move' => [
                 '1' => 'foo'
             ],
@@ -531,19 +531,19 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $file = new Folder($this->vfs->path('base/move'));
+        $file = new Folder($this->vfs()->path('base/move'));
 
-        $this->assertFileExists($this->vfs->path('base/move'));
-        $this->assertFileExists($this->vfs->path('base/move-to'));
-        $this->assertFileExists($this->vfs->path('base/move-to/2'));
-        $this->assertTrue(is_dir($this->vfs->path('base/move-to')));
+        $this->assertFileExists($this->vfs()->path('base/move'));
+        $this->assertFileExists($this->vfs()->path('base/move-to'));
+        $this->assertFileExists($this->vfs()->path('base/move-to/2'));
+        $this->assertTrue(is_dir($this->vfs()->path('base/move-to')));
 
-        $file->move($this->vfs->path('base/move-to'), true);
+        $file->move($this->vfs()->path('base/move-to'), true);
 
-        $this->assertFileNotExists($this->vfs->path('base/move'));
-        $this->assertFileExists($this->vfs->path('base/move-to'));
-        $this->assertFileNotExists($this->vfs->path('base/move/2'));
-        $this->assertTrue(is_dir($this->vfs->path('base/move-to')));
+        $this->assertFileNotExists($this->vfs()->path('base/move'));
+        $this->assertFileExists($this->vfs()->path('base/move-to'));
+        $this->assertFileNotExists($this->vfs()->path('base/move/2'));
+        $this->assertTrue(is_dir($this->vfs()->path('base/move-to')));
     }
 
     public function testName(): void {
@@ -557,13 +557,13 @@ class FolderTest extends TestCase {
     }
 
     public function testPath(): void {
-        $this->assertEquals($this->vfs->path('/base/'), $this->object->path());
-        $this->assertEquals($this->vfs->path('/temp/'), $this->temp->path());
+        $this->assertEquals($this->vfs()->path('/base/'), $this->object->path());
+        $this->assertEquals($this->vfs()->path('/temp/'), $this->temp->path());
     }
 
     public function testParent(): void {
         $this->assertInstanceOf('Titon\Io\Folder', $this->object->parent());
-        $this->assertEquals($this->vfs->scheme() . ':/', $this->object->parent()->path());
+        $this->assertEquals($this->vfs()->scheme() . ':/', $this->object->parent()->path());
     }
 
     public function testPermissions(): void {
@@ -604,12 +604,12 @@ class FolderTest extends TestCase {
     }
 
     public function testPwd(): void {
-        $this->assertEquals($this->vfs->path('base/'), $this->object->path());
-        $this->assertEquals($this->vfs->path('temp/'), $this->temp->path());
+        $this->assertEquals($this->vfs()->path('base/'), $this->object->path());
+        $this->assertEquals($this->vfs()->path('temp/'), $this->temp->path());
     }
 
     public function testRead(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/read' => [
                 '4' => 'd',
                 '5' => 'e',
@@ -625,10 +625,10 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/read'));
+        $folder = new Folder($this->vfs()->path('base/read'));
         $contents = $folder->read();
 
-        $scheme = $this->vfs->scheme();
+        $scheme = $this->vfs()->scheme();
         $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
@@ -648,7 +648,7 @@ class FolderTest extends TestCase {
     }
 
     public function testReadRecursive(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/read' => [
                 '4' => 'd',
                 '5' => 'e',
@@ -664,10 +664,10 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/read'));
+        $folder = new Folder($this->vfs()->path('base/read'));
         $contents = $folder->read(false, true);
 
-        $scheme = $this->vfs->scheme();
+        $scheme = $this->vfs()->scheme();
         $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
@@ -690,7 +690,7 @@ class FolderTest extends TestCase {
     }
 
     public function testReadSorting(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/read' => [
                 '4' => 'd',
                 '5' => 'e',
@@ -706,10 +706,10 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/read'));
+        $folder = new Folder($this->vfs()->path('base/read'));
         $contents = $folder->read(true);
 
-        $scheme = $this->vfs->scheme();
+        $scheme = $this->vfs()->scheme();
         $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
@@ -729,7 +729,7 @@ class FolderTest extends TestCase {
     }
 
     public function testReadSortingRecursive(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/read' => [
                 '4' => 'd',
                 '5' => 'e',
@@ -745,10 +745,10 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/read'));
+        $folder = new Folder($this->vfs()->path('base/read'));
         $contents = $folder->read(true, true);
 
-        $scheme = $this->vfs->scheme();
+        $scheme = $this->vfs()->scheme();
         $paths = $contents->map(($value) ==> {
             return str_replace($scheme . '://', '', $value->path());
         });
@@ -771,17 +771,17 @@ class FolderTest extends TestCase {
     }
 
     public function testRename(): void {
-        $file = new Folder($this->vfs->path('base/rename'), true);
+        $file = new Folder($this->vfs()->path('base/rename'), true);
 
-        $this->assertEquals($this->vfs->path('base/rename/'), $file->path());
-        $this->assertFileExists($this->vfs->path('base/rename'));
-        $this->assertFileNotExists($this->vfs->path('base/rename-to'));
+        $this->assertEquals($this->vfs()->path('base/rename/'), $file->path());
+        $this->assertFileExists($this->vfs()->path('base/rename'));
+        $this->assertFileNotExists($this->vfs()->path('base/rename-to'));
 
         $file->rename('rename-to');
 
-        $this->assertEquals($this->vfs->path('base/rename-to/'), $file->path());
-        $this->assertFileNotExists($this->vfs->path('base/rename'));
-        $this->assertFileExists($this->vfs->path('base/rename-to'));
+        $this->assertEquals($this->vfs()->path('base/rename-to/'), $file->path());
+        $this->assertFileNotExists($this->vfs()->path('base/rename'));
+        $this->assertFileExists($this->vfs()->path('base/rename-to'));
     }
 
     public function testRenameMissingFile(): void {
@@ -789,7 +789,7 @@ class FolderTest extends TestCase {
     }
 
     public function testRenameExitsEarlySameLocation(): void {
-        $file = new Folder($this->vfs->path('base/rename'), true);
+        $file = new Folder($this->vfs()->path('base/rename'), true);
 
         $this->assertTrue($file->rename('rename'));
     }
@@ -798,7 +798,7 @@ class FolderTest extends TestCase {
      * @expectedException \Titon\Io\Exception\ExistingFileException
      */
     public function testRenameTargetExists(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/rename' => [
                 '1' => 'foo',
                 '2' => 'foo'
@@ -808,33 +808,33 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/rename'));
+        $folder = new Folder($this->vfs()->path('base/rename'));
         $folder->rename('rename-to', false);
     }
 
     public function testRenameOverwriteTargetFile(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/rename' => [
                 '1' => 'foo'
             ],
             'base/rename-to' => 'bar'
         ]);
 
-        $file = new Folder($this->vfs->path('base/rename'));
+        $file = new Folder($this->vfs()->path('base/rename'));
 
-        $this->assertFileExists($this->vfs->path('base/rename'));
-        $this->assertFileExists($this->vfs->path('base/rename-to'));
-        $this->assertTrue(is_file($this->vfs->path('base/rename-to')));
+        $this->assertFileExists($this->vfs()->path('base/rename'));
+        $this->assertFileExists($this->vfs()->path('base/rename-to'));
+        $this->assertTrue(is_file($this->vfs()->path('base/rename-to')));
 
         $file->rename('rename-to', true);
 
-        $this->assertFileNotExists($this->vfs->path('base/rename'));
-        $this->assertFileExists($this->vfs->path('base/rename-to'));
-        $this->assertFalse(is_file($this->vfs->path('base/rename-to')));
+        $this->assertFileNotExists($this->vfs()->path('base/rename'));
+        $this->assertFileExists($this->vfs()->path('base/rename-to'));
+        $this->assertFalse(is_file($this->vfs()->path('base/rename-to')));
     }
 
     public function testRenameOverwriteTargetFolder(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/rename' => [
                 '1' => 'foo'
             ],
@@ -843,44 +843,44 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $file = new Folder($this->vfs->path('base/rename'));
+        $file = new Folder($this->vfs()->path('base/rename'));
 
-        $this->assertFileExists($this->vfs->path('base/rename'));
-        $this->assertFileExists($this->vfs->path('base/rename-to'));
-        $this->assertFileExists($this->vfs->path('base/rename-to/2'));
-        $this->assertTrue(is_dir($this->vfs->path('base/rename-to')));
+        $this->assertFileExists($this->vfs()->path('base/rename'));
+        $this->assertFileExists($this->vfs()->path('base/rename-to'));
+        $this->assertFileExists($this->vfs()->path('base/rename-to/2'));
+        $this->assertTrue(is_dir($this->vfs()->path('base/rename-to')));
 
         $file->rename('rename-to', true);
 
-        $this->assertFileNotExists($this->vfs->path('base/rename'));
-        $this->assertFileExists($this->vfs->path('base/rename-to'));
-        $this->assertFileNotExists($this->vfs->path('base/rename/2'));
-        $this->assertTrue(is_dir($this->vfs->path('base/rename-to')));
+        $this->assertFileNotExists($this->vfs()->path('base/rename'));
+        $this->assertFileExists($this->vfs()->path('base/rename-to'));
+        $this->assertFileNotExists($this->vfs()->path('base/rename/2'));
+        $this->assertTrue(is_dir($this->vfs()->path('base/rename-to')));
     }
 
     public function testRenameFormatName(): void {
-        $file = new Folder($this->vfs->path('base/rename'), true);
+        $file = new Folder($this->vfs()->path('base/rename'), true);
 
         $this->assertTrue($file->rename('SA# DM)8NS #$ 97py1n  6 d6as9 #%@ P'));
         $this->assertEquals('SA--DM-8NS----97py1n--6-d6as9-----P', $file->name());
     }
 
     public function testReset(): void {
-        $this->object->reset($this->vfs->path('reset-to'));
-        $this->assertEquals($this->vfs->path('reset-to/'), $this->object->path());
+        $this->object->reset($this->vfs()->path('reset-to'));
+        $this->assertEquals($this->vfs()->path('reset-to/'), $this->object->path());
     }
 
     /**
      * @expectedException \Titon\Io\Exception\InvalidPathException
      */
     public function testResetFailsOnFile(): void {
-        $this->vfs->createFile('base/reset-to', 'foo');
+        $this->vfs()->createFile('base/reset-to', 'foo');
 
-        $this->object->reset($this->vfs->path('base/reset-to'));
+        $this->object->reset($this->vfs()->path('base/reset-to'));
     }
 
     public function testSize(): void {
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             'base/size' => [
                 '1' => 'a',
                 '2' => 'b',
@@ -892,7 +892,7 @@ class FolderTest extends TestCase {
             ]
         ]);
 
-        $folder = new Folder($this->vfs->path('base/size'));
+        $folder = new Folder($this->vfs()->path('base/size'));
 
         $this->assertEquals(5, $folder->size());
         $this->assertEquals(null, $this->temp->size());

--- a/tests/Titon/Io/NodeTest.hh
+++ b/tests/Titon/Io/NodeTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io;
 
 use Titon\Test\TestCase;
@@ -6,7 +6,7 @@ use VirtualFileSystem\FileSystem;
 
 class NodeTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->vfs = new FileSystem();
@@ -14,7 +14,7 @@ class NodeTest extends TestCase {
         $this->vfs->createFile('/file');
     }
 
-    public function testDestroy() {
+    public function testDestroy(): void {
         $this->assertFalse(Node::destroy($this->vfs->path('missing')));
 
         $this->assertFileExists($this->vfs->path('folder'));
@@ -26,7 +26,7 @@ class NodeTest extends TestCase {
         $this->assertFileNotExists($this->vfs->path('file'));
     }
 
-    public function testLoad() {
+    public function testLoad(): void {
         $this->assertInstanceOf('Titon\Io\Folder', Node::load($this->vfs->path('folder')));
         $this->assertInstanceOf('Titon\Io\File', Node::load($this->vfs->path('file')));
     }
@@ -34,7 +34,7 @@ class NodeTest extends TestCase {
     /**
      * @expectedException \Titon\Common\Exception\MissingFileException
      */
-    public function testLoadMissingTarget() {
+    public function testLoadMissingTarget(): void {
         Node::load($this->vfs->path('missing'));
     }
 

--- a/tests/Titon/Io/NodeTest.hh
+++ b/tests/Titon/Io/NodeTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io;
 
 use Titon\Test\TestCase;
@@ -10,32 +10,32 @@ class NodeTest extends TestCase {
         parent::setUp();
 
         $this->vfs = new FileSystem();
-        $this->vfs->createDirectory('/folder');
-        $this->vfs->createFile('/file');
+        $this->vfs()->createDirectory('/folder');
+        $this->vfs()->createFile('/file');
     }
 
     public function testDestroy(): void {
-        $this->assertFalse(Node::destroy($this->vfs->path('missing')));
+        $this->assertFalse(Node::destroy($this->vfs()->path('missing')));
 
-        $this->assertFileExists($this->vfs->path('folder'));
-        $this->assertTrue(Node::destroy($this->vfs->path('folder')));
-        $this->assertFileNotExists($this->vfs->path('folder'));
+        $this->assertFileExists($this->vfs()->path('folder'));
+        $this->assertTrue(Node::destroy($this->vfs()->path('folder')));
+        $this->assertFileNotExists($this->vfs()->path('folder'));
 
-        $this->assertFileExists($this->vfs->path('file'));
-        $this->assertTrue(Node::destroy($this->vfs->path('file')));
-        $this->assertFileNotExists($this->vfs->path('file'));
+        $this->assertFileExists($this->vfs()->path('file'));
+        $this->assertTrue(Node::destroy($this->vfs()->path('file')));
+        $this->assertFileNotExists($this->vfs()->path('file'));
     }
 
     public function testLoad(): void {
-        $this->assertInstanceOf('Titon\Io\Folder', Node::load($this->vfs->path('folder')));
-        $this->assertInstanceOf('Titon\Io\File', Node::load($this->vfs->path('file')));
+        $this->assertInstanceOf('Titon\Io\Folder', Node::load($this->vfs()->path('folder')));
+        $this->assertInstanceOf('Titon\Io\File', Node::load($this->vfs()->path('file')));
     }
 
     /**
      * @expectedException \Titon\Common\Exception\MissingFileException
      */
     public function testLoadMissingTarget(): void {
-        Node::load($this->vfs->path('missing'));
+        Node::load($this->vfs()->path('missing'));
     }
 
 }

--- a/tests/Titon/Io/Reader/IniReaderTest.hh
+++ b/tests/Titon/Io/Reader/IniReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php

--- a/tests/Titon/Io/Reader/IniReaderTest.hh
+++ b/tests/Titon/Io/Reader/IniReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php
@@ -11,7 +11,7 @@ use Titon\Test\TestCase;
 
 class IniReaderTest extends TestCase {
 
-    public function testReadResource() {
+    public function testReadResource(): void {
         $reader = new IniReader(TEMP_DIR . '/io/ini.ini');
 
         $this->assertMapsEqual(Map {

--- a/tests/Titon/Io/Reader/JsonReaderTest.hh
+++ b/tests/Titon/Io/Reader/JsonReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php
@@ -11,7 +11,7 @@ use Titon\Test\TestCase;
 
 class JsonReaderTest extends TestCase {
 
-    public function testReadResource() {
+    public function testReadResource(): void {
         $reader = new JsonReader(TEMP_DIR . '/io/json.json');
 
         $this->assertMapsEqual(Map {

--- a/tests/Titon/Io/Reader/JsonReaderTest.hh
+++ b/tests/Titon/Io/Reader/JsonReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php

--- a/tests/Titon/Io/Reader/PhpReaderTest.hh
+++ b/tests/Titon/Io/Reader/PhpReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php
@@ -11,7 +11,7 @@ use Titon\Test\TestCase;
 
 class PhpReaderTest extends TestCase {
 
-    public function testReadResource() {
+    public function testReadResource(): void {
         $reader = new PhpReader(TEMP_DIR . '/io/php.php');
 
         $this->assertMapsEqual(Map {

--- a/tests/Titon/Io/Reader/PhpReaderTest.hh
+++ b/tests/Titon/Io/Reader/PhpReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php

--- a/tests/Titon/Io/Reader/PoReaderTest.hh
+++ b/tests/Titon/Io/Reader/PoReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php
@@ -11,7 +11,7 @@ use Titon\Test\TestCase;
 
 class PoReaderTest extends TestCase {
 
-    public function testReadResource() {
+    public function testReadResource(): void {
         $reader = new PoReader(TEMP_DIR . '/io/po.po');
 
         $this->assertMapsEqual(Map {

--- a/tests/Titon/Io/Reader/PoReaderTest.hh
+++ b/tests/Titon/Io/Reader/PoReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php

--- a/tests/Titon/Io/Reader/XmlReaderTest.hh
+++ b/tests/Titon/Io/Reader/XmlReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php
@@ -11,7 +11,7 @@ use Titon\Test\TestCase;
 
 class XmlReaderTest extends TestCase {
 
-    public function testReadResource() {
+    public function testReadResource(): void {
         $reader = new XmlReader(TEMP_DIR . '/io/xml.xml');
 
         $this->assertMapsEqual(Map {

--- a/tests/Titon/Io/Reader/XmlReaderTest.hh
+++ b/tests/Titon/Io/Reader/XmlReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php

--- a/tests/Titon/Io/Reader/YamlReaderTest.hh
+++ b/tests/Titon/Io/Reader/YamlReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php

--- a/tests/Titon/Io/Reader/YamlReaderTest.hh
+++ b/tests/Titon/Io/Reader/YamlReaderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 /**
  * @copyright   2010-2013, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php
@@ -11,7 +11,7 @@ use Titon\Test\TestCase;
 
 class YamlReaderTest extends TestCase {
 
-    public function testReadResource() {
+    public function testReadResource(): void {
         if (!extension_loaded('yaml')) {
             $this->markTestSkipped('YAML extension must be installed to use the YamlReader');
         }

--- a/tests/Titon/Io/Writer/IniWriterTest.hh
+++ b/tests/Titon/Io/Writer/IniWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\IniWriter;
@@ -9,12 +9,11 @@ class IniWriterTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/writer');
+        $this->vfs()->createDirectory('/writer');
     }
 
     public function testWriteResource(): void {
-        $path = $this->vfs->path('/writer/ini.ini');
+        $path = $this->vfs()->path('/writer/ini.ini');
 
         $writer = new IniWriter($path, true);
         $writer->writeResource(Map {

--- a/tests/Titon/Io/Writer/IniWriterTest.hh
+++ b/tests/Titon/Io/Writer/IniWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\IniWriter;
@@ -6,14 +6,14 @@ use Titon\Test\TestCase;
 
 class IniWriterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
         $this->vfs->createDirectory('/writer');
     }
 
-    public function testWriteResource() {
+    public function testWriteResource(): void {
         $path = $this->vfs->path('/writer/ini.ini');
 
         $writer = new IniWriter($path, true);

--- a/tests/Titon/Io/Writer/JsonWriterTest.hh
+++ b/tests/Titon/Io/Writer/JsonWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\JsonWriter;
@@ -9,12 +9,11 @@ class JsonWriterTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/writer');
+        $this->vfs()->createDirectory('/writer');
     }
 
     public function testWriteResource(): void {
-        $path = $this->vfs->path('/writer/json.json');
+        $path = $this->vfs()->path('/writer/json.json');
 
         $writer = new JsonWriter($path, true);
         $writer->writeResource(Map {

--- a/tests/Titon/Io/Writer/JsonWriterTest.hh
+++ b/tests/Titon/Io/Writer/JsonWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\JsonWriter;
@@ -6,14 +6,14 @@ use Titon\Test\TestCase;
 
 class JsonWriterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
         $this->vfs->createDirectory('/writer');
     }
 
-    public function testWriteResource() {
+    public function testWriteResource(): void {
         $path = $this->vfs->path('/writer/json.json');
 
         $writer = new JsonWriter($path, true);

--- a/tests/Titon/Io/Writer/PhpWriterTest.hh
+++ b/tests/Titon/Io/Writer/PhpWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\PhpWriter;
@@ -6,14 +6,14 @@ use Titon\Test\TestCase;
 
 class PhpWriterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
         $this->vfs->createDirectory('/writer');
     }
 
-    public function testWriteResource() {
+    public function testWriteResource(): void {
         $path = $this->vfs->path('/writer/php.php');
 
         $writer = new PhpWriter($path, true);

--- a/tests/Titon/Io/Writer/PhpWriterTest.hh
+++ b/tests/Titon/Io/Writer/PhpWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\PhpWriter;
@@ -9,12 +9,11 @@ class PhpWriterTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/writer');
+        $this->vfs()->createDirectory('/writer');
     }
 
     public function testWriteResource(): void {
-        $path = $this->vfs->path('/writer/php.php');
+        $path = $this->vfs()->path('/writer/php.php');
 
         $writer = new PhpWriter($path, true);
         $writer->writeResource(Map {

--- a/tests/Titon/Io/Writer/PoWriterTest.hh
+++ b/tests/Titon/Io/Writer/PoWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\PoWriter;
@@ -6,14 +6,14 @@ use Titon\Test\TestCase;
 
 class PoWriterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
         $this->vfs->createDirectory('/writer');
     }
 
-    public function testWriteResource() {
+    public function testWriteResource(): void {
         $path = $this->vfs->path('/writer/po.po');
 
         $writer = new PoWriter($path, true);

--- a/tests/Titon/Io/Writer/PoWriterTest.hh
+++ b/tests/Titon/Io/Writer/PoWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\PoWriter;
@@ -9,12 +9,11 @@ class PoWriterTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/writer');
+        $this->vfs()->createDirectory('/writer');
     }
 
     public function testWriteResource(): void {
-        $path = $this->vfs->path('/writer/po.po');
+        $path = $this->vfs()->path('/writer/po.po');
 
         $writer = new PoWriter($path, true);
         $writer->writeResource(Map {

--- a/tests/Titon/Io/Writer/XmlWriterTest.hh
+++ b/tests/Titon/Io/Writer/XmlWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\XmlWriter;
@@ -6,14 +6,14 @@ use Titon\Test\TestCase;
 
 class XmlWriterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
         $this->vfs->createDirectory('/writer');
     }
 
-    public function testWriteResource() {
+    public function testWriteResource(): void {
         $path = $this->vfs->path('/writer/xml.xml');
 
         $writer = new XmlWriter($path, true);

--- a/tests/Titon/Io/Writer/XmlWriterTest.hh
+++ b/tests/Titon/Io/Writer/XmlWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io\Writer;
 
 use Titon\Io\Writer\XmlWriter;
@@ -9,12 +9,11 @@ class XmlWriterTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/writer');
+        $this->vfs()->createDirectory('/writer');
     }
 
     public function testWriteResource(): void {
-        $path = $this->vfs->path('/writer/xml.xml');
+        $path = $this->vfs()->path('/writer/xml.xml');
 
         $writer = new XmlWriter($path, true);
         $writer->writeResource(Map {

--- a/tests/Titon/Io/Writer/YamlWriterTest.hh
+++ b/tests/Titon/Io/Writer/YamlWriterTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Io\Writer;
 
 use Titon\Test\TestCase;
 
 class YamlWriterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         if (!extension_loaded('yaml')) {
@@ -16,7 +16,7 @@ class YamlWriterTest extends TestCase {
         $this->vfs->createDirectory('/writer');
     }
 
-    public function testWriteResource() {
+    public function testWriteResource(): void {
         $path = $this->vfs->path('/writer/yaml.yaml');
 
         $writer = new YamlWriter($path, true);

--- a/tests/Titon/Io/Writer/YamlWriterTest.hh
+++ b/tests/Titon/Io/Writer/YamlWriterTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Io\Writer;
 
 use Titon\Test\TestCase;
@@ -12,12 +12,11 @@ class YamlWriterTest extends TestCase {
             $this->markTestSkipped('YAML extension must be installed to use the YamlWriter');
         }
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/writer');
+        $this->vfs()->createDirectory('/writer');
     }
 
     public function testWriteResource(): void {
-        $path = $this->vfs->path('/writer/yaml.yaml');
+        $path = $this->vfs()->path('/writer/yaml.yaml');
 
         $writer = new YamlWriter($path, true);
         $writer->writeResource(Map {

--- a/tests/Titon/Kernel/KernelTest.hh
+++ b/tests/Titon/Kernel/KernelTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Kernel;
 
 use Titon\Kernel\Middleware\Pipeline;
@@ -18,7 +18,7 @@ use Titon\Test\TestCase;
  */
 class KernelTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new KernelStub(new ApplicationStub(), new Pipeline());
@@ -26,7 +26,7 @@ class KernelTest extends TestCase {
         $this->output = new OutputStub();
     }
 
-    public function testKernelModifiesOutputInHandle() {
+    public function testKernelModifiesOutputInHandle(): void {
         $this->assertFalse($this->output->ran);
 
         $this->object->run($this->input, $this->output);
@@ -34,7 +34,7 @@ class KernelTest extends TestCase {
         $this->assertTrue($this->output->ran);
     }
 
-    public function testKernelRunsWithoutMiddleware() {
+    public function testKernelRunsWithoutMiddleware(): void {
         $this->object = new KernelStub(new ApplicationStub(), new Pipeline());
 
         $this->assertFalse($this->output->ran);
@@ -44,7 +44,7 @@ class KernelTest extends TestCase {
         $this->assertTrue($this->output->ran);
     }
 
-    public function testKernelCallNextHandleDoesNothing() {
+    public function testKernelCallNextHandleDoesNothing(): void {
         $this->object = new CallNextKernelStub(new ApplicationStub(), new Pipeline());
         $this->object->pipe(new MiddlewareStub('foo'));
         $this->object->pipe(new MiddlewareStub('bar'));
@@ -57,7 +57,7 @@ class KernelTest extends TestCase {
         $this->assertTrue($this->output->ran);
     }
 
-    public function testMiddlewareAreExecutedInANestedFormat() {
+    public function testMiddlewareAreExecutedInANestedFormat(): void {
         $this->object->pipe(new MiddlewareStub('foo'));
         $this->object->pipe(new MiddlewareStub('bar'));
         $this->object->pipe(new MiddlewareStub('baz'));
@@ -69,7 +69,7 @@ class KernelTest extends TestCase {
         $this->assertEquals(['foo', 'bar', 'baz', 'kernel', 'baz', 'bar', 'foo'], $this->input->stack);
     }
 
-    public function testMiddlewareCanInterruptCycle() {
+    public function testMiddlewareCanInterruptCycle(): void {
         $this->object->pipe(new MiddlewareStub('foo'));
         $this->object->pipe(new InterruptMiddlewareStub('bar'));
         $this->object->pipe(new MiddlewareStub('baz'));
@@ -81,7 +81,7 @@ class KernelTest extends TestCase {
         $this->assertEquals(['foo', 'bar', 'foo'], $this->input->stack);
     }
 
-    public function testExecutionTimeIsLogged() {
+    public function testExecutionTimeIsLogged(): void {
         $this->object->run($this->input, $this->output);
 
         $this->assertLessThan($this->object->getStartTime(), $this->object->getExecutionTime());

--- a/tests/Titon/Kernel/KernelTest.hh
+++ b/tests/Titon/Kernel/KernelTest.hh
@@ -1,14 +1,20 @@
 <?hh
 namespace Titon\Kernel;
 
-use Titon\Kernel\Middleware\Next;
 use Titon\Kernel\Middleware\Pipeline;
+use Titon\Test\Stub\Kernel\ApplicationStub;
+use Titon\Test\Stub\Kernel\CallNextKernelStub;
+use Titon\Test\Stub\Kernel\InputStub;
+use Titon\Test\Stub\Kernel\InterruptMiddlewareStub;
+use Titon\Test\Stub\Kernel\KernelStub;
+use Titon\Test\Stub\Kernel\MiddlewareStub;
+use Titon\Test\Stub\Kernel\OutputStub;
 use Titon\Test\TestCase;
 
 /**
- * @property \Titon\Kernel\KernelStub $object
- * @property \Titon\Kernel\InputStub $input
- * @property \Titon\Kernel\OutputStub $output
+ * @property \Titon\Test\Stub\Kernel\KernelStub $object
+ * @property \Titon\Test\Stub\Kernel\InputStub $input
+ * @property \Titon\Test\Stub\Kernel\OutputStub $output
  */
 class KernelTest extends TestCase {
 
@@ -81,58 +87,4 @@ class KernelTest extends TestCase {
         $this->assertLessThan($this->object->getStartTime(), $this->object->getExecutionTime());
     }
 
-}
-
-class ApplicationStub implements Application {
-
-}
-
-class KernelStub extends AbstractKernel<InputStub, OutputStub> {
-    public function handle(Input $input, Output $output, Next $next): Output {
-        $input->stack[] = 'kernel';
-        $output->ran = true;
-
-        return $output;
-    }
-}
-
-class CallNextKernelStub extends KernelStub {
-    public function handle(Input $input, Output $output, Next $next): Output {
-        $next->handle($input, $output);
-        $output->ran = true;
-
-        return $output;
-    }
-}
-
-class InputStub implements Input {
-    public array<mixed> $stack = [];
-}
-
-class OutputStub implements Output {
-    public bool $ran = false;
-
-    public function send(): void {}
-}
-
-class MiddlewareStub implements Middleware {
-    public function __construct(protected string $key) {}
-
-    public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
-        $input->stack[] = $this->key;
-
-        $output = $next->handle($input, $output);
-
-        $input->stack[] = $this->key;
-
-        return $output;
-    }
-}
-
-class InterruptMiddlewareStub extends MiddlewareStub {
-    public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
-        $input->stack[] = $this->key;
-
-        return $output;
-    }
 }

--- a/tests/Titon/Kernel/KernelTest.hh
+++ b/tests/Titon/Kernel/KernelTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Kernel;
 
 use Titon\Kernel\Middleware\Pipeline;

--- a/tests/Titon/Route/Annotation/RouteTest.hh
+++ b/tests/Titon/Route/Annotation/RouteTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Route\Annotation;
 
 use Titon\Annotation\Reader;
@@ -13,6 +13,8 @@ class RouteTest extends TestCase {
         // Class
         $class = $reader->getClassAnnotation('Route');
 
+        invariant($class instanceof Route, 'Must be a Route annotation.');
+
         $this->assertEquals('parent', $class->getKey());
         $this->assertEquals('/controller', $class->getPath());
         $this->assertEquals(Vector {}, $class->getMethods());
@@ -21,6 +23,8 @@ class RouteTest extends TestCase {
 
         // Foo
         $foo = $reader->getMethodAnnotation('foo', 'Route');
+
+        invariant($foo instanceof Route, 'Must be a Route annotation.');
 
         $this->assertEquals('foo', $foo->getKey());
         $this->assertEquals('/foo', $foo->getPath());
@@ -31,6 +35,8 @@ class RouteTest extends TestCase {
         // Bar
         $bar = $reader->getMethodAnnotation('bar', 'Route');
 
+        invariant($bar instanceof Route, 'Must be a Route annotation.');
+
         $this->assertEquals('bar', $bar->getKey());
         $this->assertEquals('/bar', $bar->getPath());
         $this->assertEquals(Vector {'post'}, $bar->getMethods());
@@ -40,6 +46,8 @@ class RouteTest extends TestCase {
         // Baz
         $baz = $reader->getMethodAnnotation('baz', 'Route');
 
+        invariant($baz instanceof Route, 'Must be a Route annotation.');
+
         $this->assertEquals('baz', $baz->getKey());
         $this->assertEquals('/baz', $baz->getPath());
         $this->assertEquals(Vector {'get'}, $baz->getMethods());
@@ -48,6 +56,8 @@ class RouteTest extends TestCase {
 
         // Qux
         $qux = $reader->getMethodAnnotation('qux', 'Route');
+
+        invariant($qux instanceof Route, 'Must be a Route annotation.');
 
         $this->assertEquals('qux', $qux->getKey());
         $this->assertEquals('/qux', $qux->getPath());

--- a/tests/Titon/Route/Annotation/RouteTest.hh
+++ b/tests/Titon/Route/Annotation/RouteTest.hh
@@ -2,12 +2,13 @@
 namespace Titon\Route\Annotation;
 
 use Titon\Annotation\Reader;
+use Titon\Test\Stub\Route\RouteAnnotatedStub;
 use Titon\Test\TestCase;
 
 class RouteTest extends TestCase {
 
     public function testParamsAreSetOnRouteAnnotation() {
-        $reader = new Reader(new RouteStub());
+        $reader = new Reader(new RouteAnnotatedStub());
 
         // Class
         $class = $reader->getClassAnnotation('Route');
@@ -54,22 +55,5 @@ class RouteTest extends TestCase {
         $this->assertEquals(Vector {}, $qux->getFilters());
         $this->assertEquals(Map {'id' => '[1-8]+'}, $qux->getPatterns());
     }
-
-}
-
-<<Route('parent', '/controller')>>
-class RouteStub {
-
-    <<Route('foo', '/foo')>>
-    public function foo(): void {}
-
-    <<Route('bar', '/bar', 'POST')>>
-    public function bar(): void {}
-
-    <<Route('baz', '/baz', ['get'], ['auth', 'guest'])>>
-    public function baz(): void {}
-
-    <<Route('qux', '/qux', ['PUT', 'POST'], [], ['id' => '[1-8]+'])>>
-    public function qux(): void {}
 
 }

--- a/tests/Titon/Route/Annotation/RouteTest.hh
+++ b/tests/Titon/Route/Annotation/RouteTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Route\Annotation;
 
 use Titon\Annotation\Reader;
@@ -7,7 +7,7 @@ use Titon\Test\TestCase;
 
 class RouteTest extends TestCase {
 
-    public function testParamsAreSetOnRouteAnnotation() {
+    public function testParamsAreSetOnRouteAnnotation(): void {
         $reader = new Reader(new RouteAnnotatedStub());
 
         // Class

--- a/tests/Titon/Route/CallbackRouteTest.hh
+++ b/tests/Titon/Route/CallbackRouteTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Route;
 
 use Titon\Test\TestCase;
 
 class CallbackRouteTest extends TestCase {
 
-    public function testDispatch() {
+    public function testDispatch(): void {
         $route = new CallbackRoute('/{a}/{b}', function(string $a, string $b): string {
             return $a . $b;
         });
@@ -14,7 +14,7 @@ class CallbackRouteTest extends TestCase {
         $this->assertEquals('foobar', $route->dispatch());
     }
 
-    public function testDispatchOptional() {
+    public function testDispatchOptional(): void {
         $route = new CallbackRoute('/{a}/{b?}', function(string $a, string $b = 'baz'): string {
             return $a . $b;
         });
@@ -23,7 +23,7 @@ class CallbackRouteTest extends TestCase {
         $this->assertEquals('foobaz', $route->dispatch());
     }
 
-    public function testDispatchTypeHints() {
+    public function testDispatchTypeHints(): void {
         $route = new CallbackRoute('/{a}/[b]/(c)', function(string $a, int $b, string $c): string {
             return $a . $b . $c;
         });
@@ -35,7 +35,7 @@ class CallbackRouteTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\NoMatchException
      */
-    public function testDispatchNoMatch() {
+    public function testDispatchNoMatch(): void {
         $route = new CallbackRoute('/', () ==> '');
         $route->dispatch();
     }

--- a/tests/Titon/Route/CallbackRouteTest.hh
+++ b/tests/Titon/Route/CallbackRouteTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Route;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Route/GroupTest.hh
+++ b/tests/Titon/Route/GroupTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Route;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Route/GroupTest.hh
+++ b/tests/Titon/Route/GroupTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Route;
 
 use Titon\Test\TestCase;
@@ -8,13 +8,13 @@ use Titon\Test\TestCase;
  */
 class GroupTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new Group();
     }
 
-    public function testPrefixing() {
+    public function testPrefixing(): void {
         $this->assertEquals('', $this->object->getPrefix());
 
         $this->object->setPrefix('foo');
@@ -22,7 +22,7 @@ class GroupTest extends TestCase {
         $this->assertEquals('foo', $this->object->getPrefix());
     }
 
-    public function testSuffixing() {
+    public function testSuffixing(): void {
         $this->assertEquals('', $this->object->getSuffix());
 
         $this->object->setSuffix('bar');

--- a/tests/Titon/Route/RouteTest.hh
+++ b/tests/Titon/Route/RouteTest.hh
@@ -36,9 +36,9 @@ class RouteTest extends TestCase {
 
         $this->assertEquals(Vector {}, $route->getConditions());
 
-        $cond1 = function(): void {};
-        $cond2 = function(): void {};
-        $cond3 = function(): void {};
+        $cond1 = () ==> {};
+        $cond2 = () ==> {};
+        $cond3 = () ==> {};
 
         $route->addCondition($cond1);
         $route->addConditions(Vector {$cond3, $cond2});
@@ -335,9 +335,7 @@ class RouteTest extends TestCase {
 
     public function testIsMatchConditions(): void {
         $route = new Route('/{module}', 'Controller@action');
-        $route->addCondition(function(): bool {
-            return (strpos($_SERVER['HTTP_ACCEPT'], 'json') !== false);
-        });
+        $route->addCondition(() ==> (strpos($_SERVER['HTTP_ACCEPT'], 'json') !== false));
 
         $_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
 

--- a/tests/Titon/Route/RouteTest.hh
+++ b/tests/Titon/Route/RouteTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Route;
 
 use Titon\Test\Stub\Route\TestRouteStub;
@@ -7,7 +7,7 @@ use Titon\Utility\State\Server;
 
 class RouteTest extends TestCase {
 
-    public function testAppendPrepend() {
+    public function testAppendPrepend(): void {
         $route = new Route('/', 'Controller@action');
 
         $this->assertEquals('/', $route->getPath());
@@ -31,14 +31,14 @@ class RouteTest extends TestCase {
         $this->assertEquals('/{prefix}/before/prepend/append/after/{suffix}', $route->getPath());
     }
 
-    public function testConditions() {
+    public function testConditions(): void {
         $route = new Route('/', 'Controller@action');
 
         $this->assertEquals(Vector {}, $route->getConditions());
 
-        $cond1 = function() {};
-        $cond2 = function() {};
-        $cond3 = function() {};
+        $cond1 = function(): void {};
+        $cond2 = function(): void {};
+        $cond3 = function(): void {};
 
         $route->addCondition($cond1);
         $route->addConditions(Vector {$cond3, $cond2});
@@ -50,7 +50,7 @@ class RouteTest extends TestCase {
         $this->assertEquals(Vector {$cond2}, $route->getConditions());
     }
 
-    public function testCompile() {
+    public function testCompile(): void {
         $moduleControllerActionExt = new Route('/{module}/{controller}/{action}.{ext}', 'Controller@action');
         $moduleControllerAction = new Route('/{module}/{controller}/{action}', 'Controller@action');
         $moduleController = new Route('/{module}/{controller}', 'Controller@action');
@@ -83,12 +83,12 @@ class RouteTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\MissingPatternException
      */
-    public function testCompileMissingPattern() {
+    public function testCompileMissingPattern(): void {
         $noPattern = new Route('<missing>', 'Controller@action');
         $noPattern->compile();
     }
 
-    public function testCompileOptionalToken() {
+    public function testCompileOptionalToken(): void {
         $route = new Route('/users/[id]', 'Controller@action');
 
         $this->assertEquals('\/users\/([0-9\.]+)\/?', $route->compile());
@@ -103,21 +103,21 @@ class RouteTest extends TestCase {
         $this->assertTrue($route->isMatch('/users'));
     }
 
-    public function testDispatch() {
+    public function testDispatch(): void {
         $route = new Route('/{a}/{b}', 'Titon\Test\Stub\Route\DispatchRouteStub@noOptional');
         $route->isMatch('/foo/bar');
 
         $this->assertEquals('foobar', $route->dispatch());
     }
 
-    public function testDispatchOptional() {
+    public function testDispatchOptional(): void {
         $route = new Route('/{a}/{b?}', 'Titon\Test\Stub\Route\DispatchRouteStub@withOptional');
         $route->isMatch('/foo');
 
         $this->assertEquals('foobaz', $route->dispatch());
     }
 
-    public function testDispatchTypeHints() {
+    public function testDispatchTypeHints(): void {
         $route = new Route('/{a}/[b]/(c)', 'Titon\Test\Stub\Route\DispatchRouteStub@typeHints');
         $route->isMatch('/foo/123/bar_456');
 
@@ -127,12 +127,12 @@ class RouteTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\NoMatchException
      */
-    public function testDispatchNoMatch() {
+    public function testDispatchNoMatch(): void {
         $route = new Route('/{a}/{b}', 'Titon\Test\Stub\Route\DispatchRouteStub@noOptional');
         $route->dispatch();
     }
 
-    public function testFilters() {
+    public function testFilters(): void {
         $route = new Route('/', 'Controller@action');
 
         $this->assertEquals(Vector {}, $route->getFilters());
@@ -147,19 +147,19 @@ class RouteTest extends TestCase {
         $this->assertEquals(Vector {'baz'}, $route->getFilters());
     }
 
-    public function testGetAction() {
+    public function testGetAction(): void {
         $route = new Route('/', 'Controller@action');
 
         $this->assertEquals(shape('class' => 'Controller', 'action' => 'action'), $route->getAction());
     }
 
-    public function testGetPath() {
+    public function testGetPath(): void {
         $route = new Route('/users/profile/[id]', 'Controller@action');
 
         $this->assertEquals('/users/profile/[id]', $route->getPath());
     }
 
-    public function testIsMethod() {
+    public function testIsMethod(): void {
         $noMethod = new Route('/', 'Controller@action');
         $singleMethod = (new Route('/', 'Controller@action'))->addMethod('POST');
         $multiMethod = (new Route('/', 'Controller@action'))->setMethods(Vector {'post', 'put'});
@@ -186,7 +186,7 @@ class RouteTest extends TestCase {
         $this->assertTrue($multiMethod->isMethod());
     }
 
-    public function testIsSecure() {
+    public function testIsSecure(): void {
         $unsecureRoute = (new Route('/', 'Controller@action'))->setSecure(false);
         $secureRoute = (new Route('/', 'Controller@action'))->setSecure(true);
 
@@ -200,7 +200,7 @@ class RouteTest extends TestCase {
         $this->assertTrue($secureRoute->isSecure());
     }
 
-    public function testIsStatic() {
+    public function testIsStatic(): void {
         $route = (new Route('/', 'Controller@action'))->setStatic(false);
         $staticRoute = (new Route('/', 'Controller@action'))->setStatic(true);
         $tokenRoute = new Route('/{module}', 'Controller@action');
@@ -210,7 +210,7 @@ class RouteTest extends TestCase {
         $this->assertFalse($tokenRoute->isStatic());
     }
 
-    public function testIsMatch() {
+    public function testIsMatch(): void {
         $route = new Route('/{module}/{controller}/{action}.{ext}', 'Controller@action');
 
         $this->assertFalse($route->isMatch('/users'));
@@ -219,7 +219,7 @@ class RouteTest extends TestCase {
         $this->assertTrue($route->isMatch('/users/profile/activity.json'));
     }
 
-    public function testIsMatchAlphaPattern() {
+    public function testIsMatchAlphaPattern(): void {
         $route = (new Route('/<alpha>', 'Controller@action'))->addPattern('alpha', Route::ALPHA);
 
         $this->assertTrue($route->isMatch('/FOO'));
@@ -230,7 +230,7 @@ class RouteTest extends TestCase {
         $this->assertFalse($route->isMatch('/foo123'));
     }
 
-    public function testIsMatchAlnumPattern() {
+    public function testIsMatchAlnumPattern(): void {
         $route = new Route('/{alpha}', 'Controller@action');
 
         $this->assertTrue($route->isMatch('/FOO'));
@@ -243,7 +243,7 @@ class RouteTest extends TestCase {
         $this->assertFalse($route->isMatch('/foo+123'));
     }
 
-    public function testIsMatchNumericPattern() {
+    public function testIsMatchNumericPattern(): void {
         $route = new Route('/[numeric]', 'Controller@action');
 
         $this->assertTrue($route->isMatch('/123'));
@@ -253,7 +253,7 @@ class RouteTest extends TestCase {
         $this->assertFalse($route->isMatch('/foo'));
     }
 
-    public function testIsMatchWildcardPattern() {
+    public function testIsMatchWildcardPattern(): void {
         $route = new Route('/(wild)', 'Controller@action');
 
         $this->assertTrue($route->isMatch('/FOO'));
@@ -267,7 +267,7 @@ class RouteTest extends TestCase {
         $this->assertTrue($route->isMatch('/foo.123'));
     }
 
-    public function testIsMatchLocalePattern() {
+    public function testIsMatchLocalePattern(): void {
         $route = (new Route('/<locale>', 'Controller@action'))->addPattern('locale', Route::LOCALE);
 
         $this->assertTrue($route->isMatch('/en'));
@@ -276,7 +276,7 @@ class RouteTest extends TestCase {
         $this->assertFalse($route->isMatch('/eng'));
     }
 
-    public function testIsMatchMethod() {
+    public function testIsMatchMethod(): void {
         $route = new Route('/{module}', 'Controller@action');
 
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -293,7 +293,7 @@ class RouteTest extends TestCase {
         $this->assertFalse($route->isMatch('/foo'));
     }
 
-    public function testIsMatchSecure() {
+    public function testIsMatchSecure(): void {
         $route = new Route('/{module}', 'Controller@action');
 
         $_SERVER['HTTPS'] = 'off';
@@ -311,13 +311,13 @@ class RouteTest extends TestCase {
         $this->assertTrue($route->isMatch('/foo'));
     }
 
-    public function testIsMatchDirectEqualPath() {
+    public function testIsMatchDirectEqualPath(): void {
         $route = new Route('/foo', 'Controller@action');
 
         $this->assertTrue($route->isMatch('/foo'));
     }
 
-    public function testIsMatchTrailingSlash() {
+    public function testIsMatchTrailingSlash(): void {
         $route = new Route('/{module}', 'Controller@action');
 
         $this->assertTrue($route->isMatch('/users'));
@@ -325,7 +325,7 @@ class RouteTest extends TestCase {
         $this->assertFalse($route->isMatch('/users//'));
     }
 
-    public function testIsMatchMultipleOptionals() {
+    public function testIsMatchMultipleOptionals(): void {
         $route = new Route('/{year}/{month?}/{day?}', 'Controller@action');
 
         $this->assertTrue($route->isMatch('/2014/01/01'));
@@ -333,7 +333,7 @@ class RouteTest extends TestCase {
         $this->assertTrue($route->isMatch('/2014'));
     }
 
-    public function testIsMatchConditions() {
+    public function testIsMatchConditions(): void {
         $route = new Route('/{module}', 'Controller@action');
         $route->addCondition(function(): bool {
             return (strpos($_SERVER['HTTP_ACCEPT'], 'json') !== false);
@@ -348,7 +348,7 @@ class RouteTest extends TestCase {
         $this->assertTrue($route->isMatch('/users'));
     }
 
-    public function testMethods() {
+    public function testMethods(): void {
         $route = new Route('/', 'Controller@action');
 
         $this->assertEquals(Vector {}, $route->getMethods());
@@ -363,7 +363,7 @@ class RouteTest extends TestCase {
         $this->assertEquals(Vector {'put'}, $route->getMethods());
     }
 
-    public function testParams() {
+    public function testParams(): void {
         $route = new Route('/{module}/{controller}/{action}.{ext}', 'Controller@action');
         $route->isMatch('/users/profile/activity.json');
 
@@ -380,7 +380,7 @@ class RouteTest extends TestCase {
         $this->assertEquals(null, $route->getParam('hash'));
     }
 
-    public function testParamsOptional() {
+    public function testParamsOptional(): void {
         $route = new TestRouteStub('/blog/[year]/[month]/[day?]', 'Module\Controller@action');
         $route->isMatch('/blog/2014/02');
 
@@ -403,7 +403,7 @@ class RouteTest extends TestCase {
         }, $route->getParams());
     }
 
-    public function testPatterns() {
+    public function testPatterns(): void {
         $route = new Route('/', 'Controller@action');
 
         $this->assertEquals(Map {}, $route->getPatterns());
@@ -418,7 +418,7 @@ class RouteTest extends TestCase {
         $this->assertEquals(Map {'key' => '[A-Z]+'}, $route->getPatterns());
     }
 
-    public function testTokens() {
+    public function testTokens(): void {
         $route = new Route('/{string}', 'Controller@action');
         $this->assertEquals('\/([a-z0-9\_\-\.]+)\/?', $route->compile());
 
@@ -463,7 +463,7 @@ class RouteTest extends TestCase {
         $this->assertEquals('\/([^\/]+)\/([a-z0-9\_\-\.]+)\/([a-z]\-[A-Z])(?:\/([0-9\.]+))?\/?', $route->compile());
     }
 
-    public function testSerialize() {
+    public function testSerialize(): void {
         $route = new Route('/{module}/{controller}/{action}.{ext}', 'Controller@action');
         $route->addFilter('foo');
         $route->addMethod('post');

--- a/tests/Titon/Route/RouteTest.hh
+++ b/tests/Titon/Route/RouteTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Route;
 
 use Titon\Test\Stub\Route\TestRouteStub;
@@ -36,9 +36,9 @@ class RouteTest extends TestCase {
 
         $this->assertEquals(Vector {}, $route->getConditions());
 
-        $cond1 = () ==> {};
-        $cond2 = () ==> {};
-        $cond3 = () ==> {};
+        $cond1 = ($route) ==> { return true; };
+        $cond2 = ($route) ==> { return true; };
+        $cond3 = ($route) ==> { return true; };
 
         $route->addCondition($cond1);
         $route->addConditions(Vector {$cond3, $cond2});

--- a/tests/Titon/Route/RouteTest.hh
+++ b/tests/Titon/Route/RouteTest.hh
@@ -1,6 +1,7 @@
 <?hh
 namespace Titon\Route;
 
+use Titon\Test\Stub\Route\TestRouteStub;
 use Titon\Test\TestCase;
 use Titon\Utility\State\Server;
 
@@ -103,21 +104,21 @@ class RouteTest extends TestCase {
     }
 
     public function testDispatch() {
-        $route = new Route('/{a}/{b}', 'Titon\Route\TestDispatch@noOptional');
+        $route = new Route('/{a}/{b}', 'Titon\Test\Stub\Route\DispatchRouteStub@noOptional');
         $route->isMatch('/foo/bar');
 
         $this->assertEquals('foobar', $route->dispatch());
     }
 
     public function testDispatchOptional() {
-        $route = new Route('/{a}/{b?}', 'Titon\Route\TestDispatch@withOptional');
+        $route = new Route('/{a}/{b?}', 'Titon\Test\Stub\Route\DispatchRouteStub@withOptional');
         $route->isMatch('/foo');
 
         $this->assertEquals('foobaz', $route->dispatch());
     }
 
     public function testDispatchTypeHints() {
-        $route = new Route('/{a}/[b]/(c)', 'Titon\Route\TestDispatch@typeHints');
+        $route = new Route('/{a}/[b]/(c)', 'Titon\Test\Stub\Route\DispatchRouteStub@typeHints');
         $route->isMatch('/foo/123/bar_456');
 
         $this->assertEquals('foo123bar_456', $route->dispatch());
@@ -127,7 +128,7 @@ class RouteTest extends TestCase {
      * @expectedException \Titon\Route\Exception\NoMatchException
      */
     public function testDispatchNoMatch() {
-        $route = new Route('/{a}/{b}', 'Titon\Route\TestDispatch@noOptional');
+        $route = new Route('/{a}/{b}', 'Titon\Test\Stub\Route\DispatchRouteStub@noOptional');
         $route->dispatch();
     }
 
@@ -380,7 +381,7 @@ class RouteTest extends TestCase {
     }
 
     public function testParamsOptional() {
-        $route = new TestRoute('/blog/[year]/[month]/[day?]', 'Module\Controller@action');
+        $route = new TestRouteStub('/blog/[year]/[month]/[day?]', 'Module\Controller@action');
         $route->isMatch('/blog/2014/02');
 
         $this->assertEquals('/blog/2014/02', $route->url());
@@ -476,18 +477,4 @@ class RouteTest extends TestCase {
         $this->assertEquals($route, unserialize($serialized));
     }
 
-}
-
-class TestDispatch {
-    public function noOptional(string $a, string $b): string {
-        return $a . $b;
-    }
-
-    public function withOptional(string $a, string $b = 'baz'): string {
-        return $a . $b;
-    }
-
-    public function typeHints(string $a, int $b, string $c): string {
-        return $a . $b . $c;
-    }
 }

--- a/tests/Titon/Route/RouterTest.hh
+++ b/tests/Titon/Route/RouterTest.hh
@@ -75,14 +75,14 @@ class RouterTest extends TestCase {
         $stub = new FilterStub();
 
         $this->object->filter('test', $stub);
-        $this->object->filterCallback('test2', function(): void {});
+        $this->object->filterCallback('test2', () ==> {});
 
         $this->assertEquals(inst_meth($stub, 'filter'), $this->object->getFilter('test'));
         $this->assertEquals(Vector {'test', 'test2'}, $this->object->getFilters()->keys());
 
         // Filtering is passed to routes
         $this->object->map('f1', (new Route('/f1', 'Controller@action'))->addFilter('test2'));
-        $this->object->group(function(Router $router, Group $group): void {
+        $this->object->group(($router, $group) ==> {
             $group->setFilters(Vector {'test'});
 
             $router->map('f2', new Route('/f2', 'Controller@action'));
@@ -112,7 +112,7 @@ class RouterTest extends TestCase {
         });
 
         $router->map('f1', (new Route('/f1', 'Controller@action'))->addFilter('test'));
-        $router->group(function(Router $router, Group $group): void {
+        $router->group(($router, $group) ==> {
             $group->setFilters(Vector {'test'});
 
             $router->map('f2', new Route('/f2', 'Controller@action'));
@@ -143,7 +143,7 @@ class RouterTest extends TestCase {
     }
 
     public function testGroupPrefixing(): void {
-        $this->object->group(function(Router $router, Group $group) {
+        $this->object->group(($router, $group) ==> {
             $group->setPrefix('/pre/');
 
             $router->map('group1', new Route('/group-1', 'Controller@action'));
@@ -161,7 +161,7 @@ class RouterTest extends TestCase {
     }
 
     public function testGroupSuffixing(): void {
-        $this->object->group(function(Router $router, Group $group) {
+        $this->object->group(($router, $group) ==> {
             $group->setSuffix('/post/');
 
             $router->map('group1', new Route('/group-1', 'Controller@action'));
@@ -179,7 +179,7 @@ class RouterTest extends TestCase {
     }
 
     public function testGroupSecure(): void {
-        $this->object->group(function(Router $router, Group $group) {
+        $this->object->group(($router, $group) ==> {
             $group->setSecure(true);
 
             $router->map('group1', new Route('/group-1', 'Controller@action'));
@@ -197,7 +197,7 @@ class RouterTest extends TestCase {
     }
 
     public function testGroupPatterns(): void {
-        $this->object->group(function(Router $router, Group $group) {
+        $this->object->group(($router, $group) ==> {
             $group->setPrefix('<token>');
             $group->addPattern('token', '([abcd]+)');
 
@@ -221,10 +221,10 @@ class RouterTest extends TestCase {
     }
 
     public function testGroupConditions(): void {
-        $cond1 = function(): void {};
-        $cond2 = function(): void {};
+        $cond1 = () ==> {};
+        $cond2 = () ==> {};
 
-        $this->object->group(function(Router $router, Group $group) use ($cond1, $cond2) {
+        $this->object->group(($router, $group) ==> {
             $group->setConditions(Vector {$cond1, $cond2});
 
             $router->map('group1', new Route('/group-1', 'Controller@action'));
@@ -242,12 +242,12 @@ class RouterTest extends TestCase {
     }
 
     public function testGroupNesting(): void {
-        $this->object->group(function(Router $router, Group $group1) {
+        $this->object->group(($router, $group1) ==> {
             $group1->setPrefix('/pre/');
 
             $router->map('group1', new Route('/group-1', 'Controller@action'));
 
-            $router->group(function(Router $router, Group $group2) {
+            $router->group(($router, $group2) ==> {
                 $group2->setSuffix('/post');
 
                 $router->map('group2', new Route('/group-2', 'Controller@action'));
@@ -265,17 +265,17 @@ class RouterTest extends TestCase {
     }
 
     public function testGroupNestingInherits(): void {
-        $this->object->group(function(Router $router, Group $group1) {
+        $this->object->group(($router, $group1) ==> {
             $group1->setFilters(Vector {'foo'})->setMethods(Vector {'get'});
 
             $router->map('group1', new Route('/group-1', 'Controller@action'));
 
-            $router->group(function(Router $router, Group $group2) {
+            $router->group(($router, $group2) ==> {
                 $group2->setFilters(Vector {'bar'});
 
                 $router->map('group2', new Route('/group-2', 'Controller@action'));
 
-                $router->group(function(Router $router, Group $group3) {
+                $router->group(($router, $group3) ==> {
                     $group3->setMethods(Vector {'post'});
 
                     $router->map('group3', new Route('/group-3', 'Controller@action'));

--- a/tests/Titon/Route/RouterTest.hh
+++ b/tests/Titon/Route/RouterTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Route;
 
 use Titon\Cache\Storage\MemoryStorage;
@@ -14,7 +14,7 @@ use Titon\Context\Depository;
  */
 class RouterTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $container = Depository::getInstance();
@@ -30,16 +30,16 @@ class RouterTest extends TestCase {
         $this->object->map('root', new TestRouteStub('/', 'Module\Controller@action'));
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         Depository::getInstance()->remove('Titon\Route\Router');
         Depository::getInstance()->remove('Titon\Route\UrlBuilder');
     }
 
-    public function testBuildAction() {
+    public function testBuildAction(): void {
         $this->assertEquals('Controller@action', Router::buildAction(shape('class' => 'Controller', 'action' => 'action')));
     }
 
-    public function testCaching() {
+    public function testCaching(): void {
         $storage = new MemoryStorage();
         $route1 = new Route('/{module}', 'Module\Controller@action');
         $route2 = new Route('/', 'Module\Controller@action');
@@ -71,18 +71,18 @@ class RouterTest extends TestCase {
         $this->assertEquals('/', $router2->getRoute('root')->getPath());
     }
 
-    public function testFilters() {
+    public function testFilters(): void {
         $stub = new FilterStub();
 
         $this->object->filter('test', $stub);
-        $this->object->filterCallback('test2', function() {});
+        $this->object->filterCallback('test2', function(): void {});
 
         $this->assertEquals(inst_meth($stub, 'filter'), $this->object->getFilter('test'));
         $this->assertEquals(Vector {'test', 'test2'}, $this->object->getFilters()->keys());
 
         // Filtering is passed to routes
         $this->object->map('f1', (new Route('/f1', 'Controller@action'))->addFilter('test2'));
-        $this->object->group(function(Router $router, Group $group) {
+        $this->object->group(function(Router $router, Group $group): void {
             $group->setFilters(Vector {'test'});
 
             $router->map('f2', new Route('/f2', 'Controller@action'));
@@ -99,11 +99,11 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\MissingFilterException
      */
-    public function testFilterMissingKey() {
+    public function testFilterMissingKey(): void {
         $this->object->getFilter('fakeKey');
     }
 
-    public function testFilterIsTriggered() {
+    public function testFilterIsTriggered(): void {
         $router = new Router();
         $count = 0;
 
@@ -112,7 +112,7 @@ class RouterTest extends TestCase {
         });
 
         $router->map('f1', (new Route('/f1', 'Controller@action'))->addFilter('test'));
-        $router->group(function(Router $router, Group $group) {
+        $router->group(function(Router $router, Group $group): void {
             $group->setFilters(Vector {'test'});
 
             $router->map('f2', new Route('/f2', 'Controller@action'));
@@ -132,7 +132,7 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Exception
      */
-    public function testFilterCanThrowException() {
+    public function testFilterCanThrowException(): void {
         $this->object->filterCallback('test', function() use (&$count) {
             throw new \Exception('Filter error!');
         });
@@ -142,7 +142,7 @@ class RouterTest extends TestCase {
         $this->object->match('/');
     }
 
-    public function testGroupPrefixing() {
+    public function testGroupPrefixing(): void {
         $this->object->group(function(Router $router, Group $group) {
             $group->setPrefix('/pre/');
 
@@ -160,7 +160,7 @@ class RouterTest extends TestCase {
         $this->assertEquals('/solo', $routes['solo']->getPath());
     }
 
-    public function testGroupSuffixing() {
+    public function testGroupSuffixing(): void {
         $this->object->group(function(Router $router, Group $group) {
             $group->setSuffix('/post/');
 
@@ -178,7 +178,7 @@ class RouterTest extends TestCase {
         $this->assertEquals('/solo', $routes['solo']->getPath());
     }
 
-    public function testGroupSecure() {
+    public function testGroupSecure(): void {
         $this->object->group(function(Router $router, Group $group) {
             $group->setSecure(true);
 
@@ -196,7 +196,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(false, $routes['solo']->getSecure());
     }
 
-    public function testGroupPatterns() {
+    public function testGroupPatterns(): void {
         $this->object->group(function(Router $router, Group $group) {
             $group->setPrefix('<token>');
             $group->addPattern('token', '([abcd]+)');
@@ -220,9 +220,9 @@ class RouterTest extends TestCase {
         $this->assertEquals(Map {}, $routes['solo']->getPatterns());
     }
 
-    public function testGroupConditions() {
-        $cond1 = function() {};
-        $cond2 = function() {};
+    public function testGroupConditions(): void {
+        $cond1 = function(): void {};
+        $cond2 = function(): void {};
 
         $this->object->group(function(Router $router, Group $group) use ($cond1, $cond2) {
             $group->setConditions(Vector {$cond1, $cond2});
@@ -241,7 +241,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {}, $routes['solo']->getConditions());
     }
 
-    public function testGroupNesting() {
+    public function testGroupNesting(): void {
         $this->object->group(function(Router $router, Group $group1) {
             $group1->setPrefix('/pre/');
 
@@ -264,7 +264,7 @@ class RouterTest extends TestCase {
         $this->assertEquals('/solo', $routes['solo']->getPath());
     }
 
-    public function testGroupNestingInherits() {
+    public function testGroupNestingInherits(): void {
         $this->object->group(function(Router $router, Group $group1) {
             $group1->setFilters(Vector {'foo'})->setMethods(Vector {'get'});
 
@@ -294,7 +294,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {'get', 'post'}, $routes['group3']->getMethods());
     }
 
-    public function testHttpMapping() {
+    public function testHttpMapping(): void {
         $this->object->map('url1', new Route('/url', 'Controller@action'));
         $this->object->get('url2', new Route('/url', 'Controller@action'));
         $this->object->post('url3', new Route('/url', 'Controller@action'));
@@ -316,7 +316,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {'get', 'post'}, $routes['url8']->getMethods());
     }
 
-    public function testLoopMatch() {
+    public function testLoopMatch(): void {
         $route = $this->object->match('/');
         $this->assertEquals('/', $route->getPath());
         $this->assertEquals($route, $this->object->current());
@@ -337,11 +337,11 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\NoMatchException
      */
-    public function testLoopMatchNoMatch() {
+    public function testLoopMatchNoMatch(): void {
         $this->object->match('/path~tilde');
     }
 
-    public function testParseAction() {
+    public function testParseAction(): void {
         $this->assertEquals(shape(
             'class' => 'Controller',
             'action' => 'action'
@@ -386,11 +386,11 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\InvalidRouteActionException
      */
-    public function testParseActionInvalidRoute() {
+    public function testParseActionInvalidRoute(): void {
         Router::parseAction('Broken+Route');
     }
 
-    public function testPrgMapping() {
+    public function testPrgMapping(): void {
         $this->object->prg('prg', (new Route('/foo', 'Controller@action'))->addFilter('auth'));
 
         $routes = $this->object->getRoutes();
@@ -417,7 +417,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {'auth'}, $routes['prg.post']->getFilters());
     }
 
-    public function testResourceMap() {
+    public function testResourceMap(): void {
         $this->assertEquals(Map {
             'list' => 'index',
             'create' => 'create',
@@ -442,7 +442,7 @@ class RouterTest extends TestCase {
         }, $this->object->getResourceMap());
     }
 
-    public function testResourceMapping() {
+    public function testResourceMapping(): void {
         $this->object->resource('rest', new Route('/rest', 'Api\Rest@action'));
 
         $routes = $this->object->getRoutes();
@@ -477,7 +477,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {'delete', 'post'}, $routes['rest.delete']->getMethods());
     }
 
-    public function TestRouteStubs() {
+    public function TestRouteStubs(): void {
         $route = new Route('/', 'Controller@action');
         $router = new Router();
         $router->map('key', $route);
@@ -489,11 +489,11 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\MissingRouteException
      */
-    public function TestRouteStubsMissingKey() {
+    public function TestRouteStubsMissingKey(): void {
         $this->object->getRoute('fakeKey');
     }
 
-    public function testSegments() {
+    public function testSegments(): void {
         $_SERVER['DOCUMENT_ROOT'] = '';
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['SCRIPT_FILENAME'] = '/index.php';
@@ -601,11 +601,11 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\MissingSegmentException
      */
-    public function testSegmentsMissingKey() {
+    public function testSegmentsMissingKey(): void {
         $this->object->getSegment('fakeKey');
     }
 
-    public function testWireClassMapping() {
+    public function testWireClassMapping(): void {
         $this->object->wire('Titon\Test\Stub\Route\RouteAnnotatedStub');
 
         $routes = $this->object->getRoutes();
@@ -640,7 +640,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {'delete', 'post'}, $routes['parent.delete']->getMethods());
     }
 
-    public function testWireMethodMapping() {
+    public function testWireMethodMapping(): void {
         $this->object->wire('Titon\Test\Stub\Route\RouteAnnotatedStub');
 
         $routes = $this->object->getRoutes();

--- a/tests/Titon/Route/RouterTest.hh
+++ b/tests/Titon/Route/RouterTest.hh
@@ -2,6 +2,8 @@
 namespace Titon\Route;
 
 use Titon\Cache\Storage\MemoryStorage;
+use Titon\Test\Stub\Route\FilterStub;
+use Titon\Test\Stub\Route\TestRouteStub;
 use Titon\Test\TestCase;
 use Titon\Utility\State\Get;
 use Titon\Utility\State\Server;
@@ -16,15 +18,16 @@ class RouterTest extends TestCase {
         parent::setUp();
 
         $container = Depository::getInstance();
-
         $container->singleton('Titon\Route\Router');
+
         $this->object = Depository::getInstance()->make('Titon\Route\Router');
         $container->register('Titon\Route\UrlBuilder')->with($this->object);
-        $this->object->map('action.ext', new TestRoute('/{module}/{controller}/{action}.{ext}', 'Module\Controller@action'));
-        $this->object->map('action', new TestRoute('/{module}/{controller}/{action}', 'Module\Controller@action'));
-        $this->object->map('controller', new TestRoute('/{module}/{controller}', 'Module\Controller@action'));
-        $this->object->map('module', new TestRoute('/{module}', 'Module\Controller@action'));
-        $this->object->map('root', new TestRoute('/', 'Module\Controller@action'));
+
+        $this->object->map('action.ext', new TestRouteStub('/{module}/{controller}/{action}.{ext}', 'Module\Controller@action'));
+        $this->object->map('action', new TestRouteStub('/{module}/{controller}/{action}', 'Module\Controller@action'));
+        $this->object->map('controller', new TestRouteStub('/{module}/{controller}', 'Module\Controller@action'));
+        $this->object->map('module', new TestRouteStub('/{module}', 'Module\Controller@action'));
+        $this->object->map('root', new TestRouteStub('/', 'Module\Controller@action'));
     }
 
     protected function tearDown() {
@@ -65,7 +68,6 @@ class RouterTest extends TestCase {
         $this->assertEquals(Map {'module' => $route1, 'root' => $route2}, $router2->getRoutes());
 
         // The previous routes should be overwritten
-
         $this->assertEquals('/', $router2->getRoute('root')->getPath());
     }
 
@@ -475,7 +477,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {'delete', 'post'}, $routes['rest.delete']->getMethods());
     }
 
-    public function testRoutes() {
+    public function TestRouteStubs() {
         $route = new Route('/', 'Controller@action');
         $router = new Router();
         $router->map('key', $route);
@@ -487,7 +489,7 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\MissingRouteException
      */
-    public function testRoutesMissingKey() {
+    public function TestRouteStubsMissingKey() {
         $this->object->getRoute('fakeKey');
     }
 
@@ -604,7 +606,7 @@ class RouterTest extends TestCase {
     }
 
     public function testWireClassMapping() {
-        $this->object->wire('Titon\Route\AnnotationStub');
+        $this->object->wire('Titon\Test\Stub\Route\RouteAnnotatedStub');
 
         $routes = $this->object->getRoutes();
 
@@ -617,18 +619,18 @@ class RouterTest extends TestCase {
         $this->assertTrue(isset($routes['parent.delete']));
 
         // Paths
-        $this->assertEquals('/parent', $routes['parent.list']->getPath());
-        $this->assertEquals('/parent', $routes['parent.create']->getPath());
-        $this->assertEquals('/parent/{id}', $routes['parent.read']->getPath());
-        $this->assertEquals('/parent/{id}', $routes['parent.update']->getPath());
-        $this->assertEquals('/parent/{id}', $routes['parent.delete']->getPath());
+        $this->assertEquals('/controller', $routes['parent.list']->getPath());
+        $this->assertEquals('/controller', $routes['parent.create']->getPath());
+        $this->assertEquals('/controller/{id}', $routes['parent.read']->getPath());
+        $this->assertEquals('/controller/{id}', $routes['parent.update']->getPath());
+        $this->assertEquals('/controller/{id}', $routes['parent.delete']->getPath());
 
         // Action
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'index'), $routes['parent.list']->getAction());
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'create'), $routes['parent.create']->getAction());
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'read'), $routes['parent.read']->getAction());
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'update'), $routes['parent.update']->getAction());
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'delete'), $routes['parent.delete']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'index'), $routes['parent.list']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'create'), $routes['parent.create']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'read'), $routes['parent.read']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'update'), $routes['parent.update']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'delete'), $routes['parent.delete']->getAction());
 
         // Method
         $this->assertEquals(Vector {'get'}, $routes['parent.list']->getMethods());
@@ -639,7 +641,7 @@ class RouterTest extends TestCase {
     }
 
     public function testWireMethodMapping() {
-        $this->object->wire('Titon\Route\AnnotationStub');
+        $this->object->wire('Titon\Test\Stub\Route\RouteAnnotatedStub');
 
         $routes = $this->object->getRoutes();
 
@@ -656,10 +658,10 @@ class RouterTest extends TestCase {
         $this->assertEquals('/qux', $routes['qux']->getPath());
 
         // Action
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'foo'), $routes['foo']->getAction());
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'bar'), $routes['bar']->getAction());
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'baz'), $routes['baz']->getAction());
-        $this->assertEquals(shape('class' => 'Titon\Route\AnnotationStub', 'action' => 'qux'), $routes['qux']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'foo'), $routes['foo']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'bar'), $routes['bar']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'baz'), $routes['baz']->getAction());
+        $this->assertEquals(shape('class' => 'Titon\Test\Stub\Route\RouteAnnotatedStub', 'action' => 'qux'), $routes['qux']->getAction());
 
         // Method
         $this->assertEquals(Vector {}, $routes['foo']->getMethods());
@@ -679,36 +681,5 @@ class RouterTest extends TestCase {
         $this->assertEquals(Map {}, $routes['baz']->getPatterns());
         $this->assertEquals(Map {'id' => '[1-8]+'}, $routes['qux']->getPatterns());
     }
-
-}
-
-class FilterStub implements Filter {
-    public function filter(Router $router, Route $route): void {
-        return;
-    }
-}
-
-class TestRoute extends Route {
-    public function __construct(string $path, string $action) {
-        parent::__construct($path, $action);
-
-        $this->compile();
-    }
-}
-
-<<Route('parent', '/parent')>>
-class AnnotationStub {
-
-    <<Route('foo', '/foo')>>
-    public function foo(): void {}
-
-    <<Route('bar', '/bar', 'POST')>>
-    public function bar(): void {}
-
-    <<Route('baz', '/baz', ['get'], ['auth', 'guest'])>>
-    public function baz(): void {}
-
-    <<Route('qux', '/qux', ['PUT', 'POST'], [], ['id' => '[1-8]+'])>>
-    public function qux(): void {}
 
 }

--- a/tests/Titon/Route/UrlBuilderTest.hh
+++ b/tests/Titon/Route/UrlBuilderTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Route;
 
 use Titon\Context\Depository;
@@ -29,13 +29,18 @@ class UrlBuilderTest extends TestCase {
         $container = Depository::getInstance();
 
         $router = $container->make('Titon\Route\Router');
+
+        invariant($router instanceof Router, 'Must be a Router.');
+
         $router->map('action.ext', new TestRouteStub('/{module}/{controller}/{action}.{ext}', 'Module\Controller@action'));
         $router->map('action', new TestRouteStub('/{module}/{controller}/{action}', 'Module\Controller@action'));
         $router->map('controller', new TestRouteStub('/{module}/{controller}', 'Module\Controller@action'));
         $router->map('module', new TestRouteStub('/{module}', 'Module\Controller@action'));
         $router->map('root', new TestRouteStub('/', 'Module\Controller@action'));
 
-        $this->object = $container->make('Titon\Route\UrlBuilder');
+        $this->object = $builder = $container->make('Titon\Route\UrlBuilder');
+
+        invariant($builder instanceof UrlBuilder, 'Must be a UrlBuilder.');
     }
 
     public function testBuild(): void {

--- a/tests/Titon/Route/UrlBuilderTest.hh
+++ b/tests/Titon/Route/UrlBuilderTest.hh
@@ -2,7 +2,7 @@
 namespace Titon\Route;
 
 use Titon\Context\Depository;
-use Titon\Context\Exception\AlreadyRegisteredException;
+use Titon\Test\Stub\Route\TestRouteStub;
 use Titon\Test\TestCase;
 use Titon\Utility\Config;
 use Titon\Utility\State\Get;
@@ -15,7 +15,6 @@ class UrlBuilderTest extends TestCase {
 
     public static function setUpBeforeClass() {
         $container = Depository::getInstance();
-
         $container->singleton('Titon\Route\Router');
         $container->register('Titon\Route\UrlBuilder')->with($container->make('Titon\Route\Router'));
     }
@@ -30,11 +29,11 @@ class UrlBuilderTest extends TestCase {
         $container = Depository::getInstance();
 
         $router = $container->make('Titon\Route\Router');
-        $router->map('action.ext', new TestRoute('/{module}/{controller}/{action}.{ext}', 'Module\Controller@action'));
-        $router->map('action', new TestRoute('/{module}/{controller}/{action}', 'Module\Controller@action'));
-        $router->map('controller', new TestRoute('/{module}/{controller}', 'Module\Controller@action'));
-        $router->map('module', new TestRoute('/{module}', 'Module\Controller@action'));
-        $router->map('root', new TestRoute('/', 'Module\Controller@action'));
+        $router->map('action.ext', new TestRouteStub('/{module}/{controller}/{action}.{ext}', 'Module\Controller@action'));
+        $router->map('action', new TestRouteStub('/{module}/{controller}/{action}', 'Module\Controller@action'));
+        $router->map('controller', new TestRouteStub('/{module}/{controller}', 'Module\Controller@action'));
+        $router->map('module', new TestRouteStub('/{module}', 'Module\Controller@action'));
+        $router->map('root', new TestRouteStub('/', 'Module\Controller@action'));
 
         $this->object = $container->make('Titon\Route\UrlBuilder');
     }
@@ -57,7 +56,7 @@ class UrlBuilderTest extends TestCase {
     }
 
     public function testBuildOptionalToken() {
-        $this->object->getRouter()->map('blog.archives', new TestRoute('/blog/[year]/[month]/[day?]', 'Module\Controller@action'));
+        $this->object->getRouter()->map('blog.archives', new TestRouteStub('/blog/[year]/[month]/[day?]', 'Module\Controller@action'));
 
         $this->assertEquals('/blog/2012/2', $this->object->build('blog.archives', Map {'year' => 2012, 'month' => 02}));
         $this->assertEquals('/blog/2012/2/26', $this->object->build('blog.archives', Map {'year' => 2012, 'month' => 02, 'day' => 26}));
@@ -70,7 +69,7 @@ class UrlBuilderTest extends TestCase {
         Server::initialize($_SERVER);
 
         $router = new Router();
-        $router->map('module', new TestRoute('/{module}', 'Module\Controller@action'));
+        $router->map('module', new TestRouteStub('/{module}', 'Module\Controller@action'));
 
         $builder = new UrlBuilder($router);
 

--- a/tests/Titon/Route/UrlBuilderTest.hh
+++ b/tests/Titon/Route/UrlBuilderTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Route;
 
 use Titon\Context\Depository;
@@ -13,17 +13,17 @@ use Titon\Utility\State\Server;
  */
 class UrlBuilderTest extends TestCase {
 
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         $container = Depository::getInstance();
         $container->singleton('Titon\Route\Router');
         $container->register('Titon\Route\UrlBuilder')->with($container->make('Titon\Route\Router'));
     }
 
-    public static function tearDownAfterClass() {
+    public static function tearDownAfterClass(): void {
         Depository::getInstance()->clear();
     }
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $container = Depository::getInstance();
@@ -38,31 +38,31 @@ class UrlBuilderTest extends TestCase {
         $this->object = $container->make('Titon\Route\UrlBuilder');
     }
 
-    public function testBuild() {
+    public function testBuild(): void {
         $this->assertEquals('/', $this->object->build('root'));
         $this->assertEquals('/users', $this->object->build('module', Map {'module' => 'users'}));
         $this->assertEquals('/users/profile/feed.json', $this->object->build('action.ext', Map {'module' => 'users', 'controller' => 'profile', 'action' => 'feed', 'ext' => 'json'}));
     }
 
-    public function testBuildQueryString() {
+    public function testBuildQueryString(): void {
         $this->assertEquals('/users?foo=bar', $this->object->build('module', Map {'module' => 'users'}, Map {'foo' => 'bar'}));
         $this->assertEquals('/users?foo=bar&baz%5B0%5D=1&baz%5B1%5D=2&baz%5B2%5D=3', $this->object->build('module', Map {'module' => 'users'}, Map {'foo' => 'bar', 'baz' => Vector{1, 2, 3}}));
     }
 
-    public function testBuildHashFragment() {
+    public function testBuildHashFragment(): void {
         $this->assertEquals('/users#foobar', $this->object->build('module', Map {'module' => 'users'}, Map {'#' => 'foobar'}));
         $this->assertEquals('/users#foo=bar', $this->object->build('module', Map {'module' => 'users'}, Map {'#' => Map {'foo' => 'bar'}}));
         $this->assertEquals('/users?key=value#foobar', $this->object->build('module', Map {'module' => 'users'}, Map {'#' => 'foobar', 'key' => 'value'}));
     }
 
-    public function testBuildOptionalToken() {
+    public function testBuildOptionalToken(): void {
         $this->object->getRouter()->map('blog.archives', new TestRouteStub('/blog/[year]/[month]/[day?]', 'Module\Controller@action'));
 
         $this->assertEquals('/blog/2012/2', $this->object->build('blog.archives', Map {'year' => 2012, 'month' => 02}));
         $this->assertEquals('/blog/2012/2/26', $this->object->build('blog.archives', Map {'year' => 2012, 'month' => 02, 'day' => 26}));
     }
 
-    public function testBuildInBaseFolder() {
+    public function testBuildInBaseFolder(): void {
         $_SERVER['DOCUMENT_ROOT'] = '/root';
         $_SERVER['SCRIPT_FILENAME'] = '/root/base/index.php';
 
@@ -77,7 +77,7 @@ class UrlBuilderTest extends TestCase {
         $this->assertEquals('/base/users', $builder->build('module', Map {'module' => 'users'}));
     }
 
-    public function testBuildWithLocale() {
+    public function testBuildWithLocale(): void {
         $route = new Route('/<locale>/{module}', 'Module\Controller@action');
         $route->addPattern('locale', Route::LOCALE)->compile();
 
@@ -92,17 +92,17 @@ class UrlBuilderTest extends TestCase {
         Config::remove('titon.locale.current');
     }
 
-    public function testBuildTokenInflection() {
+    public function testBuildTokenInflection(): void {
         $this->assertEquals('/download-center', $this->object->build('module', Map {'module' => 'download_center'}));
         $this->assertEquals('/customer-support', $this->object->build('module', Map {'module' => 'cusToMer-SuPPorT@#&(#'}));
         $this->assertEquals('/users/profile/feed.json', $this->object->build('action.ext', Map {'module' => 'Users', 'controller' => 'ProfILE', 'action' => 'feeD', 'ext' => 'JSON'}));
     }
 
-    public function testBuildLinkToFunction() {
+    public function testBuildLinkToFunction(): void {
         $this->assertEquals('/users/profile/feed.json', link_to('action.ext', Map {'module' => 'users', 'controller' => 'profile', 'action' => 'feed', 'ext' => 'json'}));
     }
 
-    public function testBuildCaching() {
+    public function testBuildCaching(): void {
         $this->assertFalse($this->object->hasCache('Titon\Route\UrlBuilder::build-module-97a181b0b36bd36f504742ea2acd6746'));
 
         $this->assertEquals('/users', $this->object->build('module', Map {'module' => 'users'}));
@@ -116,18 +116,18 @@ class UrlBuilderTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\MissingRouteException
      */
-    public function testBuildInvalidKey() {
+    public function testBuildInvalidKey(): void {
         $this->object->build('foobar');
     }
 
     /**
      * @expectedException \Titon\Route\Exception\MissingTokenException
      */
-    public function testBuildMissingToken() {
+    public function testBuildMissingToken(): void {
         $this->object->build('module');
     }
 
-    public function testUrl() {
+    public function testUrl(): void {
         $_SERVER['DOCUMENT_ROOT'] = '/root';
         $_SERVER['HTTP_HOST'] = 'sub.domain.com';
         $_SERVER['SCRIPT_FILENAME'] = '/root/base/app/index.php';

--- a/tests/Titon/Test/Stub/Annotation/BarAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/BarAnnotationStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Annotation;
+
+use Titon\Annotation\Annotation;
+
+class BarAnnotationStub extends Annotation {
+    public function __construct(public string $string, public int $int = 0) {}
+}

--- a/tests/Titon/Test/Stub/Annotation/BarAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/BarAnnotationStub.hh
@@ -1,8 +1,8 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Annotation;
 
 use Titon\Annotation\Annotation;
 
 class BarAnnotationStub extends Annotation {
-    public function __construct(public string $string, public int $int = 0) {}
+    public function __construct(public string $string, public int $int = 0): void {}
 }

--- a/tests/Titon/Test/Stub/Annotation/BazAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/BazAnnotationStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Annotation;
+
+use Titon\Annotation\Annotation;
+
+class BazAnnotationStub extends Annotation {
+    public function __construct(public array<mixed, mixed> $array) {}
+}

--- a/tests/Titon/Test/Stub/Annotation/BazAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/BazAnnotationStub.hh
@@ -1,8 +1,8 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Annotation;
 
 use Titon\Annotation\Annotation;
 
 class BazAnnotationStub extends Annotation {
-    public function __construct(public array<mixed, mixed> $array) {}
+    public function __construct(public array<mixed, mixed> $array): void {}
 }

--- a/tests/Titon/Test/Stub/Annotation/FooAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/FooAnnotationStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Annotation;
 
 use Titon\Annotation\Annotation;

--- a/tests/Titon/Test/Stub/Annotation/FooAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/FooAnnotationStub.hh
@@ -1,0 +1,6 @@
+<?hh
+namespace Titon\Test\Stub\Annotation;
+
+use Titon\Annotation\Annotation;
+
+class FooAnnotationStub extends Annotation {}

--- a/tests/Titon/Test/Stub/Annotation/ReaderStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/ReaderStub.hh
@@ -1,0 +1,11 @@
+<?hh
+namespace Titon\Test\Stub\Annotation;
+
+<<Foo, Bar('abc', 123)>>
+class ReaderStub {
+
+    <<Baz(['a' => 1])>>
+    public function hasAnno(): void {}
+
+    public function noAnno(): void {}
+}

--- a/tests/Titon/Test/Stub/Annotation/ReaderStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/ReaderStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Annotation;
 
 <<Foo, Bar('abc', 123)>>

--- a/tests/Titon/Test/Stub/Annotation/WireAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/WireAnnotationStub.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Annotation;
 
 use Titon\Annotation\Annotation;
 use Titon\Annotation\Wireable;
 
 class WireAnnotationStub extends Annotation implements Wireable {
-    public function __construct(public string $type, public string $message) {}
+    public function __construct(public string $type, public string $message): void {}
 
     public function wire<T>(T $class, string $method = ''): this {
         if ($method) {

--- a/tests/Titon/Test/Stub/Annotation/WireAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/WireAnnotationStub.hh
@@ -1,0 +1,17 @@
+<?hh
+namespace Titon\Test\Stub\Annotation;
+
+use Titon\Annotation\Annotation;
+use Titon\Annotation\Wireable;
+
+class WireAnnotationStub extends Annotation implements Wireable {
+    public function __construct(public string $type, public string $message) {}
+
+    public function wire<T>(T $class, string $method = ''): this {
+        if ($method) {
+            $class->{$this->type}[$method] = $this->message;
+        } else {
+            $class->{$this->type} = $this->message;
+        }
+    }
+}

--- a/tests/Titon/Test/Stub/Annotation/WireAnnotationStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/WireAnnotationStub.hh
@@ -5,13 +5,16 @@ use Titon\Annotation\Annotation;
 use Titon\Annotation\Wireable;
 
 class WireAnnotationStub extends Annotation implements Wireable {
-    public function __construct(public string $type, public string $message): void {}
+    public function __construct(public string $type, public string $message) {}
 
     public function wire<T>(T $class, string $method = ''): this {
+        // UNSAFE
         if ($method) {
             $class->{$this->type}[$method] = $this->message;
         } else {
             $class->{$this->type} = $this->message;
         }
+
+        return $this;
     }
 }

--- a/tests/Titon/Test/Stub/Annotation/WireableStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/WireableStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Annotation;
 
 use Titon\Annotation\WiresAnnotations;
@@ -11,7 +11,7 @@ class WireableStub {
 
     public Map<string, string> $method = Map {};
 
-    public function __construct(string $type = 'both') {
+    public function __construct(string $type = 'both'): void {
         if ($type === 'method') {
             $this->wireMethodAnnotation('doAction', 'Wire');
         } else if ($type === 'class') {

--- a/tests/Titon/Test/Stub/Annotation/WireableStub.hh
+++ b/tests/Titon/Test/Stub/Annotation/WireableStub.hh
@@ -1,0 +1,26 @@
+<?hh
+namespace Titon\Test\Stub\Annotation;
+
+use Titon\Annotation\WiresAnnotations;
+
+<<Wire('class', 'This is a class annotation')>>
+class WireableStub {
+    use WiresAnnotations;
+
+    public string $class = '';
+
+    public Map<string, string> $method = Map {};
+
+    public function __construct(string $type = 'both') {
+        if ($type === 'method') {
+            $this->wireMethodAnnotation('doAction', 'Wire');
+        } else if ($type === 'class') {
+            $this->wireClassAnnotation('Wire');
+        } else {
+            $this->wireAnnotations();
+        }
+    }
+
+    <<Wire('method', 'This is a method annotation')>>
+    public function doAction(): void {}
+}

--- a/tests/Titon/Test/Stub/Common/BagStub.hh
+++ b/tests/Titon/Test/Stub/Common/BagStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Common;
 
 use Titon\Common\Bag\AbstractBag;

--- a/tests/Titon/Test/Stub/Common/BagStub.hh
+++ b/tests/Titon/Test/Stub/Common/BagStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Common;
+
+use Titon\Common\Bag\AbstractBag;
+
+class BagStub extends AbstractBag {
+
+}

--- a/tests/Titon/Test/Stub/Common/BagStub.hh
+++ b/tests/Titon/Test/Stub/Common/BagStub.hh
@@ -3,6 +3,6 @@ namespace Titon\Test\Stub\Common;
 
 use Titon\Common\Bag\AbstractBag;
 
-class BagStub extends AbstractBag {
+class BagStub<Tk, Tv> extends AbstractBag<Tk, Tv> {
 
 }

--- a/tests/Titon/Test/Stub/Common/CacheableStub.hh
+++ b/tests/Titon/Test/Stub/Common/CacheableStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Common;
+
+use Titon\Common\Cacheable;
+
+class CacheableStub {
+    use Cacheable;
+}

--- a/tests/Titon/Test/Stub/Common/CacheableStub.hh
+++ b/tests/Titon/Test/Stub/Common/CacheableStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Common;
 
 use Titon\Common\Cacheable;

--- a/tests/Titon/Test/Stub/Common/MutableStub.hh
+++ b/tests/Titon/Test/Stub/Common/MutableStub.hh
@@ -5,6 +5,6 @@ use Countable;
 use IteratorAggregate;
 use Titon\Common\Mutable;
 
-class MutableStub implements IteratorAggregate, Countable {
-    use Mutable;
+class MutableStub<Tk, Tv> implements IteratorAggregate<Tv>, Countable {
+    use Mutable<Tk, Tv>;
 }

--- a/tests/Titon/Test/Stub/Common/MutableStub.hh
+++ b/tests/Titon/Test/Stub/Common/MutableStub.hh
@@ -1,0 +1,10 @@
+<?hh
+namespace Titon\Test\Stub\Common;
+
+use Countable;
+use IteratorAggregate;
+use Titon\Common\Mutable;
+
+class MutableStub implements IteratorAggregate, Countable {
+    use Mutable;
+}

--- a/tests/Titon/Test/Stub/Common/MutableStub.hh
+++ b/tests/Titon/Test/Stub/Common/MutableStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Common;
 
 use Countable;

--- a/tests/Titon/Test/Stub/Common/StaticCacheableStub.hh
+++ b/tests/Titon/Test/Stub/Common/StaticCacheableStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Common;
+
+use Titon\Common\StaticCacheable;
+
+class StaticCacheableStub {
+    use StaticCacheable;
+}

--- a/tests/Titon/Test/Stub/Common/StaticCacheableStub.hh
+++ b/tests/Titon/Test/Stub/Common/StaticCacheableStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Common;
 
 use Titon\Common\StaticCacheable;

--- a/tests/Titon/Test/Stub/Common/StringableStub.hh
+++ b/tests/Titon/Test/Stub/Common/StringableStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Common;
+
+use Titon\Common\Stringable;
+
+class StringableStub {
+    use Stringable;
+}

--- a/tests/Titon/Test/Stub/Common/StringableStub.hh
+++ b/tests/Titon/Test/Stub/Common/StringableStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Common;
 
 use Titon\Common\Stringable;

--- a/tests/Titon/Test/Stub/Context/BarServiceProviderStub.hh
+++ b/tests/Titon/Test/Stub/Context/BarServiceProviderStub.hh
@@ -1,0 +1,13 @@
+<?hh
+namespace Titon\Test\Stub\Context;
+
+use Titon\Context\ServiceProvider\AbstractServiceProvider;
+
+class BarServiceProviderStub extends AbstractServiceProvider {
+
+    public function register() {
+        $this->depository->singleton('bar', 'Titon\Test\Stub\Context\BarStub')
+            ->with('Titon\Test\Stub\Context\FooStub');
+    }
+
+}

--- a/tests/Titon/Test/Stub/Context/BarServiceProviderStub.hh
+++ b/tests/Titon/Test/Stub/Context/BarServiceProviderStub.hh
@@ -6,8 +6,11 @@ use Titon\Context\ServiceProvider\AbstractServiceProvider;
 class BarServiceProviderStub extends AbstractServiceProvider {
 
     public function register(): void {
-        $this->depository->singleton('bar', 'Titon\Test\Stub\Context\BarStub')
-            ->with('Titon\Test\Stub\Context\FooStub');
+        // UNSAFE
+        if ($this->depository !== null) {
+            $this->depository->singleton('bar', 'Titon\Test\Stub\Context\BarStub')
+                ->with('Titon\Test\Stub\Context\FooStub');
+        }
     }
 
 }

--- a/tests/Titon/Test/Stub/Context/BarServiceProviderStub.hh
+++ b/tests/Titon/Test/Stub/Context/BarServiceProviderStub.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Context;
 
 use Titon\Context\ServiceProvider\AbstractServiceProvider;
 
 class BarServiceProviderStub extends AbstractServiceProvider {
 
-    public function register() {
+    public function register(): void {
         $this->depository->singleton('bar', 'Titon\Test\Stub\Context\BarStub')
             ->with('Titon\Test\Stub\Context\FooStub');
     }

--- a/tests/Titon/Test/Stub/Context/BarStub.hh
+++ b/tests/Titon/Test/Stub/Context/BarStub.hh
@@ -1,0 +1,22 @@
+<?hh
+namespace Titon\Test\Stub\Context;
+
+class BarStub
+{
+    private $foo;
+
+    public function __construct(FooStub $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+}

--- a/tests/Titon/Test/Stub/Context/BarStub.hh
+++ b/tests/Titon/Test/Stub/Context/BarStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Context;
 
 class BarStub

--- a/tests/Titon/Test/Stub/Context/BarStub.hh
+++ b/tests/Titon/Test/Stub/Context/BarStub.hh
@@ -1,22 +1,20 @@
 <?hh // strict
 namespace Titon\Test\Stub\Context;
 
-class BarStub
-{
-    private $foo;
+class BarStub {
+    protected FooStub $foo;
 
-    public function __construct(FooStub $foo)
-    {
+    public function __construct(FooStub $foo) {
         $this->foo = $foo;
     }
 
-    public function getFoo()
-    {
+    public function getFoo(): FooStub {
         return $this->foo;
     }
 
-    public function setFoo($foo)
-    {
+    public function setFoo(FooStub $foo): this {
         $this->foo = $foo;
+
+        return $this;
     }
 }

--- a/tests/Titon/Test/Stub/Context/FooServiceProviderStub.hh
+++ b/tests/Titon/Test/Stub/Context/FooServiceProviderStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Context;
 
 use Titon\Context\ClassList;
@@ -10,7 +10,7 @@ class FooServiceProviderStub extends AbstractServiceProvider {
         'Titon\Test\Stub\Context\FooStub'
     };
 
-    public function register() {
+    public function register(): void {
         $this->depository->register('foo', 'Titon\Test\Stub\Context\FooStub');
     }
 

--- a/tests/Titon/Test/Stub/Context/FooServiceProviderStub.hh
+++ b/tests/Titon/Test/Stub/Context/FooServiceProviderStub.hh
@@ -11,7 +11,9 @@ class FooServiceProviderStub extends AbstractServiceProvider {
     };
 
     public function register(): void {
-        $this->depository->register('foo', 'Titon\Test\Stub\Context\FooStub');
+        if ($this->depository !== null) {
+            $this->depository->register('foo', 'Titon\Test\Stub\Context\FooStub');
+        }
     }
 
 }

--- a/tests/Titon/Test/Stub/Context/FooServiceProviderStub.hh
+++ b/tests/Titon/Test/Stub/Context/FooServiceProviderStub.hh
@@ -1,0 +1,17 @@
+<?hh
+namespace Titon\Test\Stub\Context;
+
+use Titon\Context\ClassList;
+use Titon\Context\ServiceProvider\AbstractServiceProvider;
+
+class FooServiceProviderStub extends AbstractServiceProvider {
+
+    protected ClassList $provides = Vector {
+        'Titon\Test\Stub\Context\FooStub'
+    };
+
+    public function register() {
+        $this->depository->register('foo', 'Titon\Test\Stub\Context\FooStub');
+    }
+
+}

--- a/tests/Titon/Test/Stub/Context/FooStub.hh
+++ b/tests/Titon/Test/Stub/Context/FooStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Context;
 
 class FooStub
@@ -35,6 +35,6 @@ class FooStub
     }
 }
 
-function foo_stub_func(FooStub $foo) {
+function foo_stub_func(FooStub $foo): void {
     return $foo->getName();
 }

--- a/tests/Titon/Test/Stub/Context/FooStub.hh
+++ b/tests/Titon/Test/Stub/Context/FooStub.hh
@@ -1,40 +1,36 @@
 <?hh // strict
 namespace Titon\Test\Stub\Context;
 
-class FooStub
-{
-    public $name;
+class FooStub {
+    public string $name;
 
-    private $bar;
+    protected ?BarStub $bar;
 
-    public function __construct($name = 'Alex Phillips')
-    {
+    public function __construct(string $name = 'Alex Phillips') {
         $this->name = $name;
     }
 
-    public static function factory($name = 'Alex Phillips')
-    {
+    public static function factory(string $name = 'Alex Phillips'): FooStub {
         return new FooStub($name);
     }
 
-    public function getName()
-    {
+    public function getName(): string {
         return $this->name;
     }
 
-    public function setName($name)
-    {
+    public function setName(string $name): this {
         $this->name = $name;
 
         return $this;
     }
 
-    public function setBar(BarStub $bar)
-    {
+    public function setBar(BarStub $bar): this {
         $this->bar = $bar;
+
+        return $this;
     }
 }
 
-function foo_stub_func(FooStub $foo): void {
+function foo_stub_func(FooStub $foo): string {
     return $foo->getName();
 }

--- a/tests/Titon/Test/Stub/Context/FooStub.hh
+++ b/tests/Titon/Test/Stub/Context/FooStub.hh
@@ -1,0 +1,40 @@
+<?hh
+namespace Titon\Test\Stub\Context;
+
+class FooStub
+{
+    public $name;
+
+    private $bar;
+
+    public function __construct($name = 'Alex Phillips')
+    {
+        $this->name = $name;
+    }
+
+    public static function factory($name = 'Alex Phillips')
+    {
+        return new FooStub($name);
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function setBar(BarStub $bar)
+    {
+        $this->bar = $bar;
+    }
+}
+
+function foo_stub_func(FooStub $foo) {
+    return $foo->getName();
+}

--- a/tests/Titon/Test/Stub/Controller/ActionStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ActionStub.hh
@@ -1,0 +1,32 @@
+<?hh
+namespace Titon\Test\Stub\Controller;
+
+use Titon\Controller\Action\AbstractAction;
+
+class ActionStub extends AbstractAction {
+
+    public function get(): mixed {
+        $this->getController()->foo = 'bar';
+
+        return 'get';
+    }
+
+    public function post(): mixed {
+        return 'post';
+    }
+
+    public function delete(): mixed {
+        return 'delete';
+    }
+
+    public function put(): mixed {
+        return 'put';
+    }
+
+    public function head(): mixed {
+        $this->getController()->foo = 'baz';
+
+        return 'head';
+    }
+
+}

--- a/tests/Titon/Test/Stub/Controller/ActionStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ActionStub.hh
@@ -7,7 +7,7 @@ class ActionStub extends AbstractAction {
 
     public function get(): mixed {
         // UNSAFE
-        $this->getController()->foo = 'bar';
+        $this->getController()->value = 'bar';
 
         return 'get';
     }
@@ -26,7 +26,7 @@ class ActionStub extends AbstractAction {
 
     public function head(): mixed {
         // UNSAFE
-        $this->getController()->foo = 'baz';
+        $this->getController()->value = 'baz';
 
         return 'head';
     }

--- a/tests/Titon/Test/Stub/Controller/ActionStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ActionStub.hh
@@ -6,6 +6,7 @@ use Titon\Controller\Action\AbstractAction;
 class ActionStub extends AbstractAction {
 
     public function get(): mixed {
+        // UNSAFE
         $this->getController()->foo = 'bar';
 
         return 'get';
@@ -24,6 +25,7 @@ class ActionStub extends AbstractAction {
     }
 
     public function head(): mixed {
+        // UNSAFE
         $this->getController()->foo = 'baz';
 
         return 'head';

--- a/tests/Titon/Test/Stub/Controller/ActionStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ActionStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Controller;
 
 use Titon\Controller\Action\AbstractAction;

--- a/tests/Titon/Test/Stub/Controller/ControllerStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ControllerStub.hh
@@ -5,23 +5,23 @@ use Titon\Controller\AbstractController;
 
 class ControllerStub extends AbstractController {
 
-    public function actionWithArgs(mixed $arg1, mixed $arg2 = 0): string {
-        return strval($arg1 + $arg2);
+    public function actionWithArgs(mixed $arg1, mixed $arg2 = 0): mixed {
+        return strval((int) $arg1 + (int) $arg2);
     }
 
-    public function actionNoArgs(): string {
+    public function actionNoArgs(): mixed {
         return 'actionNoArgs';
     }
 
-    public function _actionPseudoPrivate(): string {
+    public function _actionPseudoPrivate(): mixed {
         return 'wontBeCalled';
     }
 
-    protected function actionProtected(): string {
+    protected function actionProtected(): mixed {
         return 'wontBeCalled';
     }
 
-    private function actionPrivate(): string {
+    private function actionPrivate(): mixed {
         return 'wontBeCalled';
     }
 

--- a/tests/Titon/Test/Stub/Controller/ControllerStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ControllerStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Controller;
 
 use Titon\Controller\AbstractController;

--- a/tests/Titon/Test/Stub/Controller/ControllerStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ControllerStub.hh
@@ -1,0 +1,28 @@
+<?hh
+namespace Titon\Test\Stub\Controller;
+
+use Titon\Controller\AbstractController;
+
+class ControllerStub extends AbstractController {
+
+    public function actionWithArgs(mixed $arg1, mixed $arg2 = 0): string {
+        return strval($arg1 + $arg2);
+    }
+
+    public function actionNoArgs(): string {
+        return 'actionNoArgs';
+    }
+
+    public function _actionPseudoPrivate(): string {
+        return 'wontBeCalled';
+    }
+
+    protected function actionProtected(): string {
+        return 'wontBeCalled';
+    }
+
+    private function actionPrivate(): string {
+        return 'wontBeCalled';
+    }
+
+}

--- a/tests/Titon/Test/Stub/Controller/ControllerStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ControllerStub.hh
@@ -5,6 +5,8 @@ use Titon\Controller\AbstractController;
 
 class ControllerStub extends AbstractController {
 
+    public string $value = '';
+
     public function actionWithArgs(mixed $arg1, mixed $arg2 = 0): mixed {
         return strval((int) $arg1 + (int) $arg2);
     }

--- a/tests/Titon/Test/Stub/Debug/DeprecatedClassStub.hh
+++ b/tests/Titon/Test/Stub/Debug/DeprecatedClassStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Debug;
 
 use Titon\Annotation\WiresAnnotations;
@@ -7,7 +7,7 @@ use Titon\Annotation\WiresAnnotations;
 class DeprecatedClassStub {
     use WiresAnnotations;
 
-    public function __construct() {
+    public function __construct(): void {
         $this->wireClassAnnotation('Deprecated');
     }
 }

--- a/tests/Titon/Test/Stub/Debug/DeprecatedClassStub.hh
+++ b/tests/Titon/Test/Stub/Debug/DeprecatedClassStub.hh
@@ -1,0 +1,13 @@
+<?hh
+namespace Titon\Test\Stub\Debug;
+
+use Titon\Annotation\WiresAnnotations;
+
+<<Deprecated('This is the error message.')>>
+class DeprecatedClassStub {
+    use WiresAnnotations;
+
+    public function __construct() {
+        $this->wireClassAnnotation('Deprecated');
+    }
+}

--- a/tests/Titon/Test/Stub/Debug/MonitorClassStub.hh
+++ b/tests/Titon/Test/Stub/Debug/MonitorClassStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Debug;
 
 use Titon\Annotation\WiresAnnotations;
@@ -9,7 +9,7 @@ class MonitorClassStub {
 
     public static string $triggered = '';
 
-    public function __construct() {
+    public function __construct(): void {
         $this->wireClassAnnotation('Monitor');
     }
 

--- a/tests/Titon/Test/Stub/Debug/MonitorClassStub.hh
+++ b/tests/Titon/Test/Stub/Debug/MonitorClassStub.hh
@@ -1,0 +1,19 @@
+<?hh
+namespace Titon\Test\Stub\Debug;
+
+use Titon\Annotation\WiresAnnotations;
+
+<<Monitor('Titon\Test\Stub\Debug\MonitorClassStub::testCallback')>>
+class MonitorClassStub {
+    use WiresAnnotations;
+
+    public static string $triggered = '';
+
+    public function __construct() {
+        $this->wireClassAnnotation('Monitor');
+    }
+
+    public static function testCallback<T>(T $class, string $method = ''): void {
+        static::$triggered = get_class($class);
+    }
+}

--- a/tests/Titon/Test/Stub/Environment/BootstrapperStub.hh
+++ b/tests/Titon/Test/Stub/Environment/BootstrapperStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Environment;
 
 use Titon\Environment\Bootstrapper;
@@ -8,7 +8,7 @@ class BootstrapperStub implements Bootstrapper {
 
     public static string $loaded = '';
 
-    public function bootstrap(Host $host) {
+    public function bootstrap(Host $host): void {
         static::$loaded = $host->getKey();
     }
 

--- a/tests/Titon/Test/Stub/Environment/BootstrapperStub.hh
+++ b/tests/Titon/Test/Stub/Environment/BootstrapperStub.hh
@@ -1,0 +1,15 @@
+<?hh
+namespace Titon\Test\Stub\Environment;
+
+use Titon\Environment\Bootstrapper;
+use Titon\Environment\Host;
+
+class BootstrapperStub implements Bootstrapper {
+
+    public static string $loaded = '';
+
+    public function bootstrap(Host $host) {
+        static::$loaded = $host->getKey();
+    }
+
+}

--- a/tests/Titon/Test/Stub/Environment/EnvironmentStub.hh
+++ b/tests/Titon/Test/Stub/Environment/EnvironmentStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Environment;
 
 use Titon\Environment\Environment;

--- a/tests/Titon/Test/Stub/Environment/EnvironmentStub.hh
+++ b/tests/Titon/Test/Stub/Environment/EnvironmentStub.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Test\Stub\Environment;
 
 use Titon\Environment\Environment;
@@ -7,12 +7,12 @@ class EnvironmentStub extends Environment {
 
     // Use host/IP for testing
     public function isMachine(string $name): bool {
-        $host = null;
+        $host = '';
 
-        if (!empty($_SERVER['HTTP_HOST'])) {
+        if (array_key_exists('HTTP_HOST', $_SERVER)) {
             $host = $_SERVER['HTTP_HOST'];
 
-        } else if (!empty($_SERVER['SERVER_ADDR'])) {
+        } else if (array_key_exists('SERVER_ADDR', $_SERVER)) {
             $host = $_SERVER['SERVER_ADDR'];
         }
 

--- a/tests/Titon/Test/Stub/Environment/EnvironmentStub.hh
+++ b/tests/Titon/Test/Stub/Environment/EnvironmentStub.hh
@@ -1,0 +1,22 @@
+<?hh
+namespace Titon\Test\Stub\Environment;
+
+use Titon\Environment\Environment;
+
+class EnvironmentStub extends Environment {
+
+    // Use host/IP for testing
+    public function isMachine(string $name): bool {
+        $host = null;
+
+        if (!empty($_SERVER['HTTP_HOST'])) {
+            $host = $_SERVER['HTTP_HOST'];
+
+        } else if (!empty($_SERVER['SERVER_ADDR'])) {
+            $host = $_SERVER['SERVER_ADDR'];
+        }
+
+        return (bool) preg_match('/^' . preg_quote($name, '/') . '/i', $host);
+    }
+
+}

--- a/tests/Titon/Test/Stub/Event/ListenerStub.hh
+++ b/tests/Titon/Test/Stub/Event/ListenerStub.hh
@@ -1,0 +1,57 @@
+<?hh
+namespace Titon\Test\Stub\Event;
+
+use Titon\Event\Event;
+use Titon\Event\Listener;
+use Titon\Event\ListenerMap;
+
+class ListenerStub implements Listener {
+
+    public function subscribeToEvents(): ListenerMap {
+        return Map {
+            'event.test1' => Vector {
+                'noop1',
+                Map {'method' => 'noop2', 'priority' => 45}
+            },
+            'event.test2' => 'noop1',
+            'event.test3' => Map {'method' => 'noop2', 'priority' => 15}
+        };
+    }
+
+    public function noop1(Event $e): void {}
+
+    public function noop2(Event $e): void {}
+
+    public function noop3(Event $e, $object1, $object2): void {
+        $object2->foo = 'bar';
+    }
+
+    public function counter(Event $e, &$count): void {
+        $count++;
+    }
+
+    public async function asyncNoop1(Event $e, &$list): Awaitable<mixed> {
+        await SleepWaitHandle::create(rand(100, 1000) * 1000);
+
+        $list[] = 1;
+
+        return true;
+    }
+
+    public async function asyncNoop2(Event $e, &$list): Awaitable<mixed> {
+        await SleepWaitHandle::create(rand(100, 500) * 1000);
+
+        $list[] = 2;
+
+        return true;
+    }
+
+    public async function asyncNoop3(Event $e, &$list): Awaitable<mixed> {
+        await SleepWaitHandle::create(rand(1, 500) * 1000);
+
+        $list[] = 3;
+
+        return true;
+    }
+
+}

--- a/tests/Titon/Test/Stub/Event/ListenerStub.hh
+++ b/tests/Titon/Test/Stub/Event/ListenerStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Event;
 
 use Titon\Event\Event;

--- a/tests/Titon/Test/Stub/Event/ListenerStub.hh
+++ b/tests/Titon/Test/Stub/Event/ListenerStub.hh
@@ -4,6 +4,7 @@ namespace Titon\Test\Stub\Event;
 use Titon\Event\Event;
 use Titon\Event\Listener;
 use Titon\Event\ListenerMap;
+use stdClass;
 
 class ListenerStub implements Listener {
 
@@ -22,15 +23,15 @@ class ListenerStub implements Listener {
 
     public function noop2(Event $e): void {}
 
-    public function noop3(Event $e, $object1, $object2): void {
-        $object2->foo = 'bar';
+    public function noop3(Event $e, int $int, stdClass $object): void {
+        $object->foo = 'bar';
     }
 
-    public function counter(Event $e, &$count): void {
+    public function counter(Event $e, int &$count): void {
         $count++;
     }
 
-    public async function asyncNoop1(Event $e, &$list): Awaitable<mixed> {
+    public async function asyncNoop1(Event $e, array<int> &$list): Awaitable<mixed> {
         await SleepWaitHandle::create(rand(100, 1000) * 1000);
 
         $list[] = 1;
@@ -38,7 +39,7 @@ class ListenerStub implements Listener {
         return true;
     }
 
-    public async function asyncNoop2(Event $e, &$list): Awaitable<mixed> {
+    public async function asyncNoop2(Event $e, array<int> &$list): Awaitable<mixed> {
         await SleepWaitHandle::create(rand(100, 500) * 1000);
 
         $list[] = 2;
@@ -46,7 +47,7 @@ class ListenerStub implements Listener {
         return true;
     }
 
-    public async function asyncNoop3(Event $e, &$list): Awaitable<mixed> {
+    public async function asyncNoop3(Event $e, array<int> &$list): Awaitable<mixed> {
         await SleepWaitHandle::create(rand(1, 500) * 1000);
 
         $list[] = 3;

--- a/tests/Titon/Test/Stub/Event/ObserverClassStub.hh
+++ b/tests/Titon/Test/Stub/Event/ObserverClassStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Event;
 
 use Titon\Annotation\WiresAnnotations;
@@ -9,7 +9,7 @@ use Titon\Event\Subject;
 class ObserverClassStub implements Subject {
     use EmitsEvents, WiresAnnotations;
 
-    public function __construct() {
+    public function __construct(): void {
         $this->wireMethodAnnotation('defaultObserver', 'Observer');
         $this->wireMethodAnnotation('priorityObserver', 'Observer');
         $this->wireMethodAnnotation('onceObserver', 'Observer');

--- a/tests/Titon/Test/Stub/Event/ObserverClassStub.hh
+++ b/tests/Titon/Test/Stub/Event/ObserverClassStub.hh
@@ -1,0 +1,31 @@
+<?hh
+namespace Titon\Test\Stub\Event;
+
+use Titon\Annotation\WiresAnnotations;
+use Titon\Event\EmitsEvents;
+use Titon\Event\Event;
+use Titon\Event\Subject;
+
+class ObserverClassStub implements Subject {
+    use EmitsEvents, WiresAnnotations;
+
+    public function __construct() {
+        $this->wireMethodAnnotation('defaultObserver', 'Observer');
+        $this->wireMethodAnnotation('priorityObserver', 'Observer');
+        $this->wireMethodAnnotation('onceObserver', 'Observer');
+        $this->wireMethodAnnotation('asyncObserver', 'Observer');
+    }
+
+    <<Observer('event.foo')>>
+    public function defaultObserver(Event $event): void {}
+
+    <<Observer('event.bar', 5)>>
+    public function priorityObserver(Event $event): void {}
+
+    <<Observer('event.baz', 0, true)>>
+    public function onceObserver(Event $event): void {}
+
+    <<Observer('event.qux')>>
+    public async function asyncObserver(Event $event): Awaitable<mixed> {}
+
+}

--- a/tests/Titon/Test/Stub/Event/SubjectStub.hh
+++ b/tests/Titon/Test/Stub/Event/SubjectStub.hh
@@ -1,0 +1,9 @@
+<?hh
+namespace Titon\Test\Stub\Event;
+
+use Titon\Event\EmitsEvents;
+use Titon\Event\Subject;
+
+class SubjectStub implements Subject {
+    use EmitsEvents;
+}

--- a/tests/Titon/Test/Stub/Event/SubjectStub.hh
+++ b/tests/Titon/Test/Stub/Event/SubjectStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Event;
 
 use Titon\Event\EmitsEvents;

--- a/tests/Titon/Test/Stub/Kernel/ApplicationStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/ApplicationStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Kernel;
+
+use Titon\Kernel\Application;
+
+class ApplicationStub implements Application {
+
+}

--- a/tests/Titon/Test/Stub/Kernel/ApplicationStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/ApplicationStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\Application;

--- a/tests/Titon/Test/Stub/Kernel/CallNextKernelStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/CallNextKernelStub.hh
@@ -1,15 +1,17 @@
 <?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
-use Titon\Kernel\Input;
 use Titon\Kernel\Middleware\Next;
-use Titon\Kernel\Output;
 
 class CallNextKernelStub extends KernelStub {
-    public function handle(Input $input, Output $output, Next $next): Output {
+    public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
         $next->handle($input, $output);
-        $output->ran = true;
 
+        if ($output instanceof OutputStub) {
+            $output->ran = true;
+        }
+
+        // UNSAFE
         return $output;
     }
 }

--- a/tests/Titon/Test/Stub/Kernel/CallNextKernelStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/CallNextKernelStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\Input;

--- a/tests/Titon/Test/Stub/Kernel/CallNextKernelStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/CallNextKernelStub.hh
@@ -1,0 +1,15 @@
+<?hh
+namespace Titon\Test\Stub\Kernel;
+
+use Titon\Kernel\Input;
+use Titon\Kernel\Middleware\Next;
+use Titon\Kernel\Output;
+
+class CallNextKernelStub extends KernelStub {
+    public function handle(Input $input, Output $output, Next $next): Output {
+        $next->handle($input, $output);
+        $output->ran = true;
+
+        return $output;
+    }
+}

--- a/tests/Titon/Test/Stub/Kernel/InputStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/InputStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\Input;

--- a/tests/Titon/Test/Stub/Kernel/InputStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/InputStub.hh
@@ -1,0 +1,8 @@
+<?hh
+namespace Titon\Test\Stub\Kernel;
+
+use Titon\Kernel\Input;
+
+class InputStub implements Input {
+    public array<mixed> $stack = [];
+}

--- a/tests/Titon/Test/Stub/Kernel/InterruptMiddlewareStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/InterruptMiddlewareStub.hh
@@ -1,0 +1,12 @@
+<?hh
+namespace Titon\Test\Stub\Kernel;
+
+use Titon\Kernel\Middleware\Next;
+
+class InterruptMiddlewareStub extends MiddlewareStub {
+    public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
+        $input->stack[] = $this->key;
+
+        return $output;
+    }
+}

--- a/tests/Titon/Test/Stub/Kernel/InterruptMiddlewareStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/InterruptMiddlewareStub.hh
@@ -5,7 +5,9 @@ use Titon\Kernel\Middleware\Next;
 
 class InterruptMiddlewareStub extends MiddlewareStub {
     public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
-        $input->stack[] = $this->key;
+        if ($input instanceof InputStub) {
+            $input->stack[] = $this->key;
+        }
 
         return $output;
     }

--- a/tests/Titon/Test/Stub/Kernel/InterruptMiddlewareStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/InterruptMiddlewareStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\Middleware\Next;

--- a/tests/Titon/Test/Stub/Kernel/KernelStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/KernelStub.hh
@@ -2,15 +2,19 @@
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\AbstractKernel;
-use Titon\Kernel\Input;
 use Titon\Kernel\Middleware\Next;
-use Titon\Kernel\Output;
 
 class KernelStub extends AbstractKernel<InputStub, OutputStub> {
-    public function handle(Input $input, Output $output, Next $next): Output {
-        $input->stack[] = 'kernel';
-        $output->ran = true;
+    public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
+        if ($input instanceof InputStub) {
+            $input->stack[] = 'kernel';
+        }
 
+        if ($output instanceof OutputStub) {
+            $output->ran = true;
+        }
+
+        // UNSAFE
         return $output;
     }
 }

--- a/tests/Titon/Test/Stub/Kernel/KernelStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/KernelStub.hh
@@ -1,0 +1,16 @@
+<?hh
+namespace Titon\Test\Stub\Kernel;
+
+use Titon\Kernel\AbstractKernel;
+use Titon\Kernel\Input;
+use Titon\Kernel\Middleware\Next;
+use Titon\Kernel\Output;
+
+class KernelStub extends AbstractKernel<InputStub, OutputStub> {
+    public function handle(Input $input, Output $output, Next $next): Output {
+        $input->stack[] = 'kernel';
+        $output->ran = true;
+
+        return $output;
+    }
+}

--- a/tests/Titon/Test/Stub/Kernel/KernelStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/KernelStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\AbstractKernel;

--- a/tests/Titon/Test/Stub/Kernel/MiddlewareStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/MiddlewareStub.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\Middleware;
 use Titon\Kernel\Middleware\Next;
 
 class MiddlewareStub implements Middleware {
-    public function __construct(protected string $key) {}
+    public function __construct(protected string $key): void {}
 
     public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
         $input->stack[] = $this->key;

--- a/tests/Titon/Test/Stub/Kernel/MiddlewareStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/MiddlewareStub.hh
@@ -8,11 +8,15 @@ class MiddlewareStub implements Middleware {
     public function __construct(protected string $key): void {}
 
     public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
-        $input->stack[] = $this->key;
+        if ($input instanceof InputStub) {
+            $input->stack[] = $this->key;
+        }
 
         $output = $next->handle($input, $output);
 
-        $input->stack[] = $this->key;
+        if ($input instanceof InputStub) {
+            $input->stack[] = $this->key;
+        }
 
         return $output;
     }

--- a/tests/Titon/Test/Stub/Kernel/MiddlewareStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/MiddlewareStub.hh
@@ -1,0 +1,19 @@
+<?hh
+namespace Titon\Test\Stub\Kernel;
+
+use Titon\Kernel\Middleware;
+use Titon\Kernel\Middleware\Next;
+
+class MiddlewareStub implements Middleware {
+    public function __construct(protected string $key) {}
+
+    public function handle<Ti, To>(Ti $input, To $output, Next $next): To {
+        $input->stack[] = $this->key;
+
+        $output = $next->handle($input, $output);
+
+        $input->stack[] = $this->key;
+
+        return $output;
+    }
+}

--- a/tests/Titon/Test/Stub/Kernel/OutputStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/OutputStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Kernel;
 
 use Titon\Kernel\Output;

--- a/tests/Titon/Test/Stub/Kernel/OutputStub.hh
+++ b/tests/Titon/Test/Stub/Kernel/OutputStub.hh
@@ -1,0 +1,10 @@
+<?hh
+namespace Titon\Test\Stub\Kernel;
+
+use Titon\Kernel\Output;
+
+class OutputStub implements Output {
+    public bool $ran = false;
+
+    public function send(): void {}
+}

--- a/tests/Titon/Test/Stub/Route/DispatchRouteStub.hh
+++ b/tests/Titon/Test/Stub/Route/DispatchRouteStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Route;
 
 class DispatchRouteStub {

--- a/tests/Titon/Test/Stub/Route/DispatchRouteStub.hh
+++ b/tests/Titon/Test/Stub/Route/DispatchRouteStub.hh
@@ -1,0 +1,16 @@
+<?hh
+namespace Titon\Test\Stub\Route;
+
+class DispatchRouteStub {
+    public function noOptional(string $a, string $b): string {
+        return $a . $b;
+    }
+
+    public function withOptional(string $a, string $b = 'baz'): string {
+        return $a . $b;
+    }
+
+    public function typeHints(string $a, int $b, string $c): string {
+        return $a . $b . $c;
+    }
+}

--- a/tests/Titon/Test/Stub/Route/FilterStub.hh
+++ b/tests/Titon/Test/Stub/Route/FilterStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Route;
 
 use Titon\Route\Filter;

--- a/tests/Titon/Test/Stub/Route/FilterStub.hh
+++ b/tests/Titon/Test/Stub/Route/FilterStub.hh
@@ -1,0 +1,12 @@
+<?hh
+namespace Titon\Test\Stub\Route;
+
+use Titon\Route\Filter;
+use Titon\Route\Route;
+use Titon\Route\Router;
+
+class FilterStub implements Filter {
+    public function filter(Router $router, Route $route): void {
+        return;
+    }
+}

--- a/tests/Titon/Test/Stub/Route/RouteAnnotatedStub.hh
+++ b/tests/Titon/Test/Stub/Route/RouteAnnotatedStub.hh
@@ -1,0 +1,19 @@
+<?hh
+namespace Titon\Test\Stub\Route;
+
+<<Route('parent', '/controller')>>
+class RouteAnnotatedStub {
+
+    <<Route('foo', '/foo')>>
+    public function foo(): void {}
+
+    <<Route('bar', '/bar', 'POST')>>
+    public function bar(): void {}
+
+    <<Route('baz', '/baz', ['get'], ['auth', 'guest'])>>
+    public function baz(): void {}
+
+    <<Route('qux', '/qux', ['PUT', 'POST'], [], ['id' => '[1-8]+'])>>
+    public function qux(): void {}
+
+}

--- a/tests/Titon/Test/Stub/Route/RouteAnnotatedStub.hh
+++ b/tests/Titon/Test/Stub/Route/RouteAnnotatedStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Route;
 
 <<Route('parent', '/controller')>>

--- a/tests/Titon/Test/Stub/Route/TestRouteStub.hh
+++ b/tests/Titon/Test/Stub/Route/TestRouteStub.hh
@@ -1,10 +1,10 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\Route;
 
 use Titon\Route\Route;
 
 class TestRouteStub extends Route {
-    public function __construct(string $path, string $action) {
+    public function __construct(string $path, string $action): void {
         parent::__construct($path, $action);
 
         $this->compile();

--- a/tests/Titon/Test/Stub/Route/TestRouteStub.hh
+++ b/tests/Titon/Test/Stub/Route/TestRouteStub.hh
@@ -1,0 +1,12 @@
+<?hh
+namespace Titon\Test\Stub\Route;
+
+use Titon\Route\Route;
+
+class TestRouteStub extends Route {
+    public function __construct(string $path, string $action) {
+        parent::__construct($path, $action);
+
+        $this->compile();
+    }
+}

--- a/tests/Titon/Test/Stub/View/EngineStub.hh
+++ b/tests/Titon/Test/Stub/View/EngineStub.hh
@@ -1,0 +1,21 @@
+<?hh
+namespace Titon\Test\Stub\View;
+
+use Titon\Common\DataMap;
+use Titon\View\Engine\AbstractEngine;
+
+class EngineStub extends AbstractEngine {
+
+    public function open(string $partial, DataMap $variables = Map {}): string {
+        return '';
+    }
+
+    public function render(string $path, DataMap $variables = Map {}): string {
+        return '';
+    }
+
+    public function getExtension(): string {
+        return '';
+    }
+
+}

--- a/tests/Titon/Test/Stub/View/EngineStub.hh
+++ b/tests/Titon/Test/Stub/View/EngineStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\View;
 
 use Titon\Common\DataMap;

--- a/tests/Titon/Test/Stub/View/HelperStub.hh
+++ b/tests/Titon/Test/Stub/View/HelperStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\View;
 
 use Titon\View\Helper\AbstractHelper;

--- a/tests/Titon/Test/Stub/View/HelperStub.hh
+++ b/tests/Titon/Test/Stub/View/HelperStub.hh
@@ -1,0 +1,16 @@
+<?hh
+namespace Titon\Test\Stub\View;
+
+use Titon\View\Helper\AbstractHelper;
+use Titon\View\Helper\TagMap;
+
+class HelperStub extends AbstractHelper {
+
+    protected TagMap $tags = Map {
+        'noattr' => '<tag>{body}</tag>',
+        'nobody' => '<tag{attr} />',
+        'custom' => '<tag {one} {two}>{three}</tag>',
+        'default' => '<tag {0}>{1}</tag>{2}'
+    };
+
+}

--- a/tests/Titon/Test/Stub/View/ViewStub.hh
+++ b/tests/Titon/Test/Stub/View/ViewStub.hh
@@ -1,0 +1,17 @@
+<?hh
+namespace Titon\Test\Stub\View;
+
+use Titon\Common\DataMap;
+use Titon\View\AbstractView;
+
+class ViewStub extends AbstractView {
+
+    public function render(string $template, bool $private = false): string {
+        return '';
+    }
+
+    public function renderTemplate(string $path, DataMap $variables = Map {}): string {
+        return '';
+    }
+
+}

--- a/tests/Titon/Test/Stub/View/ViewStub.hh
+++ b/tests/Titon/Test/Stub/View/ViewStub.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Test\Stub\View;
 
 use Titon\Common\DataMap;

--- a/tests/Titon/Type/ArrayListTest.hh
+++ b/tests/Titon/Type/ArrayListTest.hh
@@ -145,9 +145,7 @@ class ArrayListTest extends TestCase {
     }
 
     public function testEach(): void {
-        $this->assertEquals(new ArrayList(Vector {'FOO', 'BAR', 'BAZ'}), $this->object->each(function(int $key, string $value): string {
-            return strtoupper($value);
-        }));
+        $this->assertEquals(new ArrayList(Vector {'FOO', 'BAR', 'BAZ'}), $this->object->each(($key, $value) ==> strtoupper($value)));
     }
 
     public function testErase(): void {
@@ -155,13 +153,11 @@ class ArrayListTest extends TestCase {
     }
 
     public function testFilter(): void {
-        $this->assertEquals(new ArrayList(Vector {'bar', 'baz'}), $this->object->filter(function(string $value): bool {
-            return (strpos($value, 'b') !== false);
-        }));
+        $this->assertEquals(new ArrayList(Vector {'bar', 'baz'}), $this->object->filter(($value) ==> (strpos($value, 'b') !== false)));
     }
 
     public function testFilterWithKey(): void {
-        $this->assertEquals(new ArrayList(Vector {'baz'}), $this->object->filterWithKey(function(int $index, string $value): bool {
+        $this->assertEquals(new ArrayList(Vector {'baz'}), $this->object->filterWithKey(($index, $value) ==> {
             return (strpos($value, 'b') !== false && $index % 2 === 0);
         }));
     }
@@ -218,15 +214,11 @@ class ArrayListTest extends TestCase {
     }
 
     public function testMap(): void {
-        $this->assertEquals(new ArrayList(Vector {'Foo', 'Bar', 'Baz'}), $this->object->map(function(string $value): string {
-            return ucfirst($value);
-        }));
+        $this->assertEquals(new ArrayList(Vector {'Foo', 'Bar', 'Baz'}), $this->object->map(($value) ==> ucfirst($value)));
     }
 
     public function testMapWithKey(): void {
-        $this->assertEquals(new ArrayList(Vector {'Foo0', 'Bar1', 'Baz2'}), $this->object->mapWithKey(function(int $index, string $value): string {
-            return ucfirst($value) . $index;
-        }));
+        $this->assertEquals(new ArrayList(Vector {'Foo0', 'Bar1', 'Baz2'}), $this->object->mapWithKey(($index, $value) ==> ucfirst($value) . $index));
     }
 
     public function testMerge(): void {
@@ -240,9 +232,7 @@ class ArrayListTest extends TestCase {
             Map {'key' => 3},
         });
 
-        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(function($value, $key): void {
-            return $value['key'];
-        }));
+        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(($value, $key) ==> $value['key']));
     }
 
     public function testPrepend(): void {
@@ -308,13 +298,9 @@ class ArrayListTest extends TestCase {
     }
 
     public function testSome(): void {
-        $this->assertTrue($this->object->some(function(int $key, mixed $value): void {
-            return is_string($value);
-        }));
+        $this->assertTrue($this->object->some(($key, $value) ==> is_string($value)));
 
-        $this->assertFalse($this->object->some(function(int $key, mixed $value): void {
-            return is_numeric($value);
-        }));
+        $this->assertFalse($this->object->some(($key, $value) ==> is_numeric($value)));
     }
 
     public function testSort(): void {
@@ -328,7 +314,7 @@ class ArrayListTest extends TestCase {
     public function testSortWithCallback(): void {
         $list = new ArrayList([5, 3, 4, 2, 1]);
 
-        $callback = function($a, $b) {
+        $callback = ($a, $b) ==> {
             if ($a == $b) {
                 return 0;
             } else if ($a > $b) {

--- a/tests/Titon/Type/ArrayListTest.hh
+++ b/tests/Titon/Type/ArrayListTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Type;
 
 use Titon\Test\TestCase;
@@ -8,13 +8,13 @@ use Titon\Test\TestCase;
  */
 class ArrayListTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new ArrayList(Vector {'foo', 'bar', 'baz'});
     }
 
-    public function testIterator() {
+    public function testIterator(): void {
         $array = [];
 
         foreach ($this->object as $key => $value) {
@@ -24,13 +24,13 @@ class ArrayListTest extends TestCase {
         $this->assertEquals([0 => 'foo', 2 => 'bar', 4 => 'baz'], $array);
     }
 
-    public function testIndexishConstructors() {
+    public function testIndexishConstructors(): void {
         $this->assertEquals(new ArrayList(Vector {'foo'}), new ArrayList(['foo']));
         $this->assertEquals(new ArrayList(Vector {'foo'}), new ArrayList(Vector {'foo'}));
         $this->assertEquals(new ArrayList(Vector {'foo'}), new ArrayList(Map {0 => 'foo'}));
     }
 
-    public function testChainableMethods() {
+    public function testChainableMethods(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $this->object
@@ -41,7 +41,7 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'zzz', 'oof', 'rab', 'zab'}), $this->object);
     }
 
-    public function testImmutableMethods() {
+    public function testImmutableMethods(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $mapped = $this->object->map(fun('strtoupper'));
@@ -53,7 +53,7 @@ class ArrayListTest extends TestCase {
         $this->assertNotSame($reversed, $this->object);
     }
 
-    public function testAdd() {
+    public function testAdd(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $this->object->add('fop');
@@ -62,7 +62,7 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz', 'fop', 'oof'}), $this->object);
     }
 
-    public function testAddAll() {
+    public function testAddAll(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $this->object->addAll(Vector {'fop', 'oof'});
@@ -70,18 +70,18 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz', 'fop', 'oof'}), $this->object);
     }
 
-    public function testAt() {
+    public function testAt(): void {
         $this->assertEquals('bar', $this->object->at(1));
     }
 
     /**
      * @expectedException \OutOfBoundsException
      */
-    public function testAtThrowsError() {
+    public function testAtThrowsError(): void {
         $this->assertEquals('bar', $this->object->at(5));
     }
 
-    public function testAppend() {
+    public function testAppend(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $list = $this->object->append('fop');
@@ -91,7 +91,7 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz', 'fop', 'oof'}), $list);
     }
 
-    public function testChunk() {
+    public function testChunk(): void {
         $this->assertEquals(new ArrayList(Vector {
             new ArrayList(Vector {'foo'}),
             new ArrayList(Vector {'bar'}),
@@ -99,17 +99,17 @@ class ArrayListTest extends TestCase {
         }), $this->object->chunk(1));
     }
 
-    public function testClean() {
+    public function testClean(): void {
         $list = new ArrayList(Vector {1, 0, '0', false, true, null, 'foo', '', 0.0});
 
         $this->assertEquals(new ArrayList(Vector {1, 0, '0', true, 'foo', 0.0}), $list->clean());
     }
 
-    public function testClear() {
+    public function testClear(): void {
         $this->assertEquals(new ArrayList(), $this->object->flush());
     }
 
-    public function testClone() {
+    public function testClone(): void {
         $vector = Vector {'foo'};
         $list = new ArrayList($vector);
         $clone = clone $list;
@@ -117,7 +117,7 @@ class ArrayListTest extends TestCase {
         $this->assertNotSame($vector, $clone->value());
     }
 
-    public function testConcat() {
+    public function testConcat(): void {
         $list1 = $this->object->concat(new ArrayList(Vector {1, 2, 3}));
 
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz', 1, 2, 3}), $list1);
@@ -129,123 +129,123 @@ class ArrayListTest extends TestCase {
         $this->assertNotSame($list1, $this->object);
     }
 
-    public function testContains() {
+    public function testContains(): void {
         $this->assertTrue($this->object->contains('foo'));
         $this->assertFalse($this->object->contains(123));
     }
 
-    public function testCount() {
+    public function testCount(): void {
         $this->assertEquals(3, $this->object->count());
         $this->object->add('fop');
         $this->assertEquals(4, $this->object->count());
     }
 
-    public function testDepth() {
+    public function testDepth(): void {
         $this->assertEquals(1, $this->object->depth());
     }
 
-    public function testEach() {
+    public function testEach(): void {
         $this->assertEquals(new ArrayList(Vector {'FOO', 'BAR', 'BAZ'}), $this->object->each(function(int $key, string $value): string {
             return strtoupper($value);
         }));
     }
 
-    public function testErase() {
+    public function testErase(): void {
         $this->assertEquals(new ArrayList(Vector {'bar', 'baz'}), $this->object->erase('foo'));
     }
 
-    public function testFilter() {
+    public function testFilter(): void {
         $this->assertEquals(new ArrayList(Vector {'bar', 'baz'}), $this->object->filter(function(string $value): bool {
             return (strpos($value, 'b') !== false);
         }));
     }
 
-    public function testFilterWithKey() {
+    public function testFilterWithKey(): void {
         $this->assertEquals(new ArrayList(Vector {'baz'}), $this->object->filterWithKey(function(int $index, string $value): bool {
             return (strpos($value, 'b') !== false && $index % 2 === 0);
         }));
     }
 
-    public function testFirst() {
+    public function testFirst(): void {
         $this->assertEquals('foo', $this->object->first());
         $this->assertEquals(null, (new ArrayList())->first());
     }
 
-    public function testFlush() {
+    public function testFlush(): void {
         $this->assertEquals(new ArrayList(), $this->object->flush());
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $this->assertEquals('bar', $this->object->get(1));
         $this->assertEquals(null, $this->object->get(4));
     }
 
-    public function testHas() {
+    public function testHas(): void {
         $this->assertTrue($this->object->has(1));
         $this->assertFalse($this->object->has(5));
     }
 
-    public function testIsEmpty() {
+    public function testIsEmpty(): void {
         $this->assertFalse($this->object->isEmpty());
         $this->object->clear();
         $this->assertTrue($this->object->isEmpty());
     }
 
-    public function testJsonSerialize() {
+    public function testJsonSerialize(): void {
         $this->assertEquals(['foo', 'bar', 'baz'], $this->object->jsonSerialize());
     }
 
-    public function testKeyOf() {
+    public function testKeyOf(): void {
         $this->assertEquals(2, $this->object->keyOf('baz'));
         $this->assertEquals(-1, $this->object->keyOf('fop'));
     }
 
-    public function testKeys() {
+    public function testKeys(): void {
         $this->assertEquals(Vector {0, 1, 2}, $this->object->keys());
         $this->object->add('fop');
         $this->assertEquals(Vector {0, 1, 2, 3}, $this->object->keys());
     }
 
-    public function testLast() {
+    public function testLast(): void {
         $this->assertEquals('baz', $this->object->last());
         $this->assertEquals(null, (new ArrayList())->last());
     }
 
-    public function testLength() {
+    public function testLength(): void {
         $this->assertEquals(3, $this->object->length());
         $this->object->add('fop');
         $this->assertEquals(4, $this->object->length());
     }
 
-    public function testMap() {
+    public function testMap(): void {
         $this->assertEquals(new ArrayList(Vector {'Foo', 'Bar', 'Baz'}), $this->object->map(function(string $value): string {
             return ucfirst($value);
         }));
     }
 
-    public function testMapWithKey() {
+    public function testMapWithKey(): void {
         $this->assertEquals(new ArrayList(Vector {'Foo0', 'Bar1', 'Baz2'}), $this->object->mapWithKey(function(int $index, string $value): string {
             return ucfirst($value) . $index;
         }));
     }
 
-    public function testMerge() {
+    public function testMerge(): void {
         $this->assertEquals(new ArrayList(Vector {1, 2, 'baz'}), $this->object->merge(new ArrayList(Vector {1, 2})));
     }
 
-    public function testPluck() {
+    public function testPluck(): void {
         $list = new ArrayList(Vector {
             Map {'key' => 1},
             Map {'key' => 2},
             Map {'key' => 3},
         });
 
-        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(function($value, $key) {
+        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(function($value, $key): void {
             return $value['key'];
         }));
     }
 
-    public function testPrepend() {
+    public function testPrepend(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $list = $this->object->prepend('fop');
@@ -255,11 +255,11 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'oof', 'fop', 'foo', 'bar', 'baz'}), $list);
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $this->assertEquals(new ArrayList(Vector {'bar', 'baz'}), $this->object->remove(0));
     }
 
-    public function testResize() {
+    public function testResize(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $this->object->resize(1, 'aaa');
@@ -271,17 +271,17 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'foo', 'zzz', 'zzz'}), $this->object);
     }
 
-    public function testReverse() {
+    public function testReverse(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
         $this->assertEquals(new ArrayList(Vector {'baz', 'bar', 'foo'}), $this->object->reverse());
     }
 
-    public function testSerialize() {
+    public function testSerialize(): void {
         $this->assertEquals('C:20:"Titon\Type\ArrayList":50:{V:9:"HH\Vector":3:{s:3:"foo";s:3:"bar";s:3:"baz";}}', serialize($this->object));
         $this->assertEquals('V:9:"HH\Vector":3:{s:3:"foo";s:3:"bar";s:3:"baz";}', $this->object->serialize());
     }
 
-    public function testSet() {
+    public function testSet(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $this->object->set(0, 'oof');
@@ -289,7 +289,7 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'oof', 'bar', 'baz'}), $this->object);
     }
 
-    public function testSetAll() {
+    public function testSetAll(): void {
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz'}), $this->object);
 
         $this->object->setAll(Map {
@@ -300,24 +300,24 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList(Vector {'oof', 'bar', 'zab'}), $this->object);
     }
 
-    public function testShuffle() {
+    public function testShuffle(): void {
         $vector = Vector {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         $list = new ArrayList($vector);
 
         $this->assertNotEquals(new ArrayList($vector), $list->shuffle());
     }
 
-    public function testSome() {
-        $this->assertTrue($this->object->some(function(int $key, mixed $value) {
+    public function testSome(): void {
+        $this->assertTrue($this->object->some(function(int $key, mixed $value): void {
             return is_string($value);
         }));
 
-        $this->assertFalse($this->object->some(function(int $key, mixed $value) {
+        $this->assertFalse($this->object->some(function(int $key, mixed $value): void {
             return is_numeric($value);
         }));
     }
 
-    public function testSort() {
+    public function testSort(): void {
         $list = new ArrayList([5, 3, 4, 2, 1]);
 
         $list2 = $list->sort();
@@ -325,7 +325,7 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList([1, 2, 3, 4, 5]), $list2);
     }
 
-    public function testSortWithCallback() {
+    public function testSortWithCallback(): void {
         $list = new ArrayList([5, 3, 4, 2, 1]);
 
         $callback = function($a, $b) {
@@ -343,7 +343,7 @@ class ArrayListTest extends TestCase {
         $this->assertEquals(new ArrayList([5, 4, 3, 2, 1]), $list2);
     }
 
-    public function testSortNatural() {
+    public function testSortNatural(): void {
         $list = new ArrayList([
             'item 109',
             'apple',
@@ -384,23 +384,23 @@ class ArrayListTest extends TestCase {
         ]), $sort2);
     }
 
-    public function testSplice() {
+    public function testSplice(): void {
         $list = $this->object->splice(1, 1);
 
         $this->assertEquals(new ArrayList(Vector {'foo', 'baz'}), $list);
         $this->assertNotEquals($this->object, $list);
     }
 
-    public function testToArray() {
+    public function testToArray(): void {
         $this->assertEquals(['foo', 'bar', 'baz'], $this->object->toArray());
     }
 
-    public function testToJson() {
+    public function testToJson(): void {
         $this->assertEquals('["foo","bar","baz"]', json_encode($this->object));
         $this->assertEquals('["foo","bar","baz"]', $this->object->toJson());
     }
 
-    public function testToXml() {
+    public function testToXml(): void {
         $this->assertEquals(
             '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
             '<items>' . PHP_EOL .
@@ -411,23 +411,23 @@ class ArrayListTest extends TestCase {
         , $this->object->toXml());
     }
 
-    public function testUnserialize() {
+    public function testUnserialize(): void {
         $serialized = serialize($this->object);
 
         $this->assertEquals($this->object, unserialize($serialized));
     }
 
-    public function testUnique() {
+    public function testUnique(): void {
         $list = new ArrayList(Vector {'foo', 'bar', 'baz', 'foo', 'baz', 'fop'});
 
         $this->assertEquals(new ArrayList(Vector {'foo', 'bar', 'baz', 'fop'}), $list->unique());
     }
 
-    public function testValue() {
+    public function testValue(): void {
         $this->assertEquals(Vector {'foo', 'bar', 'baz'}, $this->object->value());
     }
 
-    public function testValues() {
+    public function testValues(): void {
         $this->assertEquals(Vector {'foo', 'bar', 'baz'}, $this->object->values());
     }
 

--- a/tests/Titon/Type/ArrayListTest.hh
+++ b/tests/Titon/Type/ArrayListTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Type;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Type/HashMapTest.hh
+++ b/tests/Titon/Type/HashMapTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Type;
 
 use Titon\Test\TestCase;
@@ -274,7 +274,7 @@ class HashMapTest extends TestCase {
                 14 => Map {'id' => 14, 'series_id' => 3, 'name' => 'The Two Towers', 'isbn' => '', 'released' => '1954-11-11'},
                 15 => Map {'id' => 15, 'series_id' => 3, 'name' => 'The Return of the King', 'isbn' => '', 'released' => '1955-10-25'},
             ])
-        ]), $books->groupBy(($item) ==> $item['series_id']));
+        ]), $books->groupBy(($item, $key) ==> $item['series_id']));
     }
 
     public function testHas(): void {

--- a/tests/Titon/Type/HashMapTest.hh
+++ b/tests/Titon/Type/HashMapTest.hh
@@ -204,9 +204,7 @@ class HashMapTest extends TestCase {
     }
 
     public function testEach(): void {
-        $this->assertEquals(new HashMap(Map {'a' => 'FOO', 'b' => 'BAR', 'c' => 'BAZ'}), $this->object->each(function(string $key, string $value): string {
-            return strtoupper($value);
-        }));
+        $this->assertEquals(new HashMap(Map {'a' => 'FOO', 'b' => 'BAR', 'c' => 'BAZ'}), $this->object->each(($key, $value) ==> strtoupper($value)));
     }
 
     public function testErase(): void {
@@ -214,15 +212,11 @@ class HashMapTest extends TestCase {
     }
 
     public function testFilter(): void {
-        $this->assertEquals(new HashMap(Map {'b' => 'bar', 'c' => 'baz'}), $this->object->filter(function(string $value): bool {
-            return (strpos($value, 'b') !== false);
-        }));
+        $this->assertEquals(new HashMap(Map {'b' => 'bar', 'c' => 'baz'}), $this->object->filter(($value) ==> (strpos($value, 'b') !== false)));
     }
 
     public function testFilterWithKey(): void {
-        $this->assertEquals(new HashMap(Map {'c' => 'baz'}), $this->object->filterWithKey(function(string $index, string $value): bool {
-            return ($index === 'c');
-        }));
+        $this->assertEquals(new HashMap(Map {'c' => 'baz'}), $this->object->filterWithKey(($index, $value) ==> ($index === 'c')));
     }
 
     public function testFirst(): void {
@@ -280,9 +274,7 @@ class HashMapTest extends TestCase {
                 14 => Map {'id' => 14, 'series_id' => 3, 'name' => 'The Two Towers', 'isbn' => '', 'released' => '1954-11-11'},
                 15 => Map {'id' => 15, 'series_id' => 3, 'name' => 'The Return of the King', 'isbn' => '', 'released' => '1955-10-25'},
             ])
-        ]), $books->groupBy(function($item): void {
-            return $item['series_id'];
-        }));
+        ]), $books->groupBy(($item) ==> $item['series_id']));
     }
 
     public function testHas(): void {
@@ -329,15 +321,11 @@ class HashMapTest extends TestCase {
     }
 
     public function testMap(): void {
-        $this->assertEquals(new HashMap(Map {'a' => 'Foo', 'b' => 'Bar', 'c' => 'Baz'}), $this->object->map(function(string $value): string {
-            return ucfirst($value);
-        }));
+        $this->assertEquals(new HashMap(Map {'a' => 'Foo', 'b' => 'Bar', 'c' => 'Baz'}), $this->object->map(($value) ==> ucfirst($value)));
     }
 
     public function testMapWithKey(): void {
-        $this->assertEquals(new HashMap(Map {'a' => 'FooA', 'b' => 'BarB', 'c' => 'BazC'}), $this->object->mapWithKey(function(string $index, string $value): string {
-            return ucfirst($value) . strtoupper($index);
-        }));
+        $this->assertEquals(new HashMap(Map {'a' => 'FooA', 'b' => 'BarB', 'c' => 'BazC'}), $this->object->mapWithKey(($index, $value) ==> ucfirst($value) . strtoupper($index)));
     }
 
     public function testMerge(): void {
@@ -351,9 +339,7 @@ class HashMapTest extends TestCase {
             'c' => Map {'key' => 3},
         });
 
-        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(function($value, $key): void {
-            return $value['key'];
-        }));
+        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(($value, $key) ==> $value['key']));
     }
 
     public function testRemove(): void {
@@ -435,13 +421,9 @@ class HashMapTest extends TestCase {
     }
 
     public function testSome(): void {
-        $this->assertTrue($this->object->some(function(string $key, mixed $value): void {
-            return is_string($value);
-        }));
+        $this->assertTrue($this->object->some(($key, $value) ==> is_string($value)));
 
-        $this->assertFalse($this->object->some(function(string $key, mixed $value): void {
-            return is_numeric($value);
-        }));
+        $this->assertFalse($this->object->some(($key, $value) ==> is_numeric($value)));
     }
 
     public function testSort(): void {
@@ -473,7 +455,7 @@ class HashMapTest extends TestCase {
             'e' => 2
         ]);
 
-        $callback = function($a, $b) {
+        $callback = ($a, $b) ==> {
             if ($a == $b) {
                 return 0;
             } else if ($a > $b) {

--- a/tests/Titon/Type/HashMapTest.hh
+++ b/tests/Titon/Type/HashMapTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Type;
 
 use Titon\Test\TestCase;
@@ -8,7 +8,7 @@ use Titon\Test\TestCase;
  */
 class HashMapTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new HashMap(Map {
@@ -18,7 +18,7 @@ class HashMapTest extends TestCase {
         });
     }
 
-    public function testIterator() {
+    public function testIterator(): void {
         $array = [];
 
         foreach ($this->object as $key => $value) {
@@ -28,14 +28,14 @@ class HashMapTest extends TestCase {
         $this->assertEquals(['A' => 'foo', 'B' => 'bar', 'C' => 'baz'], $array);
     }
 
-    public function testIndexishConstructors() {
+    public function testIndexishConstructors(): void {
         $this->assertEquals(new HashMap(Map {0 => 'foo'}), new HashMap(['foo']));
         $this->assertEquals(new HashMap(Map {0 => 'foo'}), new HashMap(Vector {'foo'}));
         $this->assertEquals(new HashMap(Map {'a' => 'foo'}), new HashMap(['a' => 'foo']));
         $this->assertEquals(new HashMap(Map {'a' => 'foo'}), new HashMap(Map {'a' => 'foo'}));
     }
 
-    public function testChainableMethods() {
+    public function testChainableMethods(): void {
         $this->assertEquals(new HashMap(Map {
             'a' => 'foo',
             'b' => 'bar',
@@ -57,7 +57,7 @@ class HashMapTest extends TestCase {
         }), $this->object);
     }
 
-    public function testImmutableMethods() {
+    public function testImmutableMethods(): void {
         $this->assertEquals(new HashMap(Map {
             'a' => 'foo',
             'b' => 'bar',
@@ -81,7 +81,7 @@ class HashMapTest extends TestCase {
         $this->assertNotSame($mapped, $this->object);
     }
 
-    public function testAdd() {
+    public function testAdd(): void {
         $this->assertEquals(new HashMap(Map {
             'a' => 'foo',
             'b' => 'bar',
@@ -100,7 +100,7 @@ class HashMapTest extends TestCase {
         }), $this->object);
     }
 
-    public function testAddAll() {
+    public function testAddAll(): void {
         $this->assertEquals(new HashMap(Map {
             'a' => 'foo',
             'b' => 'bar',
@@ -118,18 +118,18 @@ class HashMapTest extends TestCase {
         }), $this->object);
     }
 
-    public function testAt() {
+    public function testAt(): void {
         $this->assertEquals('bar', $this->object->at('b'));
     }
 
     /**
      * @expectedException \OutOfBoundsException
      */
-    public function testAtThrowsError() {
+    public function testAtThrowsError(): void {
         $this->assertEquals('bar', $this->object->at('z'));
     }
 
-    public function testChunk() {
+    public function testChunk(): void {
         $this->assertEquals(new ArrayList(Vector {
             new HashMap(Map {'a' => 'foo'}),
             new HashMap(Map {'b' => 'bar'}),
@@ -137,7 +137,7 @@ class HashMapTest extends TestCase {
         }), $this->object->chunk(1));
     }
 
-    public function testClean() {
+    public function testClean(): void {
         $list = new HashMap(Vector {1, 0, '0', false, true, null, 'foo', '', 0.0});
 
         $this->assertEquals(new HashMap(Map {
@@ -150,11 +150,11 @@ class HashMapTest extends TestCase {
         }), $list->clean());
     }
 
-    public function testClear() {
+    public function testClear(): void {
         $this->assertEquals(new HashMap(), $this->object->flush());
     }
 
-    public function testClone() {
+    public function testClone(): void {
         $map = Map {'a' => 'foo'};
         $list = new HashMap($map);
         $clone = clone $list;
@@ -162,7 +162,7 @@ class HashMapTest extends TestCase {
         $this->assertNotSame($map, $clone->value());
     }
 
-    public function testConcat() {
+    public function testConcat(): void {
         $list1 = $this->object->concat(new HashMap(Map {'x' => 1, 'y' => 2, 'z' => 3}));
 
         $this->assertEquals(new HashMap(Map {
@@ -188,58 +188,58 @@ class HashMapTest extends TestCase {
         $this->assertNotSame($list1, $this->object);
     }
 
-    public function testContains() {
+    public function testContains(): void {
         $this->assertTrue($this->object->contains('foo'));
         $this->assertFalse($this->object->contains(123));
     }
 
-    public function testCount() {
+    public function testCount(): void {
         $this->assertEquals(3, $this->object->count());
         $this->object->add(Pair {'d', 'fop'});
         $this->assertEquals(4, $this->object->count());
     }
 
-    public function testDepth() {
+    public function testDepth(): void {
         $this->assertEquals(1, $this->object->depth());
     }
 
-    public function testEach() {
+    public function testEach(): void {
         $this->assertEquals(new HashMap(Map {'a' => 'FOO', 'b' => 'BAR', 'c' => 'BAZ'}), $this->object->each(function(string $key, string $value): string {
             return strtoupper($value);
         }));
     }
 
-    public function testErase() {
+    public function testErase(): void {
         $this->assertEquals(new HashMap(Map {'b' => 'bar', 'c' => 'baz'}), $this->object->erase('foo'));
     }
 
-    public function testFilter() {
+    public function testFilter(): void {
         $this->assertEquals(new HashMap(Map {'b' => 'bar', 'c' => 'baz'}), $this->object->filter(function(string $value): bool {
             return (strpos($value, 'b') !== false);
         }));
     }
 
-    public function testFilterWithKey() {
+    public function testFilterWithKey(): void {
         $this->assertEquals(new HashMap(Map {'c' => 'baz'}), $this->object->filterWithKey(function(string $index, string $value): bool {
             return ($index === 'c');
         }));
     }
 
-    public function testFirst() {
+    public function testFirst(): void {
         $this->assertEquals('foo', $this->object->first());
         $this->assertEquals(null, (new HashMap())->first());
     }
 
-    public function testFlush() {
+    public function testFlush(): void {
         $this->assertEquals(new HashMap(), $this->object->flush());
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $this->assertEquals('bar', $this->object->get('b'));
         $this->assertEquals(null, $this->object->get('z'));
     }
 
-    public function testGroupBy() {
+    public function testGroupBy(): void {
         $books = new HashMap([
             1 => Map {'id' => 1, 'series_id' => 1, 'name' => 'A Game of Thrones', 'isbn' => '0-553-10354-7', 'released' => '1996-08-02'},
             2 => Map {'id' => 2, 'series_id' => 1, 'name' => 'A Clash of Kings', 'isbn' => '0-553-10803-4', 'released' => '1999-02-25'},
@@ -280,87 +280,87 @@ class HashMapTest extends TestCase {
                 14 => Map {'id' => 14, 'series_id' => 3, 'name' => 'The Two Towers', 'isbn' => '', 'released' => '1954-11-11'},
                 15 => Map {'id' => 15, 'series_id' => 3, 'name' => 'The Return of the King', 'isbn' => '', 'released' => '1955-10-25'},
             ])
-        ]), $books->groupBy(function($item) {
+        ]), $books->groupBy(function($item): void {
             return $item['series_id'];
         }));
     }
 
-    public function testHas() {
+    public function testHas(): void {
         $this->assertTrue($this->object->has('b'));
         $this->assertFalse($this->object->has('z'));
     }
 
-    public function testIndexOf() {
+    public function testIndexOf(): void {
         $this->assertEquals(0, $this->object->indexOf('a'));
         $this->assertEquals(2, $this->object->indexOf('c'));
         $this->assertEquals(-1, $this->object->indexOf('z'));
     }
 
-    public function testIsEmpty() {
+    public function testIsEmpty(): void {
         $this->assertFalse($this->object->isEmpty());
         $this->object->clear();
         $this->assertTrue($this->object->isEmpty());
     }
 
-    public function testJsonSerialize() {
+    public function testJsonSerialize(): void {
         $this->assertEquals(['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], $this->object->jsonSerialize());
     }
 
-    public function testKeyOf() {
+    public function testKeyOf(): void {
         $this->assertEquals('c', $this->object->keyOf('baz'));
         $this->assertEquals(null, $this->object->keyOf('fop'));
     }
 
-    public function testKeys() {
+    public function testKeys(): void {
         $this->assertEquals(Vector {'a', 'b', 'c'}, $this->object->keys());
         $this->object->set('d', 'fop');
         $this->assertEquals(Vector {'a', 'b', 'c', 'd'}, $this->object->keys());
     }
 
-    public function testLast() {
+    public function testLast(): void {
         $this->assertEquals('baz', $this->object->last());
         $this->assertEquals(null, (new HashMap())->last());
     }
 
-    public function testLength() {
+    public function testLength(): void {
         $this->assertEquals(3, $this->object->length());
         $this->object->set('d', 'fop');
         $this->assertEquals(4, $this->object->length());
     }
 
-    public function testMap() {
+    public function testMap(): void {
         $this->assertEquals(new HashMap(Map {'a' => 'Foo', 'b' => 'Bar', 'c' => 'Baz'}), $this->object->map(function(string $value): string {
             return ucfirst($value);
         }));
     }
 
-    public function testMapWithKey() {
+    public function testMapWithKey(): void {
         $this->assertEquals(new HashMap(Map {'a' => 'FooA', 'b' => 'BarB', 'c' => 'BazC'}), $this->object->mapWithKey(function(string $index, string $value): string {
             return ucfirst($value) . strtoupper($index);
         }));
     }
 
-    public function testMerge() {
+    public function testMerge(): void {
         $this->assertEquals(new HashMap(Map {'a' => 1, 'b' => 2, 'c' => 'baz'}), $this->object->merge(new HashMap(Map {'a' => 1, 'b' => 2})));
     }
 
-    public function testPluck() {
+    public function testPluck(): void {
         $list = new HashMap(Map {
             'a' => Map {'key' => 1},
             'b' => Map {'key' => 2},
             'c' => Map {'key' => 3},
         });
 
-        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(function($value, $key) {
+        $this->assertEquals(Vector {1, 2, 3}, $list->pluck(function($value, $key): void {
             return $value['key'];
         }));
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $this->assertEquals(new HashMap(Map {'b' => 'bar', 'c' => 'baz'}), $this->object->remove('a'));
     }
 
-    public function testReorder() {
+    public function testReorder(): void {
         $this->assertEquals(new HashMap([
             'YQ==' => 'foo',
             'Yg==' => 'bar',
@@ -368,7 +368,7 @@ class HashMapTest extends TestCase {
         ]), $this->object->reorder(($item, $key) ==> base64_encode($key)));
     }
 
-    public function testReorderComplex() {
+    public function testReorderComplex(): void {
         $map = new HashMap([
             'a' => Map {'id' => 5, 'name' => 'foo'},
             'b' => Map {'id' => 10, 'name' => 'bar'},
@@ -382,17 +382,17 @@ class HashMapTest extends TestCase {
         ]), $map->reorder(($item, $key) ==> $item['id']));
     }
 
-    public function testReverse() {
+    public function testReverse(): void {
         $this->assertEquals(new HashMap(Map {'a' => 'foo', 'b' => 'bar', 'c' => 'baz'}), $this->object);
         $this->assertEquals(new HashMap(Map {'c' => 'baz', 'b' => 'bar', 'a' => 'foo'}), $this->object->reverse());
     }
 
-    public function testSerialize() {
+    public function testSerialize(): void {
         $this->assertEquals('C:18:"Titon\Type\HashMap":71:{K:6:"HH\Map":3:{s:1:"a";s:3:"foo";s:1:"b";s:3:"bar";s:1:"c";s:3:"baz";}}', serialize($this->object));
         $this->assertEquals('K:6:"HH\Map":3:{s:1:"a";s:3:"foo";s:1:"b";s:3:"bar";s:1:"c";s:3:"baz";}', $this->object->serialize());
     }
 
-    public function testSet() {
+    public function testSet(): void {
         $this->assertEquals(new HashMap(Map {
             'a' => 'foo',
             'b' => 'bar',
@@ -408,7 +408,7 @@ class HashMapTest extends TestCase {
         }), $this->object);
     }
 
-    public function testSetAll() {
+    public function testSetAll(): void {
         $this->assertEquals(new HashMap(Map {
             'a' => 'foo',
             'b' => 'bar',
@@ -427,24 +427,24 @@ class HashMapTest extends TestCase {
         }), $this->object);
     }
 
-    public function testShuffle() {
+    public function testShuffle(): void {
         $vector = Vector {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         $list = new HashMap($vector);
 
         $this->assertNotEquals(new HashMap($vector), $list->shuffle());
     }
 
-    public function testSome() {
-        $this->assertTrue($this->object->some(function(string $key, mixed $value) {
+    public function testSome(): void {
+        $this->assertTrue($this->object->some(function(string $key, mixed $value): void {
             return is_string($value);
         }));
 
-        $this->assertFalse($this->object->some(function(string $key, mixed $value) {
+        $this->assertFalse($this->object->some(function(string $key, mixed $value): void {
             return is_numeric($value);
         }));
     }
 
-    public function testSort() {
+    public function testSort(): void {
         $map = new HashMap([
             'a' => 5,
             'b' => 3,
@@ -464,7 +464,7 @@ class HashMapTest extends TestCase {
         ]), $map2);
     }
 
-    public function testSortWithCallback() {
+    public function testSortWithCallback(): void {
         $map = new HashMap([
             'a' => 5,
             'b' => 3,
@@ -494,16 +494,16 @@ class HashMapTest extends TestCase {
         ]), $map2);
     }
 
-    public function testToArray() {
+    public function testToArray(): void {
         $this->assertEquals(['a' => 'foo', 'b' => 'bar', 'c' => 'baz'], $this->object->toArray());
     }
 
-    public function testToJson() {
+    public function testToJson(): void {
         $this->assertEquals('{"a":"foo","b":"bar","c":"baz"}', json_encode($this->object));
         $this->assertEquals('{"a":"foo","b":"bar","c":"baz"}', $this->object->toJson());
     }
 
-    public function testToXml() {
+    public function testToXml(): void {
         $this->assertEquals(
             '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL .
             '<document>' . PHP_EOL .
@@ -514,13 +514,13 @@ class HashMapTest extends TestCase {
             , $this->object->toXml());
     }
 
-    public function testUnserialize() {
+    public function testUnserialize(): void {
         $serialized = serialize($this->object);
 
         $this->assertEquals($this->object, unserialize($serialized));
     }
 
-    public function testUnique() {
+    public function testUnique(): void {
         $list = new HashMap(Vector {'foo', 'bar', 'baz', 'foo', 'baz', 'fop'});
 
         $this->assertEquals(new HashMap(Map {
@@ -531,7 +531,7 @@ class HashMapTest extends TestCase {
         }), $list->unique());
     }
 
-    public function testValue() {
+    public function testValue(): void {
         $this->assertEquals(Map {
             'a' => 'foo',
             'b' => 'bar',
@@ -539,7 +539,7 @@ class HashMapTest extends TestCase {
         }, $this->object->value());
     }
 
-    public function testValues() {
+    public function testValues(): void {
         $this->assertEquals(Vector {'foo', 'bar', 'baz'}, $this->object->values());
     }
 

--- a/tests/Titon/Type/StringBufferTest.hh
+++ b/tests/Titon/Type/StringBufferTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Type;
 
 use Titon\Test\TestCase;
@@ -8,38 +8,38 @@ use Titon\Test\TestCase;
  */
 class StringTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new StringBuffer('titon');
     }
 
-    public function testAppend() {
+    public function testAppend(): void {
         $this->assertEquals('titon framework', $this->object->append(' framework')->value());
     }
 
-    public function testCapitalize() {
+    public function testCapitalize(): void {
         $this->assertEquals('Titon', $this->object->capitalize()->value());
     }
 
-    public function testCharAt() {
+    public function testCharAt(): void {
         $this->assertEquals('o', $this->object->charAt(3));
         $this->assertEquals(null, $this->object->charAt(10));
     }
 
-    public function testClean() {
+    public function testClean(): void {
         $string = new StringBuffer('  titon       framework' . PHP_EOL);
 
         $this->assertEquals('titon framework', $string->clean()->value());
     }
 
-    public function testCompare() {
+    public function testCompare(): void {
         $this->assertEquals(0, $this->object->compare('titon'));
         $this->assertLessThan(0, $this->object->compare('titon framework'));
         $this->assertGreaterThan(0, $this->object->compare('tit'));
     }
 
-    public function testConcat() {
+    public function testConcat(): void {
         $append = $this->object->concat(' append');
 
         $this->assertEquals('titon append', $append->value());
@@ -49,40 +49,40 @@ class StringTest extends TestCase {
         $this->assertEquals('prepend titon', $prepend->value());
     }
 
-    public function testContains() {
+    public function testContains(): void {
         $this->assertTrue($this->object->contains('tit'));
         $this->assertFalse($this->object->contains('tin'));
     }
 
-    public function testEndsWith() {
+    public function testEndsWith(): void {
         $this->assertTrue($this->object->endsWith('ton'));
         $this->assertFalse($this->object->endsWith('tan'));
     }
 
-    public function testEquals() {
+    public function testEquals(): void {
         $this->assertTrue($this->object->equals('titon'));
         $this->assertFalse($this->object->equals('titan'));
     }
 
-    public function testEscape() {
+    public function testEscape(): void {
         $string = new StringBuffer('"Titon"');
 
         $this->assertEquals('&quot;Titon&quot;', $string->escape()->value());
     }
 
-    public function testExtract() {
+    public function testExtract(): void {
         $this->assertEquals('tit', $this->object->extract(0, 3));
         $this->assertEquals('ton', $this->object->extract(2));
         $this->assertEquals('on', $this->object->extract(-2));
     }
 
-    public function testIndexOf() {
+    public function testIndexOf(): void {
         $this->assertEquals(0, $this->object->indexOf('t'));
         $this->assertEquals(4, $this->object->indexOf('n'));
         $this->assertEquals(-1, $this->object->indexOf('r'));
     }
 
-    public function testIsEmpty() {
+    public function testIsEmpty(): void {
         $string = new StringBuffer('');
 
         $this->assertTrue($string->isEmpty());
@@ -92,41 +92,41 @@ class StringTest extends TestCase {
         $this->assertFalse($string->isEmpty());
     }
 
-    public function testLastIndexOf() {
+    public function testLastIndexOf(): void {
         $this->assertEquals(2, $this->object->lastIndexOf('t'));
         $this->assertEquals(4, $this->object->lastIndexOf('n'));
         $this->assertEquals(-1, $this->object->lastIndexOf('r'));
     }
 
-    public function testLength() {
+    public function testLength(): void {
         $this->assertEquals(5, $this->object->length());
 
         $this->assertEquals(15, $this->object->append(' framework')->length());
     }
 
-    public function testMatches() {
+    public function testMatches(): void {
         $this->assertEquals(1, $this->object->matches('/tit/'));
         $this->assertEquals(['tit'], $this->object->matches('/tit/', true));
         $this->assertEquals(0, $this->object->matches('/tat/'));
     }
 
-    public function testPad() {
+    public function testPad(): void {
         $this->assertEquals('--titon---', $this->object->pad(10, '-'));
     }
 
-    public function testPadLeft() {
+    public function testPadLeft(): void {
         $this->assertEquals('-----titon', $this->object->padLeft(10, '-'));
     }
 
-    public function testPadRight() {
+    public function testPadRight(): void {
         $this->assertEquals('titon-----', $this->object->padRight(10, '-'));
     }
 
-    public function testPrepend() {
+    public function testPrepend(): void {
         $this->assertEquals('php framework: titon', $this->object->prepend('php framework: ')->value());
     }
 
-    public function testReplace() {
+    public function testReplace(): void {
         $object = $this->object->replace('tit', 'TIT');
         $this->assertEquals('TITon', $object->value());
 
@@ -137,82 +137,82 @@ class StringTest extends TestCase {
         $this->assertEquals('titon', $object->value());
     }
 
-    public function testReverse() {
+    public function testReverse(): void {
         $this->assertEquals('notit', $this->object->reverse()->value());
     }
 
-    public function testSerialize() {
+    public function testSerialize(): void {
         $serialized = serialize($this->object);
 
         $this->assertEquals('C:23:"Titon\Type\StringBuffer":12:{s:5:"titon";}', $serialized);
         $this->assertEquals($this->object, unserialize($serialized));
     }
 
-    public function testShuffle() {
+    public function testShuffle(): void {
         $this->object->append(' framework');
         $this->object->shuffle();
         $this->assertNotEquals('titon framework', $this->object->value());
     }
 
-    public function testStartsWith() {
+    public function testStartsWith(): void {
         $this->assertTrue($this->object->startsWith('tit'));
         $this->assertFalse($this->object->startsWith('tot'));
     }
 
-    public function testStrip() {
+    public function testStrip(): void {
         $this->assertEquals('titon', $this->object->write('<b>titon</b>')->strip()->value());
     }
 
-    public function testSplit() {
+    public function testSplit(): void {
         $this->assertEquals(Vector {'t', 'i', 't', 'o', 'n'}, $this->object->split());
         $this->assertEquals(Vector {'ti', 'to', 'n'}, $this->object->split('', 2));
         $this->assertEquals(Vector {'', 'i', 'on'}, $this->object->split('t'));
         $this->assertEquals(Vector {'', 'iton'}, $this->object->split('t', 2));
     }
 
-    public function testToCamelCase() {
+    public function testToCamelCase(): void {
         $this->assertEquals('TitonFramework', $this->object->write('titon framework')->toCamelCase()->value());
     }
 
-    public function testToLowerCase() {
+    public function testToLowerCase(): void {
         $this->assertEquals('titon framework', $this->object->write('TITON fRamEwork')->toLowerCase()->value());
     }
 
-    public function testToUpperCase() {
+    public function testToUpperCase(): void {
         $this->assertEquals('TITON FRAMEWORK', $this->object->write('titon framework')->toUpperCase()->value());
     }
 
-    public function testToUpperWords() {
+    public function testToUpperWords(): void {
         $this->assertEquals('Titon Framework', $this->object->write('titon framework')->toUpperWords()->value());
     }
 
-    public function testTrim() {
+    public function testTrim(): void {
         $this->assertEquals('iton', $this->object->trim('t')->value());
         $this->assertEquals('titon', $this->object->write(' titon ')->trim()->value());
     }
 
-    public function testTrimLeft() {
+    public function testTrimLeft(): void {
         $this->assertEquals('titon ', $this->object->write(' titon ')->trimLeft()->value());
         $this->assertEquals('titon-', $this->object->write('-titon-')->trimLeft('-')->value());
     }
 
-    public function testTrimRight() {
+    public function testTrimRight(): void {
         $this->assertEquals(' titon', $this->object->write(' titon ')->trimRight()->value());
         $this->assertEquals('-titon', $this->object->write('-titon-')->trimRight('-')->value());
     }
 
-    public function testUncapitalize() {
+    public function testUncapitalize(): void {
         $this->assertEquals('titon Framework', $this->object->write('Titon Framework')->uncapitalize()->value());
     }
 
-    public function testWordCount() {
+    public function testWordCount(): void {
         $this->assertEquals(1, $this->object->wordCount());
 
         $this->object->write('Titon Framework');
         $this->assertEquals(2, $this->object->wordCount());
     }
 
-    public function testWrite() {
+    public function testWrite(): void {
         $this->object->write('framework');
         $this->assertEquals('framework', $this->object->value());
     }

--- a/tests/Titon/Type/StringBufferTest.hh
+++ b/tests/Titon/Type/StringBufferTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Type;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Type/TypeTest.hh
+++ b/tests/Titon/Type/TypeTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Type;
 
 use Titon\Test\TestCase;
 
 class TypeTest extends TestCase {
 
-    public function testIs() {
+    public function testIs(): void {
         $this->assertEquals('array', Type::is([]));
         $this->assertEquals('object', Type::is(new \stdClass()));
         $this->assertEquals('map', Type::is(Map {}));
@@ -18,7 +18,7 @@ class TypeTest extends TestCase {
         $this->assertEquals('string', Type::is('foo'));
     }
 
-    public function testIsResource() {
+    public function testIsResource(): void {
         $f = fopen('php://input', 'r');
 
         $this->assertEquals('resource', Type::is($f));

--- a/tests/Titon/Type/TypeTest.hh
+++ b/tests/Titon/Type/TypeTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Type;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Type/Xml/ElementTest.hh
+++ b/tests/Titon/Type/Xml/ElementTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Type\Xml;
 
 use Titon\Test\TestCase;
@@ -8,18 +8,18 @@ use Titon\Test\TestCase;
  */
 class XmlElementTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new Element('root', Map {'foo' => 'bar'});
     }
 
-    public function testConstruct() {
+    public function testConstruct(): void {
         $this->assertEquals('root', $this->object->getName());
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->getAttributes());
     }
 
-    public function testAddChild() {
+    public function testAddChild(): void {
         $boy = new Element('boy');
         $girl = new Element('girl');
 
@@ -31,7 +31,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(Vector {$boy, $girl}, $this->object->getChildren());
     }
 
-    public function testAddChildren() {
+    public function testAddChildren(): void {
         $boy = new Element('boy');
         $girl = new Element('girl');
 
@@ -42,7 +42,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(Vector {$boy, $girl}, $this->object->getChildren());
     }
 
-    public function testCount() {
+    public function testCount(): void {
         $boy = new Element('boy');
         $girl = new Element('girl');
 
@@ -53,16 +53,16 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(2, $this->object->count());
     }
 
-    public function testGetAttribute() {
+    public function testGetAttribute(): void {
         $this->assertEquals('', $this->object->getAttribute('baz'));
         $this->assertEquals('bar', $this->object->getAttribute('foo'));
     }
 
-    public function testGetAttributes() {
+    public function testGetAttributes(): void {
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->getAttributes());
     }
 
-    public function testGetBoxedValue() {
+    public function testGetBoxedValue(): void {
         $this->object->setValue(false, true);
 
         $this->assertEquals('<![CDATA[' . PHP_EOL . 'false' . PHP_EOL . ']]>', $this->object->getValue());
@@ -82,7 +82,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(null, $this->object->getBoxedValue());
     }
 
-    public function testGetChild() {
+    public function testGetChild(): void {
         $boy1 = new Element('boy');
         $boy2 = new Element('boy');
         $girl = new Element('girl');
@@ -94,7 +94,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(null, $this->object->getChild('dog'));
     }
 
-    public function testGetChildrenByName() {
+    public function testGetChildrenByName(): void {
         $boy1 = new Element('boy');
         $boy2 = new Element('boy');
         $girl = new Element('girl');
@@ -105,18 +105,18 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(Vector {}, $this->object->getChildrenByName('dog'));
     }
 
-    public function testGetDeclaration() {
+    public function testGetDeclaration(): void {
         $this->assertEquals(Map {
             'version' => '1.0',
             'encoding' => 'UTF-8'
         }, $this->object->getDeclaration());
     }
 
-    public function testGetName() {
+    public function testGetName(): void {
         $this->assertEquals('root', $this->object->getName());
     }
 
-    public function testGetNamespace() {
+    public function testGetNamespace(): void {
         $this->assertEquals('', $this->object->getNamespace('foo'));
 
         $this->object->setNamespace('foo', 'baz');
@@ -124,7 +124,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals('baz', $this->object->getNamespace('foo'));
     }
 
-    public function testGetNamespaces() {
+    public function testGetNamespaces(): void {
         $this->assertEquals(Map {}, $this->object->getNamespaces());
 
         $this->object->setNamespaces(Map {
@@ -138,14 +138,14 @@ class XmlElementTest extends TestCase {
         }, $this->object->getNamespaces());
     }
 
-    public function testGetNamespaceAttributes() {
+    public function testGetNamespaceAttributes(): void {
         $this->object->setAttribute('ns:foo', 'qux');
 
         $this->assertEquals(Map {'foo' => 'bar', 'ns:foo' => 'qux'}, $this->object->getAttributes());
         $this->assertEquals(Map {'ns:foo' => 'qux'}, $this->object->getNamespaceAttributes('ns'));
     }
 
-    public function testGetNamespaceChildren() {
+    public function testGetNamespaceChildren(): void {
         $boy = new Element('boy');
         $girl = new Element('ns:girl');
 
@@ -155,7 +155,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(Vector {$girl}, $this->object->getNamespaceChildren('ns'));
     }
 
-    public function testGetParent() {
+    public function testGetParent(): void {
         $child = new Element('child');
 
         $this->object->addChild($child);
@@ -164,7 +164,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals($this->object, $child->getParent());
     }
 
-    public function testGetValueWithoutCdata() {
+    public function testGetValueWithoutCdata(): void {
         $this->object->setValue('value', true);
 
         $this->assertEquals('<![CDATA[' . PHP_EOL . 'value' . PHP_EOL . ']]>', $this->object->getValue());
@@ -176,12 +176,12 @@ class XmlElementTest extends TestCase {
         $this->assertEquals('0', $this->object->getValueWithoutCdata());
     }
 
-    public function testHasAttribute() {
+    public function testHasAttribute(): void {
         $this->assertTrue($this->object->hasAttribute('foo'));
         $this->assertFalse($this->object->hasAttribute('bar'));
     }
 
-    public function testHasAttributes() {
+    public function testHasAttributes(): void {
         $child = new Element('child');
 
         $this->assertFalse($child->hasAttributes());
@@ -191,7 +191,7 @@ class XmlElementTest extends TestCase {
         $this->assertTrue($child->hasAttributes());
     }
 
-    public function testHasChildren() {
+    public function testHasChildren(): void {
         $child = new Element('child');
 
         $this->assertFalse($child->hasChildren());
@@ -201,7 +201,7 @@ class XmlElementTest extends TestCase {
         $this->assertTrue($child->hasChildren());
     }
 
-    public function testHasNamespace() {
+    public function testHasNamespace(): void {
         $this->assertFalse($this->object->hasNamespace('foo'));
 
         $this->object->setNamespace('foo', 'bar');
@@ -209,7 +209,7 @@ class XmlElementTest extends TestCase {
         $this->assertTrue($this->object->hasNamespace('foo'));
     }
 
-    public function testHasNamespaces() {
+    public function testHasNamespaces(): void {
         $this->assertFalse($this->object->hasNamespaces());
 
         $this->object->setNamespace('foo', 'bar');
@@ -217,7 +217,7 @@ class XmlElementTest extends TestCase {
         $this->assertTrue($this->object->hasNamespaces());
     }
 
-    public function testIsChild() {
+    public function testIsChild(): void {
         $child = new Element('child');
 
         $this->object->addChild($child);
@@ -226,7 +226,7 @@ class XmlElementTest extends TestCase {
         $this->assertTrue($child->isChild());
     }
 
-    public function testIsRoot() {
+    public function testIsRoot(): void {
         $child = new Element('child');
 
         $this->object->addChild($child);
@@ -235,7 +235,7 @@ class XmlElementTest extends TestCase {
         $this->assertFalse($child->isRoot());
     }
 
-    public function testIterator() {
+    public function testIterator(): void {
         $boy = new Element('boy');
         $girl = new Element('girl');
         $names = [];
@@ -249,7 +249,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(['boy', 'girl'], $names);
     }
 
-    public function testSetAttribute() {
+    public function testSetAttribute(): void {
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->getAttributes());
 
         $this->object->setAttribute('foo', 'baz');
@@ -261,7 +261,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(Map {'foo' => 'baz', 'ns:foo' => 'baz'}, $this->object->getAttributes());
     }
 
-    public function testSetAttributes() {
+    public function testSetAttributes(): void {
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->getAttributes());
 
         $this->object->setAttributes(Map {
@@ -275,7 +275,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->getAttributes());
     }
 
-    public function testSetDeclaration() {
+    public function testSetDeclaration(): void {
         $this->assertEquals(Map {
             'version' => '1.0',
             'encoding' => 'UTF-8'
@@ -290,7 +290,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->getDeclaration());
     }
 
-    public function testSetName() {
+    public function testSetName(): void {
         $this->assertEquals('root', $this->object->getName());
 
         $this->object->setName('document');
@@ -302,7 +302,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals('ns:document', $this->object->getName());
     }
 
-    public function testSetNamespace() {
+    public function testSetNamespace(): void {
         $this->assertEquals(Map {}, $this->object->getNamespaces());
 
         $this->object->setNamespace('foo', 'baz');
@@ -310,7 +310,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals(Map {'foo' => 'baz'}, $this->object->getNamespaces());
     }
 
-    public function testSetNamespaces() {
+    public function testSetNamespaces(): void {
         $this->assertEquals(Map {}, $this->object->getNamespaces());
 
         $this->object->setNamespaces(Map {
@@ -324,7 +324,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->getNamespaces());
     }
 
-    public function testSetNameInflection() {
+    public function testSetNameInflection(): void {
         $this->object->setName('123');
         $this->assertEquals('_123', $this->object->getName());
 
@@ -332,7 +332,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals('foobar', $this->object->getName());
     }
 
-    public function testSetValue() {
+    public function testSetValue(): void {
         $this->assertEquals('', $this->object->getValue());
 
         $this->object->setValue('value');
@@ -340,7 +340,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals('value', $this->object->getValue());
     }
 
-    public function testSetValueCdata() {
+    public function testSetValueCdata(): void {
         $this->assertEquals('', $this->object->getValue());
 
         $this->object->setValue('value', true);
@@ -348,7 +348,7 @@ class XmlElementTest extends TestCase {
         $this->assertEquals('<![CDATA[' . PHP_EOL . 'value' . PHP_EOL . ']]>', $this->object->getValue());
     }
 
-    public function testToMap() {
+    public function testToMap(): void {
         $this->assertEquals(Map {
             'root' => Map {
                 '@attributes' => Map {'foo' => 'bar'},
@@ -357,7 +357,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->toMap());
     }
 
-    public function testToMapValue() {
+    public function testToMapValue(): void {
         $this->object->setValue('foo');
 
         $this->assertEquals(Map {
@@ -368,7 +368,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->toMap());
     }
 
-    public function testToMapZeroValue() {
+    public function testToMapZeroValue(): void {
         $this->object->setValue('0');
 
         $this->assertEquals(Map {
@@ -379,7 +379,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->toMap());
     }
 
-    public function testToMapChildren() {
+    public function testToMapChildren(): void {
         $this->object->setValue('foo');
 
         $this->object->addChildren(Vector {
@@ -396,7 +396,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->toMap());
     }
 
-    public function testToMapChildrenWithSameName() {
+    public function testToMapChildrenWithSameName(): void {
         $this->object->addChildren(Vector {
             new Element('boy', Map {'a' => 1}),
             new Element('boy', Map {'b' => 2}),
@@ -417,7 +417,7 @@ class XmlElementTest extends TestCase {
         }, $this->object->toMap());
     }
 
-    public function testToString() {
+    public function testToString(): void {
         $xml = new Element('root');
 
         $this->assertEquals(
@@ -426,7 +426,7 @@ class XmlElementTest extends TestCase {
         , (string) $xml);
     }
 
-    public function testToStringValue() {
+    public function testToStringValue(): void {
         $xml = new Element('root');
         $xml->setValue('foo');
 
@@ -436,7 +436,7 @@ class XmlElementTest extends TestCase {
         , (string) $xml);
     }
 
-    public function testToStringAttributes() {
+    public function testToStringAttributes(): void {
         $xml = new Element('root', Map {'foo' => 'bar'});
 
         $this->assertEquals(
@@ -445,7 +445,7 @@ class XmlElementTest extends TestCase {
         , (string) $xml);
     }
 
-    public function testToStringAttributesWithQuotes() {
+    public function testToStringAttributesWithQuotes(): void {
         $xml = new Element('root', Map {'single' => "quo'tes", 'double' => 'quo"tes'});
 
         $this->assertEquals(
@@ -454,7 +454,7 @@ class XmlElementTest extends TestCase {
         , (string) $xml);
     }
 
-    public function testToStringAttributesAndValue() {
+    public function testToStringAttributesAndValue(): void {
         $xml = new Element('root', Map {'foo' => 'bar'});
         $xml->setValue('baz');
 
@@ -464,7 +464,7 @@ class XmlElementTest extends TestCase {
         , (string) $xml);
     }
 
-    public function testToStringChildren() {
+    public function testToStringChildren(): void {
         $xml = new Element('root');
         $xml->setValue('Will not be to stringed.');
 
@@ -482,7 +482,7 @@ class XmlElementTest extends TestCase {
         , $xml->toString());
     }
 
-    public function testToStringChildrenNoIndent() {
+    public function testToStringChildrenNoIndent(): void {
         $xml = new Element('root');
         $xml->setValue('Will not be to stringed.');
 
@@ -500,7 +500,7 @@ class XmlElementTest extends TestCase {
         , $xml->toString(false));
     }
 
-    public function testToStringNamespaces() {
+    public function testToStringNamespaces(): void {
         $xml = new Element('n:root');
         $xml->setNamespace('n', 'http://domain.com/url');
 
@@ -518,7 +518,7 @@ class XmlElementTest extends TestCase {
         , $xml->toString());
     }
 
-    public function testToStringDeclaration() {
+    public function testToStringDeclaration(): void {
         $xml = new Element('root');
         $xml->setDeclaration('1.1', 'UTF-16', Map {'standalone' => 'yes'});
 

--- a/tests/Titon/Type/Xml/ElementTest.hh
+++ b/tests/Titon/Type/Xml/ElementTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Type\Xml;
 
 use Titon\Test\TestCase;
@@ -398,8 +398,8 @@ class XmlElementTest extends TestCase {
 
     public function testToMapChildrenWithSameName(): void {
         $this->object->addChildren(Vector {
-            new Element('boy', Map {'a' => 1}),
-            new Element('boy', Map {'b' => 2}),
+            new Element('boy', Map {'a' => '1'}),
+            new Element('boy', Map {'b' => '2'}),
             (new Element('boy'))->setValue('3'),
             new Element('girl')
         });
@@ -468,7 +468,7 @@ class XmlElementTest extends TestCase {
         $xml = new Element('root');
         $xml->setValue('Will not be to stringed.');
 
-        $boy = new Element('boy', Map {'age' => 15});
+        $boy = new Element('boy', Map {'age' => '15'});
         $girl = (new Element('girl'))->setValue('Mary');
 
         $xml->addChildren(Vector {$boy, $girl});
@@ -486,7 +486,7 @@ class XmlElementTest extends TestCase {
         $xml = new Element('root');
         $xml->setValue('Will not be to stringed.');
 
-        $boy = new Element('boy', Map {'age' => 15});
+        $boy = new Element('boy', Map {'age' => '15'});
         $girl = (new Element('girl'))->setValue('Mary');
 
         $xml->addChildren(Vector {$boy, $girl});

--- a/tests/Titon/Type/XmlTest.hh
+++ b/tests/Titon/Type/XmlTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Type;
 
 use Titon\Test\TestCase;
@@ -6,7 +6,7 @@ use Titon\Type\Xml\Element;
 
 class DocumentTest extends TestCase {
 
-    public function testBox() {
+    public function testBox(): void {
         $this->assertSame(123.45, Xml::box('123.45'));
         $this->assertSame(123.45, Xml::box('123.45'));
         $this->assertSame(123, Xml::box('123'));
@@ -16,7 +16,7 @@ class DocumentTest extends TestCase {
         $this->assertSame(null, Xml::box('null'));
     }
 
-    public function testUnbox() {
+    public function testUnbox(): void {
         $this->assertSame('123.45', Xml::unbox('123.45'));
         $this->assertSame('123.45', Xml::unbox(123.45));
         $this->assertSame('123', Xml::unbox('123'));
@@ -26,7 +26,7 @@ class DocumentTest extends TestCase {
         $this->assertSame('null', Xml::unbox(null));
     }
 
-    public function testFormatName() {
+    public function testFormatName(): void {
         $this->assertEquals('foo', Xml::formatName('foo'));
         $this->assertEquals('foobar', Xml::formatName('foo bar'));
         $this->assertEquals('ns:foo', Xml::formatName('ns:foo'));
@@ -37,7 +37,7 @@ class DocumentTest extends TestCase {
         $this->assertEquals('_-foo', Xml::formatName('-foo'));
     }
 
-    public function testFromMap() {
+    public function testFromMap(): void {
         $map = Map {
             'name' => 'Barbarian',
             'life' => 50,
@@ -115,7 +115,7 @@ XML;
         $this->assertEquals($this->nl($xml), Xml::fromMap('unit', $map)->toString());
     }
 
-    public function testFromMapWithAttributes() {
+    public function testFromMapWithAttributes(): void {
         $map = Map {
             'name' => 'Barbarian',
             'life' => Map {'@value' => 50},
@@ -208,7 +208,7 @@ XML;
         $this->assertEquals($this->nl($xml), Xml::fromMap('unit', $map)->toString());
     }
 
-    public function testFromMapWithCdata() {
+    public function testFromMapWithCdata(): void {
         $map = Map {
             'data' => Map {
                 '@value' => 'foobar',
@@ -232,7 +232,7 @@ XML;
         $this->assertEquals($this->nl($xml), Xml::fromMap('root', $map)->toString());
     }
 
-    public function testFromFile() {
+    public function testFromFile(): void {
         $xml = Xml::fromFile(TEMP_DIR . '/type/barbarian.xml');
 
         $expected = new Element('unit');
@@ -294,7 +294,7 @@ XML;
         $this->assertEquals($expected, $xml);
     }
 
-    public function testFromFileStringComparison() {
+    public function testFromFileStringComparison(): void {
         $path = TEMP_DIR . '/type/barbarian.xml';
         $xml = Xml::fromFile($path);
 
@@ -304,11 +304,11 @@ XML;
     /**
      * @expectedException \Titon\Common\Exception\MissingFileException
      */
-    public function testFromFileMissingFile() {
+    public function testFromFileMissingFile(): void {
         Xml::fromFile(TEMP_DIR . '/type/barbarian-missing.xml');
     }
 
-    public function testFromVector() {
+    public function testFromVector(): void {
         $list = Vector {'Helmet', 'Shoulder Plates', 'Breast Plate', 'Greaves', 'Gloves', 'Shield'};
 
         $xml = <<<XML
@@ -327,7 +327,7 @@ XML;
         $this->assertEquals($this->nl($xml), Xml::fromVector('armors', 'armor', $list)->toString());
     }
 
-    public function testFromVectorWithAttributes() {
+    public function testFromVectorWithAttributes(): void {
         $list = Vector {
             'Helmet',
             'Shoulder Plates',

--- a/tests/Titon/Type/XmlTest.hh
+++ b/tests/Titon/Type/XmlTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Type;
 
 use Titon\Test\TestCase;
@@ -238,31 +238,31 @@ XML;
         $expected = new Element('unit');
 
         $name = (new Element('name'))->setValue('Barbarian');
-        $life = (new Element('life', Map {'max' => 150}))->setValue('50');
-        $mana = (new Element('mana', Map {'max' => 250}))->setValue('100');
+        $life = (new Element('life', Map {'max' => '150'}))->setValue('50');
+        $mana = (new Element('mana', Map {'max' => '250'}))->setValue('100');
         $stamina = (new Element('stamina'))->setValue('15');
         $vitality = (new Element('vitality'))->setValue('20');
         $dexterity = new Element('dexterity', Map {'evade' => '5%', 'block' => '10%'});
         $agility = new Element('agility', Map {'turnRate' => '1.25', 'acceleration' => '5'});
-        $armors = new Element('armors', Map {'items' => 6});
+        $armors = new Element('armors', Map {'items' => '6'});
 
-            $armor1 = (new Element('armor', Map {'defense' => 15}))->setValue('Helmet');
-            $armor2 = (new Element('armor', Map {'defense' => 25}))->setValue('Shoulder Plates');
-            $armor3 = (new Element('armor', Map {'defense' => 50}))->setValue('Breast Plate');
-            $armor4 = (new Element('armor', Map {'defense' => 10}))->setValue('Greaves');
-            $armor5 = (new Element('armor', Map {'defense' => 10}))->setValue('Gloves');
-            $armor6 = (new Element('armor', Map {'defense' => 25}))->setValue('Shield');
+            $armor1 = (new Element('armor', Map {'defense' => '15'}))->setValue('Helmet');
+            $armor2 = (new Element('armor', Map {'defense' => '25'}))->setValue('Shoulder Plates');
+            $armor3 = (new Element('armor', Map {'defense' => '50'}))->setValue('Breast Plate');
+            $armor4 = (new Element('armor', Map {'defense' => '10'}))->setValue('Greaves');
+            $armor5 = (new Element('armor', Map {'defense' => '10'}))->setValue('Gloves');
+            $armor6 = (new Element('armor', Map {'defense' => '25'}))->setValue('Shield');
 
             $armors->addChildren(Vector {$armor1, $armor2, $armor3, $armor4, $armor5, $armor6});
 
-        $weapons = new Element('weapons', Map {'items' => 6});
+        $weapons = new Element('weapons', Map {'items' => '6'});
 
-            $sword1 = (new Element('sword', Map {'damage' => 25}))->setValue('Broadsword');
-            $sword2 = (new Element('sword', Map {'damage' => 30}))->setValue('Longsword');
-            $axe1 = (new Element('axe', Map {'damage' => 20}))->setValue('Heavy Axe');
-            $axe2 = (new Element('axe', Map {'damage' => 25}))->setValue('Double-edged Axe');
-            $polearm = (new Element('polearm', Map {'damage' => 50, 'range' => 3, 'speed' => 'slow'}))->setValue('Polearm');
-            $mace = (new Element('mace', Map {'damage' => 15, 'speed' => 'fast'}))->setValue('Mace');
+            $sword1 = (new Element('sword', Map {'damage' => '25'}))->setValue('Broadsword');
+            $sword2 = (new Element('sword', Map {'damage' => '30'}))->setValue('Longsword');
+            $axe1 = (new Element('axe', Map {'damage' => '20'}))->setValue('Heavy Axe');
+            $axe2 = (new Element('axe', Map {'damage' => '25'}))->setValue('Double-edged Axe');
+            $polearm = (new Element('polearm', Map {'damage' => '50', 'range' => '3', 'speed' => 'slow'}))->setValue('Polearm');
+            $mace = (new Element('mace', Map {'damage' => '15', 'speed' => 'fast'}))->setValue('Mace');
 
             $weapons->addChildren(Vector {$sword1, $sword2, $axe1, $axe2, $polearm, $mace});
 
@@ -285,7 +285,7 @@ XML;
             $food1 = (new Element('food'))->setValue('Fruit');
             $food2 = (new Element('food'))->setValue('Bread');
             $food3 = (new Element('food'))->setValue('Vegetables');
-            $scrap = (new Element('scrap', Map {'count' => 25}))->setValue('Scrap');
+            $scrap = (new Element('scrap', Map {'count' => '25'}))->setValue('Scrap');
 
             $items->addChildren(Vector {$potions, $keys, $food1, $food2, $food3, $scrap});
 

--- a/tests/Titon/Utility/ColTest.hh
+++ b/tests/Titon/Utility/ColTest.hh
@@ -21,9 +21,7 @@ class ColTest extends TestCase {
             1 => 'foo',
             2 => 123,
             3 => 'bar'
-        }, function($key, $value): void {
-            return is_string($value) ? strtoupper($value) : $value;
-        }));
+        }, ($key, $value) ==> is_string($value) ? strtoupper($value) : $value));
     }
 
     public function testEachVector(): void {
@@ -35,24 +33,18 @@ class ColTest extends TestCase {
             'foo',
             123,
             'bar'
-        }, function($key, $value): void {
-            return is_string($value) ? strtoupper($value) : $value;
-        }));
+        }, ($key, $value) ==> is_string($value) ? strtoupper($value) : $value));
     }
 
     public function testEveryMap(): void {
-        $callback = function($key, $value): void {
-            return is_int($value);
-        };
+        $callback = ($key, $value) ==> is_int($value);
 
         $this->assertTrue(Col::every(Map {1 => 123, 2 => 456, 3 => 789}, $callback));
         $this->assertFalse(Col::every(Map {1 => 123, 2 => 456, 3 => '789'}, $callback));
     }
 
     public function testEveryVector(): void {
-        $callback = function($key, $value): void {
-            return is_int($value);
-        };
+        $callback = ($key, $value) ==> is_int($value);
 
         $this->assertTrue(Col::every(Vector {123, 456, 789}, $callback));
         $this->assertFalse(Col::every(Vector {123, 456, '789'}, $callback));
@@ -515,23 +507,15 @@ class ColTest extends TestCase {
     }
 
     public function testSomeMap(): void {
-        $this->assertTrue(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, function($key, $value): void {
-            return is_numeric($value);
-        }));
+        $this->assertTrue(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, ($key, $value) ==> is_numeric($value)));
 
-        $this->assertFalse(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, function($key, $value): void {
-            return is_float($value);
-        }));
+        $this->assertFalse(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, ($key, $value) ==> is_float($value)));
     }
 
     public function testSomeVector(): void {
-        $this->assertTrue(Col::some(Vector {'foo', 123, true}, function($key, $value): void {
-            return is_numeric($value);
-        }));
+        $this->assertTrue(Col::some(Vector {'foo', 123, true}, ($key, $value) ==> is_numeric($value)));
 
-        $this->assertFalse(Col::some(Vector {'foo', 123, true}, function($key, $value): void {
-            return is_float($value);
-        }));
+        $this->assertFalse(Col::some(Vector {'foo', 123, true}, ($key, $value) ==> is_float($value)));
     }
 
     public function testToArray(): void {

--- a/tests/Titon/Utility/ColTest.hh
+++ b/tests/Titon/Utility/ColTest.hh
@@ -1,18 +1,18 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
 
 class ColTest extends TestCase {
 
-    public function testDepth() {
+    public function testDepth(): void {
         $this->assertEquals(0, Col::depth(Map {}));
         $this->assertEquals(1, Col::depth(Map {'one' => 1}));
         $this->assertEquals(3, Col::depth(Map {'one' => Map {'two' => Map {'three' => 3}}}));
         $this->assertEquals(4, Col::depth(Map {'one' => ['two' => Map {'three' => Vector {4}}]}));
     }
 
-    public function testEachMap() {
+    public function testEachMap(): void {
         $this->assertEquals(Map {
             1 => 'FOO',
             2 => 123,
@@ -21,12 +21,12 @@ class ColTest extends TestCase {
             1 => 'foo',
             2 => 123,
             3 => 'bar'
-        }, function($key, $value) {
+        }, function($key, $value): void {
             return is_string($value) ? strtoupper($value) : $value;
         }));
     }
 
-    public function testEachVector() {
+    public function testEachVector(): void {
         $this->assertEquals(Vector {
             'FOO',
             123,
@@ -35,13 +35,13 @@ class ColTest extends TestCase {
             'foo',
             123,
             'bar'
-        }, function($key, $value) {
+        }, function($key, $value): void {
             return is_string($value) ? strtoupper($value) : $value;
         }));
     }
 
-    public function testEveryMap() {
-        $callback = function($key, $value) {
+    public function testEveryMap(): void {
+        $callback = function($key, $value): void {
             return is_int($value);
         };
 
@@ -49,8 +49,8 @@ class ColTest extends TestCase {
         $this->assertFalse(Col::every(Map {1 => 123, 2 => 456, 3 => '789'}, $callback));
     }
 
-    public function testEveryVector() {
-        $callback = function($key, $value) {
+    public function testEveryVector(): void {
+        $callback = function($key, $value): void {
             return is_int($value);
         };
 
@@ -58,11 +58,11 @@ class ColTest extends TestCase {
         $this->assertFalse(Col::every(Vector {123, 456, '789'}, $callback));
     }
 
-    public function testExclude() {
+    public function testExclude(): void {
         $this->assertEquals(Map {1 => 'bar'}, Col::exclude(Map {0 => 'foo', 1 => 'bar'}, Vector {0}));
     }
 
-    public function testExpand() {
+    public function testExpand(): void {
         $this->assertEquals(Map {
             'app' => Map {
                 'name' => 'Titon',
@@ -80,7 +80,7 @@ class ColTest extends TestCase {
         }));
     }
 
-    public function testExtract() {
+    public function testExtract(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo',
@@ -105,7 +105,7 @@ class ColTest extends TestCase {
         }, Col::extract($map, 'one.two'));
     }
 
-    public function testFlatten() {
+    public function testFlatten(): void {
         $this->assertEquals(Map {
             'app.name' => 'Titon',
             'app.paths.root' => '/',
@@ -123,7 +123,7 @@ class ColTest extends TestCase {
         }));
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo'
@@ -138,7 +138,7 @@ class ColTest extends TestCase {
         }, Col::get($map, ''));
     }
 
-    public function testHas() {
+    public function testHas(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo',
@@ -158,7 +158,7 @@ class ColTest extends TestCase {
         $this->assertFalse(Col::has($map, 'one.two.three'));
     }
 
-    public function testInject() {
+    public function testInject(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo',
@@ -181,7 +181,7 @@ class ColTest extends TestCase {
         }, $map);
     }
 
-    public function testInsert() {
+    public function testInsert(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo',
@@ -227,7 +227,7 @@ class ColTest extends TestCase {
         }, $map);
     }
 
-    public function testIsAlphaMap() {
+    public function testIsAlphaMap(): void {
         $map = Map {
             1 => 'foo',
             2 => 'bar',
@@ -238,7 +238,7 @@ class ColTest extends TestCase {
         $this->assertFalse(Col::isAlpha($map));
     }
 
-    public function testIsAlphaVector() {
+    public function testIsAlphaVector(): void {
         $vector = Vector {
             'foo',
             'bar',
@@ -249,7 +249,7 @@ class ColTest extends TestCase {
         $this->assertFalse(Col::isAlpha($vector));
     }
 
-    public function testIsNumericMap() {
+    public function testIsNumericMap(): void {
         $this->assertTrue(Col::isNumeric(Map {
             1 => 123,
             2 => '456',
@@ -263,7 +263,7 @@ class ColTest extends TestCase {
         }));
     }
 
-    public function testIsNumericVectorp() {
+    public function testIsNumericVectorp(): void {
         $this->assertTrue(Col::isNumeric(Vector {
             123,
             '456',
@@ -277,7 +277,7 @@ class ColTest extends TestCase {
         }));
     }
 
-    public function testKeyOfMap() {
+    public function testKeyOfMap(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo',
@@ -295,7 +295,7 @@ class ColTest extends TestCase {
         $this->assertEquals('one.two.number', Col::keyOf($map, 789));
     }
 
-    public function testKeyOfVector() {
+    public function testKeyOfVector(): void {
         $vector = Vector {
             123,
             'foo',
@@ -313,7 +313,7 @@ class ColTest extends TestCase {
         $this->assertEquals('2.2.number', Col::keyOf($vector, 789));
     }
 
-    public function testMerge() {
+    public function testMerge(): void {
         $one = Map {
             'a' => 1,
             'b' => 2,
@@ -331,7 +331,7 @@ class ColTest extends TestCase {
         }, Col::merge($one, $two));
     }
 
-    public function testMergeMultiple() {
+    public function testMergeMultiple(): void {
         $one = Map {
             'a' => 1,
             'b' => 2,
@@ -354,7 +354,7 @@ class ColTest extends TestCase {
         }, Col::merge($one, $two, $three));
     }
 
-    public function testMergeRecursive() {
+    public function testMergeRecursive(): void {
         $one = Map {
             'a' => 1,
             'b' => Map {
@@ -385,7 +385,7 @@ class ColTest extends TestCase {
         }, Col::merge($one, $two));
     }
 
-    public function testMergeWithVector() {
+    public function testMergeWithVector(): void {
         $one = Map {
             'a' => 1,
             'b' => 2,
@@ -403,7 +403,7 @@ class ColTest extends TestCase {
         }, Col::merge($one, $two));
     }
 
-    public function testPluck() {
+    public function testPluck(): void {
         $map = Map {
             0 => Map {'name' => 'foo'},
             1 => Map {'key' => 'value'},
@@ -422,7 +422,7 @@ class ColTest extends TestCase {
         $this->assertEquals(Vector {1, 2, 3}, Col::pluck($map, 'meta.id'));
     }
 
-    public function testReduce() {
+    public function testReduce(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo',
@@ -436,7 +436,7 @@ class ColTest extends TestCase {
         }, Col::reduce($map, Vector {'number', 'float'}));
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $map = Map {
             'number' => 123,
             'string' => 'foo',
@@ -485,7 +485,7 @@ class ColTest extends TestCase {
         }, $map);
     }
 
-    public function testSet() {
+    public function testSet(): void {
         $map = Map {};
 
         $map = Col::set($map, 'string', 'foo');
@@ -514,27 +514,27 @@ class ColTest extends TestCase {
         }, $map);
     }
 
-    public function testSomeMap() {
-        $this->assertTrue(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, function($key, $value) {
+    public function testSomeMap(): void {
+        $this->assertTrue(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, function($key, $value): void {
             return is_numeric($value);
         }));
 
-        $this->assertFalse(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, function($key, $value) {
+        $this->assertFalse(Col::some(Map {0 => 'foo', 1 => 123, 2 => true}, function($key, $value): void {
             return is_float($value);
         }));
     }
 
-    public function testSomeVector() {
-        $this->assertTrue(Col::some(Vector {'foo', 123, true}, function($key, $value) {
+    public function testSomeVector(): void {
+        $this->assertTrue(Col::some(Vector {'foo', 123, true}, function($key, $value): void {
             return is_numeric($value);
         }));
 
-        $this->assertFalse(Col::some(Vector {'foo', 123, true}, function($key, $value) {
+        $this->assertFalse(Col::some(Vector {'foo', 123, true}, function($key, $value): void {
             return is_float($value);
         }));
     }
 
-    public function testToArray() {
+    public function testToArray(): void {
         $map = Map {
             'foo' => 'bar',
             'map' => Map {'baz' => 'qux'},
@@ -552,7 +552,7 @@ class ColTest extends TestCase {
         $this->assertEquals(['foo'], Col::toArray('foo'));
     }
 
-    public function testToArrayRecursive() {
+    public function testToArrayRecursive(): void {
         $actual = Map {
             'foo' => 'bar',
             'array' => Vector {1, 2, 3},
@@ -592,7 +592,7 @@ class ColTest extends TestCase {
         $this->assertEquals($expected, Col::toArray($actual));
     }
 
-    public function testToMap() {
+    public function testToMap(): void {
         $this->assertEquals(Map {}, Col::toMap(Vector {}));
         $this->assertEquals(Map {0 => 'foo'}, Col::toMap(Vector {'foo'}));
         $this->assertEquals(Map {}, Col::toMap([]));
@@ -604,7 +604,7 @@ class ColTest extends TestCase {
         $this->assertEquals(Map {'foo' => 'bar'}, Col::toMap(Map {'foo' => 'bar'}));
     }
 
-    public function testToMapRecursive() {
+    public function testToMapRecursive(): void {
         $actual = [
             'foo' => 'bar',
             'array' => [1, 2, 3],
@@ -644,7 +644,7 @@ class ColTest extends TestCase {
         $this->assertEquals($expected, Col::toMap($actual));
     }
 
-    public function testToVector() {
+    public function testToVector(): void {
         $this->assertEquals(Vector {}, Col::toVector(Vector {}));
         $this->assertEquals(Vector {'foo'}, Col::toVector(Vector {'foo'}));
         $this->assertEquals(Vector {}, Col::toVector([]));
@@ -655,7 +655,7 @@ class ColTest extends TestCase {
         $this->assertEquals(Vector {'bar'}, Col::toVector(Map {'foo' => 'bar'}));
     }
 
-    public function testToVectorRecursive() {
+    public function testToVectorRecursive(): void {
         $actual = [
             'foo' => 'bar',
             'array' => [1, 2, 3],

--- a/tests/Titon/Utility/ColTest.hh
+++ b/tests/Titon/Utility/ColTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/ConfigTest.hh
+++ b/tests/Titon/Utility/ConfigTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Io\Reader\PhpReader;
@@ -6,19 +6,19 @@ use Titon\Test\TestCase;
 
 class ConfigTest extends TestCase {
 
-    protected $app = Map {
+    protected Map<string, string> $app = Map {
         'name' => 'Titon',
         'salt' => '66c63d989368170aff46040ab2353923',
         'seed' => 'nsdASDn7012dn1dsjSa',
         'encoding' => 'UTF-8'
     };
 
-    protected $debug = Map {
+    protected Map<string, mixed> $debug = Map {
         'level' => 2,
         'email' => ''
     };
 
-    protected $test = Map {
+    protected Map<string, mixed> $test = Map {
         'integer' => 1234567890,
         'number' => '1234567890',
         'string' => 'abcdefg',
@@ -32,8 +32,6 @@ class ConfigTest extends TestCase {
 
     protected function setUp(): void {
         parent::setUp();
-
-        $this->setupVFS();
 
         Config::set('app', $this->app);
         Config::set('debug', $this->debug);
@@ -87,7 +85,7 @@ class ConfigTest extends TestCase {
         $this->assertEquals(Config::get('debug'), $this->debug);
         $this->assertEquals(Config::get('debug.level'), $this->debug['level']);
 
-        $this->assertTrue(is_integer(Config::get('test.integer')));
+        $this->assertTrue(is_int(Config::get('test.integer')));
         $this->assertTrue(is_numeric(Config::get('test.number')));
         $this->assertTrue(is_string(Config::get('test.string')));
         $this->assertTrue(empty(Config::get('test.vector')));
@@ -139,9 +137,9 @@ return [
 CFG;
 
 
-        $this->vfs->createFile('/config.php', $data);
+        $this->vfs()->createFile('/config.php', $data);
 
-        $reader = new PhpReader($this->vfs->path('/config.php'));
+        $reader = new PhpReader($this->vfs()->path('/config.php'));
 
         Config::load('Php', $reader);
         $this->assertTrue(isset(Config::all()['Php']));

--- a/tests/Titon/Utility/ConfigTest.hh
+++ b/tests/Titon/Utility/ConfigTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Io\Reader\PhpReader;
@@ -30,7 +30,7 @@ class ConfigTest extends TestCase {
         'zero' => 0
     };
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -40,7 +40,7 @@ class ConfigTest extends TestCase {
         Config::set('test', $this->test);
     }
 
-    public function testAdd() {
+    public function testAdd(): void {
         $this->assertEquals('Titon', Config::get('app.name'));
 
         Config::add('app.name', 'Framework');
@@ -50,7 +50,7 @@ class ConfigTest extends TestCase {
         $this->assertEquals(Vector {'Titon'}, Config::get('app.foobar'));
     }
 
-    public function testAll() {
+    public function testAll(): void {
         $this->assertEquals(Map {
             'app' => $this->app,
             'debug' => $this->debug,
@@ -58,7 +58,7 @@ class ConfigTest extends TestCase {
         }, Config::all());
     }
 
-    public function testEncoding() {
+    public function testEncoding(): void {
         $this->assertEquals(Config::encoding(), 'UTF-8');
 
         Config::set('app.encoding', 'UTF-16');
@@ -68,7 +68,7 @@ class ConfigTest extends TestCase {
         $this->assertEquals(Config::encoding(), 'UTF-8');
     }
 
-    public function testFlush() {
+    public function testFlush(): void {
         $this->assertEquals(Map {
             'app' => $this->app,
             'debug' => $this->debug,
@@ -80,7 +80,7 @@ class ConfigTest extends TestCase {
         $this->assertEquals(Map {}, Config::all());
     }
 
-    public function testGet() {
+    public function testGet(): void {
         $this->assertEquals(Config::get('app.name'), $this->app['name']);
         $this->assertEquals(Config::get('app.seed'), $this->app['seed']);
 
@@ -107,7 +107,7 @@ class ConfigTest extends TestCase {
         $this->assertEquals('baz', Config::get('app.foo', 'bar'));
     }
 
-    public function testHas() {
+    public function testHas(): void {
         $this->assertTrue(Config::has('app.salt'));
         $this->assertTrue(Config::has('debug.email'));
         $this->assertTrue(Config::has('test.number'));
@@ -121,7 +121,7 @@ class ConfigTest extends TestCase {
         $this->assertFalse(Config::has('test.deep.deep.deep.deep.array'));
     }
 
-    public function testLoad() {
+    public function testLoad(): void {
         $data = <<<CFG
 <?php
 
@@ -159,7 +159,7 @@ CFG;
         }, Config::get('Php'));
     }
 
-    public function testName() {
+    public function testName(): void {
         $this->assertEquals(Config::name(), $this->app['name']);
 
         Config::set('app.name', 'TestName');
@@ -169,7 +169,7 @@ CFG;
         $this->assertEquals(Config::name(), '');
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         $this->assertTrue(Config::has('app.salt'));
         $this->assertTrue(Config::has('debug.email'));
 
@@ -179,7 +179,7 @@ CFG;
         $this->assertFalse(Config::has('debug.email'));
     }
 
-    public function testSalt() {
+    public function testSalt(): void {
         $this->assertEquals(Config::salt(), $this->app['salt']);
 
         Config::set('app.salt', md5('TestSalt'));
@@ -189,7 +189,7 @@ CFG;
         $this->assertEquals(Config::salt(), '');
     }
 
-    public function testSet() {
+    public function testSet(): void {
         Config::set('Set.level1', 1);
         $this->assertEquals(Config::get('Set.level1'), 1);
 

--- a/tests/Titon/Utility/CryptTest.hh
+++ b/tests/Titon/Utility/CryptTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
@@ -7,15 +7,15 @@ class CryptTest extends TestCase {
 
     protected $string = 'This string will be used to encrypt and decrypt. It contains numbers: 1 2 3 4 5 6 7 8 9 0. It also contains punctuation: ! @ # $ % ^ & * ( ) : [ < ?. You get the picture';
 
-    public function testBlowfish() {
+    public function testBlowfish(): void {
         $this->assertEquals($this->string, Crypt::blowfish(Crypt::blowfish($this->string, 'blowfish.key'), 'blowfish.key', Crypt::DECRYPT));
     }
 
-    public function testDes() {
+    public function testDes(): void {
         $this->assertEquals($this->string, Crypt::des(Crypt::des($this->string, 'des.key'), 'des.key', Crypt::DECRYPT));
     }
 
-    public function testEncryptDecrypt() {
+    public function testEncryptDecrypt(): void {
         $e = Crypt::encrypt($this->string, 'cast.key', MCRYPT_CAST_128, MCRYPT_MODE_ECB);
         $d = Crypt::decrypt($e, 'cast.key', MCRYPT_CAST_128, MCRYPT_MODE_ECB);
 
@@ -27,7 +27,7 @@ class CryptTest extends TestCase {
         $this->assertEquals($this->string, $d);
     }
 
-    public function testHash() {
+    public function testHash(): void {
         $md51 = Crypt::hash('md5', $this->string);
         $md52 = Crypt::hash('md5', $this->string, 'md5.salt');
 
@@ -50,15 +50,15 @@ class CryptTest extends TestCase {
         $this->assertNotEquals($sha1, $sha2);
     }
 
-    public function testObfuscate() {
+    public function testObfuscate(): void {
         $this->assertEquals('&#84;&#105;&#116;&#111;&#110;&#32;&#70;&#114;&#97;&#109;&#101;&#119;&#111;&#114;&#107;', Crypt::obfuscate('Titon Framework'));
     }
 
-    public function testRijndael() {
+    public function testRijndael(): void {
         $this->assertEquals($this->string, Crypt::rijndael(Crypt::rijndael($this->string, 'rijndael.key'), 'rijndael.key', Crypt::DECRYPT));
     }
 
-    public function testTripledes() {
+    public function testTripledes(): void {
         $this->assertEquals($this->string, Crypt::tripledes(Crypt::tripledes($this->string, '3des.key'), '3des.key', Crypt::DECRYPT));
     }
 

--- a/tests/Titon/Utility/CryptTest.hh
+++ b/tests/Titon/Utility/CryptTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/FormatTest.hh
+++ b/tests/Titon/Utility/FormatTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/FormatTest.hh
+++ b/tests/Titon/Utility/FormatTest.hh
@@ -1,31 +1,31 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
 
 class FormatTest extends TestCase {
 
-    public function testAtom() {
+    public function testAtom(): void {
         $time = mktime(16, 35, 0, 2, 26, 1988);
 
         $this->assertEquals('1988-02-26T16:35:00+00:00', Format::atom($time));
     }
 
-    public function testDate() {
+    public function testDate(): void {
         $time = mktime(16, 35, 0, 2, 26, 1988);
 
         $this->assertEquals('1988-02-26', Format::date($time));
         $this->assertEquals('02/26/1988', Format::date($time, '%m/%d/%Y'));
     }
 
-    public function testDatetime() {
+    public function testDatetime(): void {
         $time = mktime(16, 35, 0, 2, 26, 1988);
 
         $this->assertEquals('1988-02-26 16:35:00', Format::datetime($time));
         $this->assertEquals('02/26/1988 04:35PM', Format::datetime($time, '%m/%d/%Y %I:%M%p'));
     }
 
-    public function testFormat() {
+    public function testFormat(): void {
         $this->assertEquals('(123) 456', Format::format('1234567890', '(###) ###'));
         $this->assertEquals('(123) 456-7890', Format::format('1234567890', '(###) ###-####'));
         $this->assertEquals('(123) 456-####', Format::format('123456', '(###) ###-####'));
@@ -44,13 +44,13 @@ class FormatTest extends TestCase {
         $this->assertEquals('3772-3483-0461-4543', Format::format('377234830461454313', '####-####-####-####'));
     }
 
-    public function testHttp() {
+    public function testHttp(): void {
         $time = mktime(16, 35, 0, 2, 26, 1988);
 
         $this->assertEquals('Fri, 26 Feb 1988 16:35:00 GMT', Format::http($time));
     }
 
-    public function testPhone() {
+    public function testPhone(): void {
         $formats = Map {
             7 => '###-####',
             10 => '(###) ###-####',
@@ -62,7 +62,7 @@ class FormatTest extends TestCase {
         $this->assertEquals('1 (888) 666-1337', Format::phone('+1 8886661337', $formats));
     }
 
-    public function testRelativeTime() {
+    public function testRelativeTime(): void {
         $time = mktime(16, 35, 0, 2, 26, 2012);
 
         // Current
@@ -102,17 +102,17 @@ class FormatTest extends TestCase {
         }));
     }
 
-    public function testRss() {
+    public function testRss(): void {
         $time = mktime(16, 35, 0, 2, 26, 1988);
 
         $this->assertEquals('Fri, 26 Feb 1988 16:35:00 +0000', Format::rss($time));
     }
 
-    public function testSsn() {
+    public function testSsn(): void {
         $this->assertEquals('998-29-3841', Format::ssn('998293841', '###-##-####'));
     }
 
-    public function testTime() {
+    public function testTime(): void {
         $time = mktime(16, 35, 0, 2, 26, 1988);
 
         $this->assertEquals('16:35:00', Format::time($time));

--- a/tests/Titon/Utility/InflectorTest.hh
+++ b/tests/Titon/Utility/InflectorTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
 
 class InflectorTest extends TestCase {
 
-    public function testCamelCase() {
+    public function testCamelCase(): void {
         $camelCase = [
             'foo Bar', 'fOo Bar', 'foo_Bar', ' foo-_--_BAR',
             'foo-BAR', 'FOO-BAR', 'foo     bar   '
@@ -16,7 +16,7 @@ class InflectorTest extends TestCase {
         }
     }
 
-    public function testFileName() {
+    public function testFileName(): void {
         $this->assertEquals('camel-Case.php', Inflector::fileName('camel Case'));
         $this->assertEquals('StuDly-CaSe.php', Inflector::fileName('StuDly CaSe'));
         $this->assertEquals('Title-Case.php', Inflector::fileName('Title Case'));
@@ -30,13 +30,13 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lots-of-white-space.php', Inflector::fileName('lots  of     white space'));
     }
 
-    public function testFileNameReplaceExt() {
+    public function testFileNameReplaceExt(): void {
         $this->assertEquals('foo.xml', Inflector::fileName('foo.php', 'xml'));
         $this->assertEquals('foo.bar.xml', Inflector::fileName('foo.bar.php', 'xml'));
         $this->assertEquals('foo.bar.xml', Inflector::fileName('foo.bar.xml', 'xml'));
     }
 
-    public function testClassName() {
+    public function testClassName(): void {
         $this->assertEquals('CamelCase', Inflector::className('camel Case'));
         $this->assertEquals('StudlyCase', Inflector::className('StuDly CaSe'));
         $this->assertEquals('TitleCase', Inflector::className('Title Case'));
@@ -50,7 +50,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('LotsOfWhiteSpace', Inflector::className('lots  of     white space'));
     }
 
-    public function testHyphenate() {
+    public function testHyphenate(): void {
         $this->assertEquals('camel-Case', Inflector::hyphenate('camel Case'));
         $this->assertEquals('StuDly-CaSe', Inflector::hyphenate('StuDly CaSe'));
         $this->assertEquals('Title-Case', Inflector::hyphenate('Title Case'));
@@ -64,7 +64,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lots-of-white-space', Inflector::hyphenate('lots  of     white space'));
     }
 
-    public function testNormalCase() {
+    public function testNormalCase(): void {
         $this->assertEquals('This is a string with studly case', Inflector::normalCase('This is A sTring wIth sTudly cAse'));
         $this->assertEquals('And this one has underscores', Inflector::normalCase('and_this_ONE_has_underscores'));
         $this->assertEquals('While this one contains -- dashes', Inflector::normalCase('WHILE this one contains -- DASHES'));
@@ -72,7 +72,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('Lastly, this string contains "punctuation"!', Inflector::normalCase('LaStlY, this STRING contains "punctuation"!'));
     }
 
-    public function testRoute() {
+    public function testRoute(): void {
         $this->assertEquals('camel-case', Inflector::route('camel Case'));
         $this->assertEquals('studly-case', Inflector::route('StuDly CaSe'));
         $this->assertEquals('title-case', Inflector::route('Title Case'));
@@ -86,7 +86,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lots-of-white-space', Inflector::route('lots  of     white space'));
     }
 
-    public function testSlug() {
+    public function testSlug(): void {
         $this->assertEquals('this-is-a-string-with-studly-case', Inflector::slug('This is A sTring wIth sTudly cAse'));
         $this->assertEquals('andthisonehasunderscores', Inflector::slug('and_this_ONE_has_underscores'));
         $this->assertEquals('while-this-one-contains-__-dashes', Inflector::slug('WHILE this one contains -- DASHES'));
@@ -94,7 +94,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lastly-this-string-contains-punctuation', Inflector::slug('LaStlY, this STRING contains "punctuation"!'));
     }
 
-    public function testSnakeCase() {
+    public function testSnakeCase(): void {
         $this->assertEquals('camel_case', Inflector::snakeCase('camel Case'));
         $this->assertEquals('stu_dly_ca_se', Inflector::snakeCase('StuDly CaSe'));
         $this->assertEquals('title_case', Inflector::snakeCase('Title Case'));
@@ -108,7 +108,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lots_of_white_space', Inflector::snakeCase('lots  of     white space'));
     }
 
-    public function testTableName() {
+    public function testTableName(): void {
         $this->assertEquals('camelCase', Inflector::tableName('camel Case'));
         $this->assertEquals('studlyCase', Inflector::tableName('StuDly CaSe'));
         $this->assertEquals('titleCase', Inflector::tableName('Title Case'));
@@ -122,7 +122,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lotsOfWhiteSpace', Inflector::tableName('lots  of     white space'));
     }
 
-    public function testTitleCase() {
+    public function testTitleCase(): void {
         $this->assertEquals('This Is A String With Studly Case', Inflector::titleCase('This is A sTring wIth sTudly cAse'));
         $this->assertEquals('And This One Has Underscores', Inflector::titleCase('and_this_ONE_has_underscores'));
         $this->assertEquals('While This One Contains -- Dashes', Inflector::titleCase('WHILE this one contains -- DASHES'));
@@ -130,7 +130,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('Lastly, This String Contains "punctuation"!', Inflector::titleCase('LaStlY, this STRING contains "punctuation"!'));
     }
 
-    public function testUnderscore() {
+    public function testUnderscore(): void {
         $this->assertEquals('camel_case', Inflector::underscore('camel Case'));
         $this->assertEquals('stu_dly_ca_se', Inflector::underscore('StuDly CaSe'));
         $this->assertEquals('title_case', Inflector::underscore('Title Case'));
@@ -144,7 +144,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lots_of_white_space', Inflector::underscore('lots  of     white space'));
     }
 
-    public function testVariable() {
+    public function testVariable(): void {
         $this->assertEquals('camelCase', Inflector::variable('camel Case'));
         $this->assertEquals('StuDlyCaSe', Inflector::variable('StuDly CaSe'));
         $this->assertEquals('TitleCase', Inflector::variable('Title Case'));

--- a/tests/Titon/Utility/InflectorTest.hh
+++ b/tests/Titon/Utility/InflectorTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/NumberTest.hh
+++ b/tests/Titon/Utility/NumberTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
@@ -39,13 +39,13 @@ class NumberTest extends TestCase {
 
     public function testBytesTo(): void {
         $this->assertEquals('1B', Number::bytesTo(1));
-        $this->assertEquals('225B', Number::bytesTo(225, 1));
-        $this->assertEquals('100B', Number::bytesTo(100, 2));
+        $this->assertEquals('225B', Number::bytesTo(225));
+        $this->assertEquals('100B', Number::bytesTo(100));
 
         // kb
         $this->assertEquals('1KB', Number::bytesTo(1024));
-        $this->assertEquals('225KB', Number::bytesTo(230400, 1));
-        $this->assertEquals('100KB', Number::bytesTo(102400, 2));
+        $this->assertEquals('225KB', Number::bytesTo(230400));
+        $this->assertEquals('100KB', Number::bytesTo(102400));
 
         // mb
         $this->assertEquals('1MB', Number::bytesTo(1048576));

--- a/tests/Titon/Utility/NumberTest.hh
+++ b/tests/Titon/Utility/NumberTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
 
 class NumberTest extends TestCase {
 
-    public function testBytesFrom() {
+    public function testBytesFrom(): void {
         $this->assertEquals('0', Number::bytesFrom(''));
         $this->assertEquals('0', Number::bytesFrom('123AB'));
 
@@ -37,7 +37,7 @@ class NumberTest extends TestCase {
         // PHPUnit blows up on higher numbers
     }
 
-    public function testBytesTo() {
+    public function testBytesTo(): void {
         $this->assertEquals('1B', Number::bytesTo(1));
         $this->assertEquals('225B', Number::bytesTo(225, 1));
         $this->assertEquals('100B', Number::bytesTo(100, 2));
@@ -65,7 +65,7 @@ class NumberTest extends TestCase {
         // PHPUnit blows up on higher numbers
     }
 
-    public function testCurrency() {
+    public function testCurrency(): void {
         $this->assertEquals('$12,345.34', Number::currency(12345.34));
         $this->assertEquals('$734.00', Number::currency(734.00));
         $this->assertEquals('$84,283.38', Number::currency(84283.384));
@@ -90,7 +90,7 @@ class NumberTest extends TestCase {
         }));
     }
 
-    public function testIn() {
+    public function testIn(): void {
         $this->assertTrue(Number::in(5, 1, 10));
         $this->assertTrue(Number::in(6, 1, 10));
         $this->assertTrue(Number::in(3.3, 1, 10));
@@ -98,28 +98,28 @@ class NumberTest extends TestCase {
         $this->assertFalse(Number::in(0, 1, 10));
     }
 
-    public function testIsEven() {
+    public function testIsEven(): void {
         $this->assertTrue(Number::isEven(2));
         $this->assertTrue(Number::isEven(88));
         $this->assertFalse(Number::isEven(9));
         $this->assertFalse(Number::isEven(17));
     }
 
-    public function testIsNegative() {
+    public function testIsNegative(): void {
         $this->assertTrue(Number::isNegative(-1));
         $this->assertTrue(Number::isNegative(-384));
         $this->assertFalse(Number::isNegative(0));
         $this->assertFalse(Number::isNegative(34));
     }
 
-    public function testIsOdd() {
+    public function testIsOdd(): void {
         $this->assertFalse(Number::isOdd(2));
         $this->assertFalse(Number::isOdd(88));
         $this->assertTrue(Number::isOdd(9));
         $this->assertTrue(Number::isOdd(17));
     }
 
-    public function testIsPositive() {
+    public function testIsPositive(): void {
         $this->assertTrue(Number::isPositive(343));
         $this->assertTrue(Number::isPositive(79));
         $this->assertTrue(Number::isPositive(0));
@@ -127,32 +127,32 @@ class NumberTest extends TestCase {
         $this->assertFalse(Number::isPositive(-1));
     }
 
-    public function testLimit() {
+    public function testLimit(): void {
         $this->assertEquals(100, Number::limit(125, 50, 100));
         $this->assertEquals(50, Number::limit(45, 50, 100));
         $this->assertEquals(77, Number::limit(77, 50, 100));
     }
 
-    public function testMin() {
+    public function testMin(): void {
         $this->assertEquals(50, Number::min(12, 50));
         $this->assertEquals(55, Number::min(55, 50));
         $this->assertEquals(123, Number::min(123, 50));
     }
 
-    public function testMax() {
+    public function testMax(): void {
         $this->assertEquals(-15, Number::max(-15, 50));
         $this->assertEquals(12, Number::max(12, 50));
         $this->assertEquals(50, Number::max(55, 50));
         $this->assertEquals(50, Number::max(123, 50));
     }
 
-    public function testOut() {
+    public function testOut(): void {
         $this->assertTrue(Number::out(15, 5, 10));
         $this->assertTrue(Number::out(3, 5, 10));
         $this->assertFalse(Number::out(8, 5, 10));
     }
 
-    public function testPercentage() {
+    public function testPercentage(): void {
         $this->assertEquals('123%', Number::percentage(123, Map {'places' => 0}));
         $this->assertEquals('4,546%', Number::percentage(4546, Map {'places' => 0}));
         $this->assertEquals('92,378,453%', Number::percentage(92378453, Map {'places' => 0}));
@@ -168,7 +168,7 @@ class NumberTest extends TestCase {
         }));
     }
 
-    public function testPrecision() {
+    public function testPrecision(): void {
         $this->assertEquals('345654.00', Number::precision(345654));
         $this->assertEquals('345654.0', Number::precision(345654, 1));
         $this->assertEquals('345654', Number::precision(345654, 0));
@@ -178,7 +178,7 @@ class NumberTest extends TestCase {
         $this->assertEquals('7483.986', Number::precision(7483.9858, 3));
     }
 
-    public function testSignum() {
+    public function testSignum(): void {
         $this->assertEquals(-1, Number::signum(-1));
         $this->assertEquals(-1, Number::signum(-34));
         $this->assertEquals(-1, Number::signum(-9459334));
@@ -192,28 +192,28 @@ class NumberTest extends TestCase {
         $this->assertEquals(1, Number::signum(45454));
     }
 
-    public function testToBinary() {
+    public function testToBinary(): void {
         $this->assertEquals(10011010010, Number::toBinary(10011010010, Number::BINARY));
         $this->assertEquals(10011010010, Number::toBinary(2322, Number::OCTAL));
         $this->assertEquals(10011010010, Number::toBinary(1234, Number::DECIMAL));
         $this->assertEquals(10011010010, Number::toBinary('4d2', Number::HEX));
     }
 
-    public function testToDecimal() {
+    public function testToDecimal(): void {
         $this->assertEquals(1234, Number::toDecimal(10011010010, Number::BINARY));
         $this->assertEquals(1234, Number::toDecimal(2322, Number::OCTAL));
         $this->assertEquals(1234, Number::toDecimal(1234, Number::DECIMAL));
         $this->assertEquals(1234, Number::toDecimal('4d2', Number::HEX));
     }
 
-    public function testToHex() {
+    public function testToHex(): void {
         $this->assertEquals('4d2', Number::toHex(10011010010, Number::BINARY));
         $this->assertEquals('4d2', Number::toHex(2322, Number::OCTAL));
         $this->assertEquals('4d2', Number::toHex(1234, Number::DECIMAL));
         $this->assertEquals('4d2', Number::toHex('4d2', Number::HEX));
     }
 
-    public function testToOctal() {
+    public function testToOctal(): void {
         $this->assertEquals(2322, Number::toOctal(10011010010, Number::BINARY));
         $this->assertEquals(2322, Number::toOctal(2322, Number::OCTAL));
         $this->assertEquals(2322, Number::toOctal(1234, Number::DECIMAL));

--- a/tests/Titon/Utility/PathTest.hh
+++ b/tests/Titon/Utility/PathTest.hh
@@ -1,30 +1,30 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
 
 class PathTest extends TestCase {
 
-    public function testAlias() {
+    public function testAlias(): void {
         $this->assertEquals('[internal]', Path::alias(''));
         $this->assertEquals('[vendor]Titon/Debug/Debugger.php', Path::alias(VENDOR_DIR . '/Titon/Debug/Debugger.php'));
         $this->assertEquals('[src]Titon/Debug/Debugger.php', Path::alias(dirname(TEST_DIR) . '/src/Titon/Debug/Debugger.php'));
         $this->assertEquals('[app]some/file.txt', Path::alias('/app/some/file.txt', Map {'app' => '/app'}));
     }
 
-    public function testClassName() {
+    public function testClassName(): void {
         $this->assertEquals('ClassName', Path::className('\test\namespace\ClassName'));
         $this->assertEquals('ClassName', Path::className('test:namespace:ClassName', ':'));
         $this->assertEquals('ClassName', Path::className('test/namespace/ClassName', '/'));
         $this->assertEquals('ClassName', Path::className('test.namespace.ClassName', '.'));
     }
 
-    public function testPackageName() {
+    public function testPackageName(): void {
         $this->assertEquals('test\namespace', Path::packageName('\test\namespace\ClassName'));
         $this->assertEquals('test/namespace', Path::packageName('/test/namespace/ClassName', '/'));
     }
 
-    public function testDs() {
+    public function testDs(): void {
         // linux
         $this->assertEquals('/some/fake/folder/path/fileName.php', Path::ds('/some/fake/folder/path/fileName.php'));
         $this->assertEquals('/some/fake/folder/path/fileName.php', Path::ds('/some\fake/folder\path/fileName.php'));
@@ -42,7 +42,7 @@ class PathTest extends TestCase {
         $this->assertEquals('C:/some/fake/folder/path/fileName/', Path::ds('C:\some/fake\folder/path\fileName\\'));
     }
 
-    public function testIncludePath() {
+    public function testIncludePath(): void {
         $baseIncludePath = get_include_path();
         $selfPath1 = '/fake/test/1';
         $selfPath2 = '/fake/test/2';
@@ -57,7 +57,7 @@ class PathTest extends TestCase {
         $this->assertEquals($baseIncludePath . PATH_SEPARATOR . $selfPath1 . PATH_SEPARATOR . $selfPath2 . PATH_SEPARATOR . $selfPath3, get_include_path());
     }
 
-    public function testIsAbsolute() {
+    public function testIsAbsolute(): void {
         $this->assertTrue(Path::isAbsolute('/root/path'));
         $this->assertTrue(Path::isAbsolute('\root\path'));
         $this->assertTrue(Path::isAbsolute('C:\root\path'));
@@ -68,7 +68,7 @@ class PathTest extends TestCase {
         $this->assertFalse(Path::isAbsolute('../sub/'));
     }
 
-    public function testIsRelative() {
+    public function testIsRelative(): void {
         $this->assertFalse(Path::isRelative('/root/path'));
         $this->assertFalse(Path::isRelative('\root\path'));
         $this->assertFalse(Path::isRelative('C:\root\path'));
@@ -79,7 +79,7 @@ class PathTest extends TestCase {
         $this->assertTrue(Path::isRelative('../sub/'));
     }
 
-    public function testJoin() {
+    public function testJoin(): void {
         $this->assertEquals('foo/bar', Path::join(Vector {'foo', 'bar'}));
         $this->assertEquals('foo/bar', Path::join(Vector {'foo/', '/bar/'}));
         $this->assertEquals('foo/baz', Path::join(Vector {'foo/', '/bar/', '..', '//baz'}));
@@ -90,7 +90,7 @@ class PathTest extends TestCase {
         $this->assertEquals(Vector {'foo', 'baz'}, Path::join(Vector {'foo/', '/bar/', '..', '//baz'}, true, false));
     }
 
-    public function testRelativeTo() {
+    public function testRelativeTo(): void {
         $this->assertEquals('./', Path::relativeTo('/foo/bar', '/foo/bar'));
         $this->assertEquals('../', Path::relativeTo('/foo/bar', '/foo'));
         $this->assertEquals('./baz/', Path::relativeTo('/foo/bar', '/foo/bar/baz'));
@@ -100,11 +100,11 @@ class PathTest extends TestCase {
     /**
      * @expectedException \Titon\Common\Exception\InvalidArgumentException
      */
-    public function testRelativeToErrorsOnAbsolute() {
+    public function testRelativeToErrorsOnAbsolute(): void {
         Path::relativeTo('/abs', '../rel');
     }
 
-    public function testStripExt() {
+    public function testStripExt(): void {
         $this->assertEquals('NoExt', Path::stripExt('NoExt'));
         $this->assertEquals('ClassName', Path::stripExt('ClassName.php'));
         $this->assertEquals('File_Name', Path::stripExt('File_Name.php'));
@@ -116,7 +116,7 @@ class PathTest extends TestCase {
         $this->assertEquals('/test/file/path/File/Name', Path::stripExt('/test/file/path/File/Name.php'));
     }
 
-    public function testToNamespace() {
+    public function testToNamespace(): void {
         $this->assertEquals('test\file\path\FileName', Path::toNamespace('/test/file/path/FileName.php'));
         $this->assertEquals('test\file\path\File\Name', Path::toNamespace('/test/file/path/File/Name.php'));
 
@@ -124,7 +124,7 @@ class PathTest extends TestCase {
         $this->assertEquals('Titon\test\file\path\File\Name', Path::toNamespace('vendors/src/Titon/test/file/path/File/Name.php'));
     }
 
-    public function testToPath() {
+    public function testToPath(): void {
         $this->assertEquals('/test/namespace/ClassName.php', Path::toPath('\test\namespace\ClassName'));
         $this->assertEquals('/test/namespace/Class/Name.php', Path::toPath('\test\namespace\Class_Name'));
 

--- a/tests/Titon/Utility/PathTest.hh
+++ b/tests/Titon/Utility/PathTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/RegistryTest.hh
+++ b/tests/Titon/Utility/RegistryTest.hh
@@ -87,7 +87,7 @@ class RegistryTest extends TestCase {
     }
 
     public function testRegisterAndGet(): void {
-        Registry::register('base', function() {
+        Registry::register('base', () ==> {
             $base = new RegistryStub();
             $base->key = 'registry';
 

--- a/tests/Titon/Utility/RegistryTest.hh
+++ b/tests/Titon/Utility/RegistryTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
@@ -112,4 +112,5 @@ class RegistryTest extends TestCase {
 }
 
 class RegistryStub {
+    public string $key = '';
 }

--- a/tests/Titon/Utility/RegistryTest.hh
+++ b/tests/Titon/Utility/RegistryTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
 
 class RegistryTest extends TestCase {
 
-    public function testAll() {
+    public function testAll(): void {
         $base = new RegistryStub();
         $config = new Config();
         $registry = new Registry();
@@ -21,14 +21,14 @@ class RegistryTest extends TestCase {
         ]), Registry::all());
     }
 
-    public function testFactory() {
+    public function testFactory(): void {
         $this->assertInstanceOf('Titon\Utility\RegistryStub', Registry::factory('Titon\Utility\RegistryStub', [], false));
         $this->assertInstanceOf('Titon\Utility\RegistryStub', Registry::factory('Titon/Utility/RegistryStub', [], false));
         $this->assertInstanceOf('Titon\Utility\RegistryStub', Registry::factory('Titon\Utility\RegistryStub', [], false));
         $this->assertInstanceOf('Titon\Utility\RegistryStub', Registry::factory('/Titon/Utility/RegistryStub', [], false));
     }
 
-    public function testFlushAndKeys() {
+    public function testFlushAndKeys(): void {
         $test = Vector {};
 
         for ($i = 1; $i <= 10; $i++) {
@@ -48,7 +48,7 @@ class RegistryTest extends TestCase {
         $this->assertEquals(0, count($registered));
     }
 
-    public function testHasAndSet() {
+    public function testHasAndSet(): void {
         for ($i = 1; $i <= 10; $i++) {
             Registry::set(new RegistryStub(), 'key' . $i);
         }
@@ -64,11 +64,11 @@ class RegistryTest extends TestCase {
     /**
      * @expectedException \Titon\Utility\Exception\InvalidObjectException
      */
-    public function testSetInvalidObject() {
+    public function testSetInvalidObject(): void {
         Registry::set(12345);
     }
 
-    public function testRemove() {
+    public function testRemove(): void {
         for ($i = 1; $i <= 10; $i++) {
             Registry::set(new RegistryStub(), 'key' . $i);
         }
@@ -86,7 +86,7 @@ class RegistryTest extends TestCase {
         $this->assertFalse(Registry::has('key8'));
     }
 
-    public function testRegisterAndGet() {
+    public function testRegisterAndGet(): void {
         Registry::register('base', function() {
             $base = new RegistryStub();
             $base->key = 'registry';
@@ -105,7 +105,7 @@ class RegistryTest extends TestCase {
     /**
      * @expectedException \Titon\Utility\Exception\MissingObjectException
      */
-    public function testGetInvalidKey() {
+    public function testGetInvalidKey(): void {
         Registry::get('missingKey');
     }
 

--- a/tests/Titon/Utility/SanitizeTest.hh
+++ b/tests/Titon/Utility/SanitizeTest.hh
@@ -1,17 +1,17 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
 
 class SanitizeTest extends TestCase {
 
-    public function testEmail() {
+    public function testEmail(): void {
         $this->assertEquals('email@domain.com', Sanitize::email('em<a>il@domain.com'));
         $this->assertEquals('email+tag@domain.com', Sanitize::email('email+t(a)g@domain.com'));
         $this->assertEquals('email+tag@domain.com', Sanitize::email('em"ail+t(a)g@domain.com'));
     }
 
-    public function testEscape() {
+    public function testEscape(): void {
         $this->assertEquals('"Double" quotes', Sanitize::escape('"Double" quotes', Map {'flags' => ENT_NOQUOTES}));
         $this->assertEquals('&quot;Double&quot; quotes', Sanitize::escape('"Double" quotes', Map {'flags' => ENT_COMPAT}));
         $this->assertEquals('&quot;Double&quot; quotes', Sanitize::escape('"Double" quotes', Map {'flags' => ENT_QUOTES}));
@@ -32,26 +32,26 @@ class SanitizeTest extends TestCase {
         $this->assertEquals('&lt;Html&gt; tags', Sanitize::escape('<Html> tags', Map {'flags' => ENT_QUOTES | ENT_XHTML}));
     }
 
-    public function testFloat() {
+    public function testFloat(): void {
         $this->assertEquals(100.25, Sanitize::float('1[0)0.25'));
         $this->assertEquals(-125.55, Sanitize::float('-abc125.55'));
         $this->assertEquals(1203.11, Sanitize::float('+1203.11'));
     }
 
-    public function testHtml() {
+    public function testHtml(): void {
         $this->assertEquals('String with b &amp; i tags.', Sanitize::html('String <b>with</b> b & i <i>tags</i>.'));
         $this->assertEquals('String &lt;b&gt;with&lt;/b&gt; b &amp; i &lt;i&gt;tags&lt;/i&gt;.', Sanitize::html('String <b>with</b> b & i <i>tags</i>.', Map {'strip' => false}));
         $this->assertEquals('String &lt;b&gt;with&lt;/b&gt; b &amp; i tags.', Sanitize::html('String <b>with</b> b & i <i>tags</i>.', Map {'whitelist' => '<b>'}));
         $this->assertEquals('String with b &amp;amp; i tags.', Sanitize::html('String <b>with</b> b &amp; i <i>tags</i>.', Map {'double' => true}));
     }
 
-    public function testInteger() {
+    public function testInteger(): void {
         $this->assertEquals(1292932, Sanitize::integer('129sdja2932'));
         $this->assertEquals(-1275452, Sanitize::integer('-12,754.52'));
         $this->assertEquals(18840, Sanitize::integer('+18#840'));
     }
 
-    public function testNewlines() {
+    public function testNewlines(): void {
         $this->assertEquals("Testing\rCarriage\rReturns", Sanitize::newlines("Testing\rCarriage\r\rReturns"));
         $this->assertEquals("Testing\r\rCarriage\rReturns", Sanitize::newlines("Testing\r\rCarriage\r\r\rReturns", Map {'limit' => 3}));
         $this->assertEquals("TestingCarriageReturns", Sanitize::newlines("Testing\r\rCarriage\r\r\rReturns", Map {'limit' => 0}));
@@ -65,12 +65,12 @@ class SanitizeTest extends TestCase {
         $this->assertEquals("Testing\r\nBoth\r\n\r\nLineFeeds\r\n\r\n\r\nAnd\r\nCarriageReturns", Sanitize::newlines("Testing\r\nBoth\r\n\r\nLineFeeds\r\n\r\n\r\nAnd\r\nCarriageReturns", Map {'crlf' => false}));
     }
 
-    public function testUrl() {
+    public function testUrl(): void {
         $this->assertEquals('http://domain.com?key=ber', Sanitize::url('http://domain.com?key=Über'));
         $this->assertEquals('http%3A%2F%2Fdomain.com%3Fkey%3D%C3%9Cber', Sanitize::url(urlencode('http://domain.com?key=Über')));
     }
 
-    public function testWhitespace() {
+    public function testWhitespace(): void {
         $this->assertEquals("Testing White Space", Sanitize::whitespace("Testing  White Space"));
         $this->assertEquals("Testing  White Space", Sanitize::whitespace("Testing  White    Space", Map {'limit' => 3}));
         $this->assertEquals("TestingWhiteSpace", Sanitize::whitespace("Testing  White    Space", Map {'limit' => 0}));
@@ -80,7 +80,7 @@ class SanitizeTest extends TestCase {
         $this->assertEquals("TestingTabs", Sanitize::whitespace("Testing\tTabs", Map {'tab' => true, 'limit' => 0}));
     }
 
-    public function testXss() {
+    public function testXss(): void {
         $test = 'Test string <script>alert("XSS!");</script> with attack <div onclick="javascript:alert(\'XSS!\')">vectors</div>';
 
         // remove HTML tags and escape

--- a/tests/Titon/Utility/SanitizeTest.hh
+++ b/tests/Titon/Utility/SanitizeTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/CookieTest.hh
+++ b/tests/Titon/Utility/State/CookieTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class CookieTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $_COOKIE = [
             'foo' => '940a8df7d359963b805f92e125dabecf',
             'bar' => '756457dc85f13450b3dfba2cbc1465e5'

--- a/tests/Titon/Utility/State/CookieTest.hh
+++ b/tests/Titon/Utility/State/CookieTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/EnvTest.hh
+++ b/tests/Titon/Utility/State/EnvTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class EnvTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $oldEnv = $_ENV;
 
         $_ENV = [

--- a/tests/Titon/Utility/State/EnvTest.hh
+++ b/tests/Titon/Utility/State/EnvTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/FilesTest.hh
+++ b/tests/Titon/Utility/State/FilesTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class FilesTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $_FILES = [
             'file' => [
                 'name' => 'file1.jpg',
@@ -44,7 +44,7 @@ class FilesTest extends TestCase {
         $this->assertFalse(Files::has('file.mime_type'));
     }
 
-    public function testPackage() {
+    public function testPackage(): void {
         $this->assertEquals(Map {
             'file' => Map {
                 'name' => 'file1.jpg',

--- a/tests/Titon/Utility/State/FilesTest.hh
+++ b/tests/Titon/Utility/State/FilesTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/GetTest.hh
+++ b/tests/Titon/Utility/State/GetTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/GetTest.hh
+++ b/tests/Titon/Utility/State/GetTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class GetTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $_GET = [
             'foo' => 123,
             'bar' => 'abc',

--- a/tests/Titon/Utility/State/PostTest.hh
+++ b/tests/Titon/Utility/State/PostTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class PostTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $_POST = [
             'foo' => 123,
             'bar' => 'abc',

--- a/tests/Titon/Utility/State/PostTest.hh
+++ b/tests/Titon/Utility/State/PostTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/RequestTest.hh
+++ b/tests/Titon/Utility/State/RequestTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/RequestTest.hh
+++ b/tests/Titon/Utility/State/RequestTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class RequestTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $_REQUEST = [
             'foo' => 123,
             'bar' => 'abc',
@@ -41,7 +41,7 @@ class RequestTest extends TestCase {
         $this->assertFalse(Request::has('map.d'));
     }
 
-    public function testStatesDontCollide() {
+    public function testStatesDontCollide(): void {
         Get::initialize(['foo' => 1]);
         Post::initialize(['bar' => 2]);
         Server::initialize(['baz' => 3]);

--- a/tests/Titon/Utility/State/ServerTest.hh
+++ b/tests/Titon/Utility/State/ServerTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/State/ServerTest.hh
+++ b/tests/Titon/Utility/State/ServerTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class ServerTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $oldServer = $_SERVER;
 
         $_SERVER = [

--- a/tests/Titon/Utility/State/SessionTest.hh
+++ b/tests/Titon/Utility/State/SessionTest.hh
@@ -1,11 +1,11 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;
 
 class SessionTest extends TestCase {
 
-    public function testClass() {
+    public function testClass(): void {
         $_SESSION = [
             'foo' => 123,
             'bar' => 'abc',

--- a/tests/Titon/Utility/State/SessionTest.hh
+++ b/tests/Titon/Utility/State/SessionTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility\State;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/StrTest.hh
+++ b/tests/Titon/Utility/StrTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
@@ -8,7 +8,7 @@ class StrTest extends TestCase {
     protected $string = 'Titon: A PHP Modular Framework';
     protected $lipsum = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi eget tellus nibh.';
 
-    public function testCharAt() {
+    public function testCharAt(): void {
         $this->assertEquals('T', Str::charAt('Titon', 0));
         $this->assertEquals('i', Str::charAt('Titon', 1));
         $this->assertEquals('t', Str::charAt('Titon', 2));
@@ -18,7 +18,7 @@ class StrTest extends TestCase {
         $this->assertEquals(null, Str::charAt('Titon', -1));
     }
 
-    public function testCompare() {
+    public function testCompare(): void {
         $this->assertEquals('0', Str::compare('foo', 'foo'));
 
         $this->assertLessThan('0', Str::compare('foo', 'Foobar'));
@@ -28,7 +28,7 @@ class StrTest extends TestCase {
         $this->assertGreaterThan('0', Str::compare('foobar', 'Foo', 5));
     }
 
-    public function testContains() {
+    public function testContains(): void {
         $this->assertTrue(Str::contains($this->string, 'Titon'));
         $this->assertFalse(Str::contains($this->string, 'Zend'));
 
@@ -39,7 +39,7 @@ class StrTest extends TestCase {
         $this->assertFalse(Str::contains($this->string, 'Titon', true, 5));
     }
 
-    public function testEndsWith() {
+    public function testEndsWith(): void {
         $this->assertTrue(Str::endsWith($this->string, 'work'));
         $this->assertFalse(Str::endsWith($this->string, 'works'));
 
@@ -48,7 +48,7 @@ class StrTest extends TestCase {
         $this->assertFalse(Str::endsWith($this->string, 'WORKS', false));
     }
 
-    public function testExtract() {
+    public function testExtract(): void {
         $this->assertEquals('Titon: A PHP Modular Framework', Str::extract($this->string, 0));
         $this->assertEquals('Titon', Str::extract($this->string, 0, 5));
         $this->assertEquals('Framework', Str::extract($this->string, -9));
@@ -56,7 +56,7 @@ class StrTest extends TestCase {
         $this->assertEquals('Modular', Str::extract($this->string, 13, 7));
     }
 
-    public function testGenerate() {
+    public function testGenerate(): void {
         $this->assertNotEquals('ABCDEFGHIJ', Str::generate(10));
         $this->assertTrue(strlen(Str::generate(10)) == 10);
 
@@ -67,7 +67,7 @@ class StrTest extends TestCase {
         $this->assertTrue(strlen(Str::generate(5)) == 5);
     }
 
-    public function testIndexOf() {
+    public function testIndexOf(): void {
         $this->assertEquals(0, Str::indexOf($this->string, 'T'));
         $this->assertEquals(2, Str::indexOf($this->string, 't'));
         $this->assertEquals(7, Str::indexOf($this->string, 'A'));
@@ -86,7 +86,7 @@ class StrTest extends TestCase {
         $this->assertEquals(14, Str::indexOf($this->string, 'o', true, 5));
     }
 
-    public function testInsert() {
+    public function testInsert(): void {
         $this->assertEquals('Titon is the best PHP framework around!', Str::insert('{framework} is the best {lang} framework around!', Map {
             'framework' => 'Titon',
             'lang' => 'PHP'
@@ -101,7 +101,7 @@ class StrTest extends TestCase {
         }));
     }
 
-    public function testLastIndexOf() {
+    public function testLastIndexOf(): void {
         $this->assertEquals(0, Str::lastIndexOf($this->string, 'T'));
         $this->assertEquals(2, Str::lastIndexOf($this->string, 't'));
         $this->assertEquals(7, Str::lastIndexOf($this->string, 'A'));
@@ -121,7 +121,7 @@ class StrTest extends TestCase {
         $this->assertEquals(27, Str::lastIndexOf($this->string, 'o', true, 5));
     }
 
-    public function testListing() {
+    public function testListing(): void {
         $this->assertEquals('red, blue &amp; green', Str::listing(Vector {'red', 'blue', 'green'}));
         $this->assertEquals('red &amp; green', Str::listing(Vector {'red', 'green'}));
         $this->assertEquals('blue', Str::listing(Vector {'blue'}));
@@ -132,7 +132,7 @@ class StrTest extends TestCase {
         $this->assertEquals('red - blue and green', Str::listing(Vector {'red', 'blue', 'green'}, ' and ', ' - '));
     }
 
-    public function testShorten() {
+    public function testShorten(): void {
         $this->assertEquals('Lorem &hellip; nibh.', Str::shorten($this->lipsum, 10));
         $this->assertEquals('Lorem ipsum &hellip; tellus nibh.', Str::shorten($this->lipsum, 25));
         $this->assertEquals('Lorem ipsum dolor sit &hellip; Morbi eget tellus nibh.', Str::shorten($this->lipsum, 50));
@@ -142,7 +142,7 @@ class StrTest extends TestCase {
         $this->assertEquals('Lorem ... nibh.', Str::shorten($this->lipsum, 10, ' ... '));
     }
 
-    public function testStartsWith() {
+    public function testStartsWith(): void {
         $this->assertTrue(Str::startsWith($this->string, 'Titon'));
         $this->assertFalse(Str::startsWith($this->string, 'Titan'));
 
@@ -151,7 +151,7 @@ class StrTest extends TestCase {
         $this->assertFalse(Str::startsWith($this->string, 'TITAN', false));
     }
 
-    public function testTruncate() {
+    public function testTruncate(): void {
         $string = 'This has <a href="/" class="link">anchor tags</a> &amp; entities in it. It has &quot;quotes&quot; as well.';
 
         // Preserve HTML and word
@@ -190,7 +190,7 @@ class StrTest extends TestCase {
         $this->assertEquals('This has [url="/"]anchor tags[/url] &amp; entities in it. It has &quot;quotes&quot; as well.', Str::truncate($string, 0, Map {'open' => '[', 'close' => ']'}));
     }
 
-    public function testUuid() {
+    public function testUuid(): void {
         $this->assertRegExp('/^[a-f0-9]{8}\-[a-f0-9]{4}\-4[a-f0-9]{3}\-[89AB]{1}[a-f0-9]{3}\-[a-f0-9]{12}$/i', Str::uuid());
         $this->assertRegExp('/^[a-f0-9]{8}\-[a-f0-9]{4}\-4[a-f0-9]{3}\-[89AB]{1}[a-f0-9]{3}\-[a-f0-9]{12}$/i', Str::uuid());
         $this->assertRegExp('/^[a-f0-9]{8}\-[a-f0-9]{4}\-4[a-f0-9]{3}\-[89AB]{1}[a-f0-9]{3}\-[a-f0-9]{12}$/i', Str::uuid());

--- a/tests/Titon/Utility/StrTest.hh
+++ b/tests/Titon/Utility/StrTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/TimeTest.hh
+++ b/tests/Titon/Utility/TimeTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
@@ -6,13 +6,13 @@ use \DateTime;
 
 class TimeTest extends TestCase {
 
-    public function testDifference() {
+    public function testDifference(): void {
         $this->assertEquals(-60, Time::difference(null, '+60 seconds'));
         $this->assertEquals(-3600, Time::difference(new DateTime(), '+1 hour'));
         $this->assertEquals(14400, Time::difference('+5 hours', '+1 hour'));
     }
 
-    public function testFactory() {
+    public function testFactory(): void {
         $this->assertInstanceOf('\DateTime', Time::factory());
         $this->assertInstanceOf('\DateTime', Time::factory('1988-02-26 12:23:12'));
         $this->assertInstanceOf('\DateTime', Time::factory(time()));
@@ -21,37 +21,37 @@ class TimeTest extends TestCase {
         $this->assertSame($dt, Time::factory($dt));
     }
 
-    public function testIsToday() {
+    public function testIsToday(): void {
         $this->assertTrue(Time::isToday('+0 day'));
         $this->assertFalse(Time::isToday('+2 day'));
         $this->assertFalse(Time::isToday('-2 day'));
     }
 
-    public function testIsThisWeek() {
+    public function testIsThisWeek(): void {
         $this->assertTrue(Time::isThisWeek('+0 week'));
         $this->assertFalse(Time::isThisWeek('+2 week'));
         $this->assertFalse(Time::isThisWeek('-2 week'));
     }
 
-    public function testIsThisMonth() {
+    public function testIsThisMonth(): void {
         $this->assertTrue(Time::isThisMonth('+0 month'));
         $this->assertFalse(Time::isThisMonth('+2 month'));
         $this->assertFalse(Time::isThisMonth('-2 month'));
     }
 
-    public function testIsThisYear() {
+    public function testIsThisYear(): void {
         $this->assertTrue(Time::isThisYear('+0 year'));
         $this->assertFalse(Time::isThisYear('+2 year'));
         $this->assertFalse(Time::isThisYear('-2 year'));
     }
 
-    public function testIsTomorrow() {
+    public function testIsTomorrow(): void {
         $this->assertTrue(Time::isTomorrow('+1 day'));
         $this->assertFalse(Time::isTomorrow('+0 day'));
         $this->assertFalse(Time::isTomorrow('-1 day'));
     }
 
-    public function testIsWithinNext() {
+    public function testIsWithinNext(): void {
         $this->assertTrue(Time::isWithinNext('+1 day', '+7 days'));
         $this->assertTrue(Time::isWithinNext('+37 hours', '+7 days'));
         $this->assertTrue(Time::isWithinNext('+1 week', '+7 days'));
@@ -60,48 +60,48 @@ class TimeTest extends TestCase {
         $this->assertFalse(Time::isWithinNext('+8 days', '+7 days'));
     }
 
-    public function testTimezone() {
+    public function testTimezone(): void {
         $this->assertInstanceOf('\DateTimeZone', Time::timezone());
 
         $dtz = new \DateTimeZone('America/Los_Angeles');
         $this->assertSame($dtz, Time::timezone($dtz));
     }
 
-    public function testToUnix() {
+    public function testToUnix(): void {
         $this->assertTrue(is_numeric(Time::toUnix(null)));
         $this->assertTrue(is_numeric(Time::toUnix(time())));
         $this->assertTrue(is_numeric(Time::toUnix('+1 week')));
         $this->assertTrue(is_numeric(Time::toUnix(new DateTime())));
     }
 
-    public function testToUnixInvalidReturnsZero() {
+    public function testToUnixInvalidReturnsZero(): void {
         $this->assertEquals(0, Time::toUnix('string'));
     }
 
-    public function testWasLastWeek() {
+    public function testWasLastWeek(): void {
         $this->assertTrue(Time::wasLastWeek('last week'));
         $this->assertFalse(Time::wasLastWeek('next week'));
     }
 
-    public function testWasLastMonth() {
+    public function testWasLastMonth(): void {
         $this->assertTrue(Time::wasLastMonth('-31 days'));
         $this->assertFalse(Time::wasLastMonth('+31 days'));
         $this->assertFalse(Time::wasLastMonth('+0 month'));
     }
 
-    public function testWasLastYear() {
+    public function testWasLastYear(): void {
         $this->assertTrue(Time::wasLastYear('-1 year'));
         $this->assertFalse(Time::wasLastYear('+1 year'));
         $this->assertFalse(Time::wasLastYear('+0 year'));
     }
 
-    public function testWasYesterday() {
+    public function testWasYesterday(): void {
         $this->assertTrue(Time::wasYesterday('-1 day'));
         $this->assertFalse(Time::wasYesterday('+0 day'));
         $this->assertFalse(Time::wasYesterday('+1 day'));
     }
 
-    public function testWasWithinLast() {
+    public function testWasWithinLast(): void {
         $this->assertTrue(Time::wasWithinLast('-1 day', '-7 days'));
         $this->assertTrue(Time::wasWithinLast('-37 hours', '-7 days'));
         $this->assertTrue(Time::wasWithinLast('-1 week', '-7 days'));

--- a/tests/Titon/Utility/TimeTest.hh
+++ b/tests/Titon/Utility/TimeTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Utility/ValidateTest.hh
+++ b/tests/Titon/Utility/ValidateTest.hh
@@ -53,13 +53,9 @@ class ValidateTest extends TestCase {
     }
 
     public function testCallback(): void {
-        $this->assertTrue(Validate::callback('123', function($value): void {
-            return is_numeric($value);
-        }));
+        $this->assertTrue(Validate::callback('123', ($value) ==> is_numeric($value)));
 
-        $this->assertFalse(Validate::callback('123abc', function($value): void {
-            return is_numeric($value);
-        }));
+        $this->assertFalse(Validate::callback('123abc', ($value) ==> is_numeric($value)));
     }
 
     public function testComparison(): void {

--- a/tests/Titon/Utility/ValidateTest.hh
+++ b/tests/Titon/Utility/ValidateTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;
@@ -7,13 +7,13 @@ class ValidateTest extends TestCase {
 
     protected $image;
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->image = TEMP_DIR . '/utility/image.jpg';
     }
 
-    public function testAlpha() {
+    public function testAlpha(): void {
         $this->assertTrue(Validate::alpha('ahjsNKHAShksdnASQfgd'));
         $this->assertTrue(Validate::alpha('asdnasdsd.dfsdfdfsdfs;', '.;'));
 
@@ -22,7 +22,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::alpha('pkmpwij*39@0'));
     }
 
-    public function testAlphaNumeric() {
+    public function testAlphaNumeric(): void {
         $this->assertTrue(Validate::alphaNumeric('ahjsNKHAShksdnASQfgd'));
         $this->assertTrue(Validate::alphaNumeric('asdnasdsd.dfsdfdfsdfs;', '.;'));
         $this->assertTrue(Validate::alphaNumeric('asdjn1803201'));
@@ -31,14 +31,14 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::alphaNumeric('pkmpwij*39@0'));
     }
 
-    public function testBetween() {
+    public function testBetween(): void {
         $this->assertTrue(Validate::between('This is just the right length', 10, 30));
 
         $this->assertFalse(Validate::between('This is far too long because its more than 30 characters', 10, 30));
         $this->assertFalse(Validate::between('Too short', 10, 30));
     }
 
-    public function testBoolean() {
+    public function testBoolean(): void {
         $this->assertTrue(Validate::boolean(true));
         $this->assertTrue(Validate::boolean(false));
         $this->assertTrue(Validate::boolean(0));
@@ -52,17 +52,17 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::boolean('abc'));
     }
 
-    public function testCallback() {
-        $this->assertTrue(Validate::callback('123', function($value) {
+    public function testCallback(): void {
+        $this->assertTrue(Validate::callback('123', function($value): void {
             return is_numeric($value);
         }));
 
-        $this->assertFalse(Validate::callback('123abc', function($value) {
+        $this->assertFalse(Validate::callback('123abc', function($value): void {
             return is_numeric($value);
         }));
     }
 
-    public function testComparison() {
+    public function testComparison(): void {
         $this->assertTrue(Validate::comparison(15, 10, '>'));
         $this->assertFalse(Validate::comparison(5, 10, 'gt'));
 
@@ -85,11 +85,11 @@ class ValidateTest extends TestCase {
     /**
      * @expectedException \Titon\Common\Exception\InvalidArgumentException
      */
-    public function testComparisonInvalidOperator() {
+    public function testComparisonInvalidOperator(): void {
         Validate::comparison(10, 10, '><');
     }
 
-    public function testCreditCard() {
+    public function testCreditCard(): void {
         $this->assertTrue(Validate::creditCard('4916933155767'));
         $this->assertFalse(Validate::creditCard('2346533'));
 
@@ -163,11 +163,11 @@ class ValidateTest extends TestCase {
     /**
      * @expectedException \Titon\Utility\Exception\InvalidCreditCardException
      */
-    public function testCreditCardInvalidType() {
+    public function testCreditCardInvalidType(): void {
         Validate::creditCard('6334768185398134', 'fakeCard');
     }
 
-    public function testCurrency() {
+    public function testCurrency(): void {
         $this->assertTrue(Validate::currency('$1,000.00'));
         $this->assertTrue(Validate::currency('$343'));
         $this->assertTrue(Validate::currency('$193,482.33'));
@@ -178,12 +178,12 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::currency('$1923.2'));
     }
 
-    public function testCustom() {
+    public function testCustom(): void {
         $this->assertTrue(Validate::custom('abcdef', '/^abc/'));
         $this->assertFalse(Validate::custom('abcdef', '/abc$/'));
     }
 
-    public function testDate() {
+    public function testDate(): void {
         $this->assertTrue(Validate::date('2012-05-25'));
         $this->assertTrue(Validate::date('1946-09-11 12:03:43'));
         $this->assertTrue(Validate::date('March 25th 1993'));
@@ -192,7 +192,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::date('May 40th 2054'));
     }
 
-    public function testDecimal() {
+    public function testDecimal(): void {
         $this->assertTrue(Validate::decimal('2923.23'));
         $this->assertTrue(Validate::decimal('1454.04'));
         $this->assertTrue(Validate::decimal('849383.938', 3));
@@ -208,7 +208,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::decimal('849383.74235', 3));
     }
 
-    public function testDimensions() {
+    public function testDimensions(): void {
         $this->assertTrue(Validate::dimensions($this->image, 'width', 200));
         $this->assertTrue(Validate::dimensions($this->image, 'height', 267));
         $this->assertFalse(Validate::dimensions($this->image, 'foobar', 267));
@@ -217,7 +217,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::dimensions(['tmp_name' => 'fake.jpg', 'error' => 0], 'height', 267));
     }
 
-    public function testEmail() {
+    public function testEmail(): void {
         $this->assertTrue(Validate::email('email@titon.com', false));
         $this->assertTrue(Validate::email('email@sub.titon.com', false));
         $this->assertTrue(Validate::email('email+group@titon.com', false));
@@ -233,7 +233,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::email('email@somereallyfakedomain.com', true));
     }
 
-    public function testEqual() {
+    public function testEqual(): void {
         $this->assertTrue(Validate::equal('1', 1));
         $this->assertTrue(Validate::equal('abc', 'abc'));
         $this->assertTrue(Validate::equal(true, 1));
@@ -243,7 +243,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::equal(true, false));
     }
 
-    public function testExact() {
+    public function testExact(): void {
         $this->assertTrue(Validate::exact(1, 1));
         $this->assertTrue(Validate::exact('abc', 'abc'));
         $this->assertTrue(Validate::exact(true, true));
@@ -252,7 +252,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::exact(true, 1));
     }
 
-    public function testExt() {
+    public function testExt(): void {
         $this->assertTrue(Validate::ext('image.gif'));
         $this->assertTrue(Validate::ext('image.jpeg'));
         $this->assertTrue(Validate::ext('doc.pdf', Vector {'pdf'}));
@@ -263,11 +263,11 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::ext('web.XML', Vector {'html', 'xhtml'}));
     }
 
-    public function testExtFile() {
+    public function testExtFile(): void {
         $this->assertTrue(Validate::ext(['name' => 'image.gif', 'error' => 0, 'type' => 'image/gif']));
     }
 
-    public function testFile() {
+    public function testFile(): void {
         $this->assertTrue(Validate::file([
             'name' => 'file1.jpg',
             'type' => 'image/jpeg',
@@ -286,12 +286,12 @@ class ValidateTest extends TestCase {
         ]));
     }
 
-    public function testHeight() {
+    public function testHeight(): void {
         $this->assertTrue(Validate::height($this->image, 267));
         $this->assertFalse(Validate::height($this->image, 233));
     }
 
-    public function testInList() {
+    public function testInList(): void {
         $this->assertTrue(Validate::inList(1, Vector {1, '1', 'c'}));
         $this->assertTrue(Validate::inList('foo', Vector {'foo', 'BAR', 'wtf'}));
 
@@ -299,14 +299,14 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::inList('test', Vector {'foo', 'BAR', 'wtf'}));
     }
 
-    public function testInRange() {
+    public function testInRange(): void {
         $this->assertTrue(Validate::inRange(20, 10, 30));
 
         $this->assertFalse(Validate::inRange(35, 10, 30));
         $this->assertFalse(Validate::inRange(5, 10, 30));
     }
 
-    public function testIp() {
+    public function testIp(): void {
         // both v4 and v6
         $this->assertTrue(Validate::ip('0.0.0.0'));
         $this->assertTrue(Validate::ip('192.168.1.156'));
@@ -360,7 +360,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::ip('255.255.255.255', Validate::IPV6));
     }
 
-    public function testLuhn() {
+    public function testLuhn(): void {
         $this->assertTrue(Validate::luhn('370482756063980')); // American Express
         $this->assertTrue(Validate::luhn('5610745867413420')); // BankCard
         $this->assertTrue(Validate::luhn('30155483651028')); // Diners Club 14
@@ -387,7 +387,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::luhn('869940697287173'));
     }
 
-    public function testMimeType() {
+    public function testMimeType(): void {
         $this->assertTrue(Validate::mimeType($this->image, Vector {'image/jpeg', 'image/jpg'}));
         $this->assertFalse(Validate::mimeType($this->image, Vector {'image/gif'}));
 
@@ -395,7 +395,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::mimeType(['tmp_name' => 'fake.jpg', 'error' => 0], Vector {'image/gif'}));
     }
 
-    public function testMinFilesize() {
+    public function testMinFilesize(): void {
         $this->assertTrue(Validate::minFilesize($this->image, 13437));
         $this->assertTrue(Validate::minFilesize(['tmp_name' => $this->image, 'error' => 0, 'size' => 13437], 10000));
         $this->assertFalse(Validate::minFilesize($this->image, 15000));
@@ -403,26 +403,26 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::minFilesize('fake.jpg', 13458));
     }
 
-    public function testMinHeight() {
+    public function testMinHeight(): void {
         $this->assertTrue(Validate::minHeight($this->image, 267));
         $this->assertTrue(Validate::minHeight($this->image, 255));
         $this->assertFalse(Validate::minHeight($this->image, 300));
         $this->assertFalse(Validate::minHeight($this->image, 268));
     }
 
-    public function testMinLength() {
+    public function testMinLength(): void {
         $this->assertTrue(Validate::minLength('This string is enough', 20));
         $this->assertFalse(Validate::minLength('This is too short', 20));
     }
 
-    public function testMinWidth() {
+    public function testMinWidth(): void {
         $this->assertTrue(Validate::minWidth($this->image, 200));
         $this->assertTrue(Validate::minWidth($this->image, 155));
         $this->assertFalse(Validate::minWidth($this->image, 215));
         $this->assertFalse(Validate::minWidth($this->image, 355));
     }
 
-    public function testMaxFilesize() {
+    public function testMaxFilesize(): void {
         $this->assertTrue(Validate::maxFilesize($this->image, 13437));
         $this->assertTrue(Validate::maxFilesize(['tmp_name' => $this->image, 'error' => 0, 'size' => 13437], 15000));
         $this->assertFalse(Validate::maxFilesize($this->image, 13000));
@@ -430,26 +430,26 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::maxFilesize('fakq.jpg', 13000));
     }
 
-    public function testMaxHeight() {
+    public function testMaxHeight(): void {
         $this->assertTrue(Validate::maxHeight($this->image, 267));
         $this->assertTrue(Validate::maxHeight($this->image, 300));
         $this->assertFalse(Validate::maxHeight($this->image, 265));
         $this->assertFalse(Validate::maxHeight($this->image, 144));
     }
 
-    public function testMaxLength() {
+    public function testMaxLength(): void {
         $this->assertTrue(Validate::maxLength('This is just right', 20));
         $this->assertFalse(Validate::maxLength('This is too far too long', 20));
     }
 
-    public function testMaxWidth() {
+    public function testMaxWidth(): void {
         $this->assertTrue(Validate::maxWidth($this->image, 200));
         $this->assertTrue(Validate::maxWidth($this->image, 255));
         $this->assertFalse(Validate::maxWidth($this->image, 100));
         $this->assertFalse(Validate::maxWidth($this->image, 199));
     }
 
-    public function testNotEmpty() {
+    public function testNotEmpty(): void {
         $this->assertTrue(Validate::notEmpty('abc'));
         $this->assertTrue(Validate::notEmpty(123));
         $this->assertTrue(Validate::notEmpty(['foo', 'bar']));
@@ -462,13 +462,13 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::notEmpty(null));
     }
 
-    public function testNumeric() {
+    public function testNumeric(): void {
         $this->assertTrue(Validate::numeric('1234'));
         $this->assertTrue(Validate::numeric(456));
         $this->assertFalse(Validate::numeric('abc34f'));
     }
 
-    public function testPhone() {
+    public function testPhone(): void {
         $this->assertTrue(Validate::phone('666-1337'));
         $this->assertTrue(Validate::phone('(888)666-1337'));
         $this->assertTrue(Validate::phone('(888) 666-1337'));
@@ -481,7 +481,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::phone('666-ABMS'));
     }
 
-    public function testPostalCode() {
+    public function testPostalCode(): void {
         $this->assertTrue(Validate::postalCode('38842'));
         $this->assertTrue(Validate::postalCode('38842-0384'));
 
@@ -490,7 +490,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::postalCode('AksiS-0384'));
     }
 
-    public function testSsn() {
+    public function testSsn(): void {
         $this->assertTrue(Validate::ssn('666-10-1337'));
         $this->assertTrue(Validate::ssn('384-29-3481'));
 
@@ -500,7 +500,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::ssn('AHE-29-34P1'));
     }
 
-    public function testUuid() {
+    public function testUuid(): void {
         $this->assertTrue(Validate::uuid('a8293fde-ce92-9abe-83de-7294ab29cd03'));
 
         $this->assertFalse(Validate::uuid('a8293fde-ce92-83de-7294ab29cd03'));
@@ -508,7 +508,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::uuid('a8293kq-ce92-9abe-83de-729pdu29cd03'));
     }
 
-    public function testUrl() {
+    public function testUrl(): void {
         $this->assertTrue(Validate::url('http://titon'));
         $this->assertTrue(Validate::url('http://titon.com'));
         $this->assertTrue(Validate::url('http://titon.com?query=string'));
@@ -529,7 +529,7 @@ class ValidateTest extends TestCase {
         $this->assertFalse(Validate::url('www.titon.com'));
     }
 
-    public function testWidth() {
+    public function testWidth(): void {
         $this->assertTrue(Validate::width($this->image, 200));
         $this->assertFalse(Validate::width($this->image, 100));
     }

--- a/tests/Titon/Utility/ValidateTest.hh
+++ b/tests/Titon/Utility/ValidateTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Utility;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Validate/ValidatorTest.hh
+++ b/tests/Titon/Validate/ValidatorTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\Validate;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/Validate/ValidatorTest.hh
+++ b/tests/Titon/Validate/ValidatorTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\Validate;
 
 use Titon\Test\TestCase;
@@ -8,7 +8,7 @@ use Titon\Test\TestCase;
  */
 class ValidatorTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new CoreValidator(Map {
@@ -17,21 +17,21 @@ class ValidatorTest extends TestCase {
         });
     }
 
-    public function testAddGetErrors() {
+    public function testAddGetErrors(): void {
         $this->assertEquals(Map {}, $this->object->getErrors());
 
         $this->object->addError('username', 'Invalid username');
         $this->assertEquals(Map {'username' => 'Invalid username'}, $this->object->getErrors());
     }
 
-    public function testAddGetFields() {
+    public function testAddGetFields(): void {
         $this->assertEquals(Map {}, $this->object->getFields());
 
         $this->object->addField('username', 'Username');
         $this->assertEquals(Map {'username' => 'Username'}, $this->object->getFields());
     }
 
-    public function testAddGetRules() {
+    public function testAddGetRules(): void {
         $this->assertEquals(Map {}, $this->object->getRules());
 
         // via addRule()
@@ -111,11 +111,11 @@ class ValidatorTest extends TestCase {
     /**
      * @expectedException \Titon\Common\Exception\InvalidArgumentException
      */
-    public function testAddRuleInvalidField() {
+    public function testAddRuleInvalidField(): void {
         $this->object->addRule('field', 'rule', 'message');
     }
 
-    public function testMessages() {
+    public function testMessages(): void {
         $this->object
             ->addField('username', 'Username')
                 ->addRule('username', 'between', 'May only be between {0} and {1} characters', Vector {25, 45})
@@ -135,7 +135,7 @@ class ValidatorTest extends TestCase {
         }, $this->object->getErrors());
     }
 
-    public function testMessageDetection() {
+    public function testMessageDetection(): void {
         $this->object
             ->addField('username', 'Username')
                 ->addRule('username', 'notEmpty', '')
@@ -165,7 +165,7 @@ class ValidatorTest extends TestCase {
         }, $this->object->getErrors());
     }
 
-    public function testFormatMessage() {
+    public function testFormatMessage(): void {
         $this->object
             ->addField('username', 'Username');
 
@@ -178,7 +178,7 @@ class ValidatorTest extends TestCase {
     /**
      * @expectedException \Titon\Validate\Exception\MissingMessageException
      */
-    public function testFormatMessageErrorOnMissing() {
+    public function testFormatMessageErrorOnMissing(): void {
         $this->object
             ->addField('username', 'Username')
                 ->addRule('username', 'notEmpty', '');
@@ -186,18 +186,18 @@ class ValidatorTest extends TestCase {
         $this->object->formatMessage('username', shape('rule' => 'notEmpty', 'message' => '', 'options' => Vector {}));
     }
 
-    public function testReset() {
+    public function testReset(): void {
         $this->assertEquals(Map {'username' => 'miles', 'email' => 'miles@titon'}, $this->object->getData());
         $this->object->reset();
         $this->assertEquals(Map {}, $this->object->getData());
     }
 
-    public function testSetGetData() {
+    public function testSetGetData(): void {
         $this->object->setData(Map {'foo' => 'bar'});
         $this->assertEquals(Map {'foo' => 'bar'}, $this->object->getData());
     }
 
-    public function testSplitShorthand() {
+    public function testSplitShorthand(): void {
         // only a rule
         $this->assertEquals(shape(
             'rule' => 'boolean',
@@ -234,7 +234,7 @@ class ValidatorTest extends TestCase {
         ), $this->object->splitShorthand('between:1,10:Must be between 1:10!'));
     }
 
-    public function testValidate() {
+    public function testValidate(): void {
         $this->object->addField('username', 'Username')->addRule('username', 'alpha', 'Not alpha');
 
         $this->assertTrue($this->object->validate());
@@ -247,7 +247,7 @@ class ValidatorTest extends TestCase {
         $this->assertEquals(Map {'email' => 'Invalid email'}, $this->object->getErrors());
     }
 
-    public function testValidateFailsNoData() {
+    public function testValidateFailsNoData(): void {
         $this->object->reset();
 
         $this->assertFalse($this->object->validate());
@@ -256,7 +256,7 @@ class ValidatorTest extends TestCase {
     /**
      * @expectedException \Titon\Validate\Exception\MissingConstraintException
      */
-    public function testValidateMissingRule() {
+    public function testValidateMissingRule(): void {
         $this->object
             ->addField('username', 'Username')
                 ->addRule('username', 'fooBar', 'A message');
@@ -264,7 +264,7 @@ class ValidatorTest extends TestCase {
         $this->object->validate();
     }
 
-    public function testMakeFromShorthand() {
+    public function testMakeFromShorthand(): void {
         // simple rule
         $obj = CoreValidator::makeFromShorthand(Map {}, Map {
             'field' => 'alphaNumeric',

--- a/tests/Titon/View/Engine/TemplateEngineTest.hh
+++ b/tests/Titon/View/Engine/TemplateEngineTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View\Engine;
 
 use Titon\View\EngineView;
@@ -13,8 +13,7 @@ class TemplateEngineTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             '/views/' => [
                 'private/' => [
                     'partials/' => [
@@ -35,7 +34,7 @@ class TemplateEngineTest extends TestCase {
 
         $this->engine = new TemplateEngine();
 
-        $this->object = new EngineView([$this->vfs->path('/views')]);
+        $this->object = new EngineView([$this->vfs()->path('/views')]);
         $this->object->setEngine($this->engine);
     }
 

--- a/tests/Titon/View/Engine/TemplateEngineTest.hh
+++ b/tests/Titon/View/Engine/TemplateEngineTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View\Engine;
 
 use Titon\View\EngineView;
@@ -10,7 +10,7 @@ use Titon\Test\TestCase;
  */
 class TemplateEngineTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -39,7 +39,7 @@ class TemplateEngineTest extends TestCase {
         $this->object->setEngine($this->engine);
     }
 
-    public function testOpen() {
+    public function testOpen(): void {
         $this->assertEquals('nested/include.tpl', $this->object->getEngine()->open('nested/include'));
         $this->assertEquals('nested/include.tpl', $this->object->getEngine()->open('nested/include.tpl'));
         $this->assertEquals('Titon - partial - variables.tpl', $this->object->getEngine()->open('variables', Map {
@@ -52,16 +52,16 @@ class TemplateEngineTest extends TestCase {
     /**
      * @expectedException \Titon\View\Exception\MissingTemplateException
      */
-    public function testOpenMissingFile() {
+    public function testOpenMissingFile(): void {
         $this->object->getEngine()->open('foobar');
     }
 
-    public function testRender() {
+    public function testRender(): void {
         $this->assertEquals('add.tpl', $this->object->renderTemplate($this->object->locateTemplate('index/add')));
         $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($this->object->locateTemplate('index/test-include')));
     }
 
-    public function testData() {
+    public function testData(): void {
         $this->assertEquals('add.tpl', $this->engine->render($this->object->locateTemplate('index/add'), Map {
             'foo' => 'bar'
         }));

--- a/tests/Titon/View/EngineTest.hh
+++ b/tests/Titon/View/EngineTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View;
 
 use Titon\Test\Stub\View\EngineStub;

--- a/tests/Titon/View/EngineTest.hh
+++ b/tests/Titon/View/EngineTest.hh
@@ -1,9 +1,8 @@
 <?hh
 namespace Titon\View;
 
-use Titon\Common\DataMap;
+use Titon\Test\Stub\View\EngineStub;
 use Titon\Test\TestCase;
-use Titon\View\Engine\AbstractEngine;
 
 /**
  * @property \Titon\View\Engine $object
@@ -39,13 +38,5 @@ class EngineTest extends TestCase {
         $this->object->setContent('content');
         $this->assertEquals('content', $this->object->getContent());
     }
-
-}
-
-class EngineStub extends AbstractEngine {
-
-    public function open(string $partial, DataMap $variables = Map {}): string {}
-    public function render(string $path, DataMap $variables = Map {}): string {}
-    public function getExtension(): string {}
 
 }

--- a/tests/Titon/View/EngineTest.hh
+++ b/tests/Titon/View/EngineTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View;
 
 use Titon\Test\Stub\View\EngineStub;
@@ -9,20 +9,20 @@ use Titon\Test\TestCase;
  */
 class EngineTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new EngineStub();
     }
 
-    public function testLayout() {
+    public function testLayout(): void {
         $this->assertEquals('default', $this->object->getLayout());
 
         $this->object->useLayout('alternate');
         $this->assertEquals('alternate', $this->object->getLayout());
     }
 
-    public function testWrappers() {
+    public function testWrappers(): void {
         $this->assertEquals(Vector {}, $this->object->getWrappers());
 
         $this->object->wrapWith('alternate');
@@ -32,7 +32,7 @@ class EngineTest extends TestCase {
         $this->assertEquals(Vector {'alternate', 'double'}, $this->object->getWrappers());
     }
 
-    public function testContent() {
+    public function testContent(): void {
         $this->assertEquals('', $this->object->getContent());
 
         $this->object->setContent('content');

--- a/tests/Titon/View/EngineViewTest.hh
+++ b/tests/Titon/View/EngineViewTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View;
 
 use Titon\Cache\Storage\MemoryStorage;
@@ -9,7 +9,7 @@ use Titon\Test\TestCase;
  */
 class EngineViewTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -61,7 +61,7 @@ class EngineViewTest extends TestCase {
         ]);
     }
 
-    public function testRender() {
+    public function testRender(): void {
         $this->assertEquals('<layout>edit.tpl</layout>', $this->object->render('index/edit'));
 
         $this->object->getEngine()->useLayout('fallback');
@@ -77,12 +77,12 @@ class EngineViewTest extends TestCase {
         $this->assertEquals('view.xml.tpl', $this->object->render('index/view.xml'));
     }
 
-    public function testRenderPrivate() {
+    public function testRenderPrivate(): void {
         $this->assertEquals('<layout>public/root.tpl</layout>', $this->object->render('root'));
         $this->assertEquals('<layout>private/root.tpl</layout>', $this->object->render('root', true));
     }
 
-    public function testRenderTemplate() {
+    public function testRenderTemplate(): void {
         $this->assertEquals('add.tpl', $this->object->renderTemplate($this->object->locateTemplate('index/add')));
         $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($this->object->locateTemplate('index/test-include')));
 
@@ -94,7 +94,7 @@ class EngineViewTest extends TestCase {
         }));
     }
 
-    public function testViewCaching() {
+    public function testViewCaching(): void {
         $storage = new MemoryStorage();
 
         $this->object->setStorage($storage);

--- a/tests/Titon/View/EngineViewTest.hh
+++ b/tests/Titon/View/EngineViewTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View;
 
 use Titon\Cache\Storage\MemoryStorage;
@@ -12,8 +12,7 @@ class EngineViewTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             '/views/' => [
                 'fallback/' => [
                     'private/' => [
@@ -56,8 +55,8 @@ class EngineViewTest extends TestCase {
         ]);
 
         $this->object = new EngineView([
-            $this->vfs->path('/views/'),
-            $this->vfs->path('/views/fallback/')
+            $this->vfs()->path('/views/'),
+            $this->vfs()->path('/views/fallback/')
         ]);
     }
 

--- a/tests/Titon/View/Helper/AssetHelperTest.hh
+++ b/tests/Titon/View/Helper/AssetHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;
@@ -9,7 +9,7 @@ use Titon\View\EngineView;
  */
 class AssetHelperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -23,7 +23,7 @@ class AssetHelperTest extends TestCase {
         $this->object->setView($view);
     }
 
-    public function testScripts() {
+    public function testScripts(): void {
         $this->object
             ->addScript('script.js')
             ->addScript('path/commons.js', 'header')
@@ -43,7 +43,7 @@ class AssetHelperTest extends TestCase {
         , $this->object->scripts('footer'));
     }
 
-    public function testScriptsOrdering() {
+    public function testScriptsOrdering(): void {
         $this->object
             ->addScript('script.js', 'footer', 3)
             ->addScript('path/commons.js', 'footer', 2)
@@ -58,7 +58,7 @@ class AssetHelperTest extends TestCase {
         , $this->object->scripts('footer'));
     }
 
-    public function testScriptsEnv() {
+    public function testScriptsEnv(): void {
         $this->object
             ->addScript('script.js', 'footer', 30, 'dev')
             ->addScript('path/commons.js', 'footer', 30, 'prod')
@@ -71,7 +71,7 @@ class AssetHelperTest extends TestCase {
         , $this->object->scripts('footer', 'dev'));
     }
 
-    public function testStylesheets() {
+    public function testStylesheets(): void {
         $this->object
             ->addStylesheet('style.css')
             ->addStylesheet('a/really/deep/path/with/no/extension/style.css')
@@ -84,7 +84,7 @@ class AssetHelperTest extends TestCase {
         , $this->object->stylesheets());
     }
 
-    public function testStylesheetsOrdering() {
+    public function testStylesheetsOrdering(): void {
         $this->object
             ->addStylesheet('style.css', Map {'media' => 'handheld'}, 3)
             ->addStylesheet('a/really/deep/path/with/no/extension/style.css', Map {'media' => 'screen'}, 1)
@@ -97,7 +97,7 @@ class AssetHelperTest extends TestCase {
         , $this->object->stylesheets());
     }
 
-    public function testStylesheetsEnv() {
+    public function testStylesheetsEnv(): void {
         $this->object
             ->addStylesheet('style.css', Map {'media' => 'handheld'}, 30, 'dev')
             ->addStylesheet('a/really/deep/path/with/no/extension/style.css', Map {'media' => 'screen'}, 30, 'staging')
@@ -106,7 +106,7 @@ class AssetHelperTest extends TestCase {
         $this->assertEquals('<link href="style.css" media="handheld" rel="stylesheet" type="text/css">' . PHP_EOL, $this->object->stylesheets('dev'));
     }
 
-    public function testPreparePath() {
+    public function testPreparePath(): void {
         $helper = $this->object;
 
         $this->assertEquals('style.css', $helper->preparePath('style', 'css'));
@@ -121,7 +121,7 @@ class AssetHelperTest extends TestCase {
         $this->assertEquals('https://domain.com/asset?version=123', $helper->preparePath('https://domain.com/asset?version=123', 'js'));
     }
 
-    public function testTimestamping() {
+    public function testTimestamping(): void {
         $this->object->addStylesheet('/css/test.css');
 
         $this->assertRegExp('/<link href="\/css\/test\.css\?([0-9]+)" media="screen" rel="stylesheet" type="text\/css">/', $this->object->stylesheets());

--- a/tests/Titon/View/Helper/AssetHelperTest.hh
+++ b/tests/Titon/View/Helper/AssetHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;
@@ -12,14 +12,13 @@ class AssetHelperTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createDirectory('/css/');
-        $this->vfs->createFile('/css/test.css');
+        $this->vfs()->createDirectory('/css/');
+        $this->vfs()->createFile('/css/test.css');
 
         $view = new EngineView(TEMP_DIR);
         $view->addHelper('html', new HtmlHelper());
 
-        $this->object = new AssetHelper($this->vfs->path('/'));
+        $this->object = new AssetHelper($this->vfs()->path('/'));
         $this->object->setView($view);
     }
 

--- a/tests/Titon/View/Helper/BlockHelperTest.hh
+++ b/tests/Titon/View/Helper/BlockHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;
@@ -8,13 +8,13 @@ use Titon\Test\TestCase;
  */
 class BlockHelperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new BlockHelper();
     }
 
-    public function testGetSetHas() {
+    public function testGetSetHas(): void {
         $this->assertFalse($this->object->has('block'));
         $this->assertEquals(null, $this->object->get('block'));
 
@@ -24,7 +24,7 @@ class BlockHelperTest extends TestCase {
         $this->assertEquals('contents', $this->object->get('block'));
     }
 
-    public function testAppendPrepend() {
+    public function testAppendPrepend(): void {
         $this->object->set('block', 'contents');
         $this->assertEquals('contents', $this->object->get('block'));
 
@@ -44,7 +44,7 @@ class BlockHelperTest extends TestCase {
         $this->assertTrue($this->object->has('block3'));
     }
 
-    public function testCapture() {
+    public function testCapture(): void {
         $this->assertEquals('', $this->object->get('block'));
 
         $this->object->start('block');
@@ -54,7 +54,7 @@ class BlockHelperTest extends TestCase {
         $this->assertEquals('foobar', $this->object->get('block'));
     }
 
-    public function testCaptureStateDetection() {
+    public function testCaptureStateDetection(): void {
         $this->object->start('block');
         $this->assertEquals('block', $this->object->active());
 
@@ -72,7 +72,7 @@ class BlockHelperTest extends TestCase {
         $this->assertEquals('whatwhat', $this->object->get('block'));
     }
 
-    public function testNestedCapture() {
+    public function testNestedCapture(): void {
         $this->object->start('first');
         echo 1;
         $this->object->start('second');
@@ -85,7 +85,7 @@ class BlockHelperTest extends TestCase {
         $this->assertEquals('2', $this->object->get('second'));
     }
 
-    public function testParentCapture() {
+    public function testParentCapture(): void {
         $this->object->start('block');
         echo 'PARENT';
         $this->object->stop();
@@ -97,7 +97,7 @@ class BlockHelperTest extends TestCase {
         $this->assertEquals('CHILD PARENT CHILD', $this->object->get('block'));
     }
 
-    public function testCaptureShow() {
+    public function testCaptureShow(): void {
         $this->object->start('block');
         echo 'foobar';
         $contents = $this->object->show();
@@ -105,7 +105,7 @@ class BlockHelperTest extends TestCase {
         $this->assertEquals('foobar', $contents);
     }
 
-    public function testStop() {
+    public function testStop(): void {
         $this->object->start('block');
         echo 'foobar';
         $this->object->stop();

--- a/tests/Titon/View/Helper/BlockHelperTest.hh
+++ b/tests/Titon/View/Helper/BlockHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/View/Helper/BreadcrumbHelperTest.hh
+++ b/tests/Titon/View/Helper/BreadcrumbHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;
@@ -10,7 +10,7 @@ use Titon\View\EngineView;
  */
 class BreadcrumbHelperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $view = new EngineView(TEMP_DIR);
@@ -20,7 +20,7 @@ class BreadcrumbHelperTest extends TestCase {
         $this->object->setView($view);
     }
 
-    public function testOneCrumb() {
+    public function testOneCrumb(): void {
         $this->object->add('Title', '/');
 
         $this->assertEquals(Vector {
@@ -28,7 +28,7 @@ class BreadcrumbHelperTest extends TestCase {
         }, $this->object->generate());
     }
 
-    public function testMultipleCrumbs() {
+    public function testMultipleCrumbs(): void {
         $this->object
             ->add('Title', '/')
             ->add('Title 2', '/static/url', Map {'class' => 'tier2'})
@@ -41,7 +41,7 @@ class BreadcrumbHelperTest extends TestCase {
         }, $this->object->generate());
     }
 
-    public function testFirstLast() {
+    public function testFirstLast(): void {
         $this->assertEquals(null, $this->object->first());
         $this->assertEquals(null, $this->object->last());
 
@@ -63,7 +63,7 @@ class BreadcrumbHelperTest extends TestCase {
         ), $this->object->last());
     }
 
-    public function testAppendPrepend() {
+    public function testAppendPrepend(): void {
         $this->object->add('Base', '/');
 
         $this->assertEquals(new ArrayList(Vector {
@@ -96,7 +96,7 @@ class BreadcrumbHelperTest extends TestCase {
         }), $this->object->getBreadcrumbs());
     }
 
-    public function testTitle() {
+    public function testTitle(): void {
         $this->object->add([
             'A' => '/a',
             'B' => '/b',
@@ -116,7 +116,7 @@ class BreadcrumbHelperTest extends TestCase {
         $this->assertEquals('Base - A - B - C - D - E - F - G', $this->object->title('Base', Map {'depth' => 15}));
     }
 
-    public function testTitleFallback() {
+    public function testTitleFallback(): void {
         $this->object->getView()->setVariable('pageTitle', 'Page Title');
 
         $this->assertEquals('Page Title', $this->object->title());

--- a/tests/Titon/View/Helper/BreadcrumbHelperTest.hh
+++ b/tests/Titon/View/Helper/BreadcrumbHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/View/Helper/FormHelperTest.hh
+++ b/tests/Titon/View/Helper/FormHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View\Helper;
 
 use Titon\Model\Model;

--- a/tests/Titon/View/Helper/FormHelperTest.hh
+++ b/tests/Titon/View/Helper/FormHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View\Helper;
 
 use Titon\Model\Model;
@@ -12,7 +12,7 @@ use Titon\Utility\State\Server;
  */
 class FormHelperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $_SERVER['HTTP_USER_AGENT'] = 'browser';
@@ -26,12 +26,12 @@ class FormHelperTest extends TestCase {
         $this->object->open('/');
     }
 
-    public function testValueAttributeEscaping() {
+    public function testValueAttributeEscaping(): void {
         $this->assertEquals('<input id="text" name="text" type="text" value="">' . PHP_EOL, $this->object->text('text'));
         $this->assertEquals('<input id="text" name="text" type="text" value="Value with &quot;quotes&quot;">' . PHP_EOL, $this->object->text('text', 'Value with "quotes"'));
     }
 
-    public function testValueOverrides() {
+    public function testValueOverrides(): void {
         if (!class_exists('Titon\Model\Model')) {
             $this->markTestSkipped('Test skipped; Please install titon/model via Composer');
         }
@@ -61,7 +61,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input id="model-text" name="text" type="text" value="model">' . PHP_EOL, $this->object->text('text', 'default'));
     }
 
-    public function testBinary() {
+    public function testBinary(): void {
         $this->assertEquals('<input id="binary-hidden" name="binary" type="hidden" value="0">' . PHP_EOL .
             '<input id="binary" name="binary" type="checkbox" value="1">' . PHP_EOL, $this->object->binary('binary'));
 
@@ -73,7 +73,7 @@ class FormHelperTest extends TestCase {
             '<input checked="checked" id="binary" name="binary" type="checkbox" value="1">' . PHP_EOL, $this->object->binary('binary'));
     }
 
-    public function testCheckbox() {
+    public function testCheckbox(): void {
         $this->assertEquals('<input id="checkbox" name="checkbox" type="checkbox" value="1">' . PHP_EOL, $this->object->checkbox('checkbox'));
 
         // tiered depth
@@ -103,7 +103,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input checked="checked" id="test-checkbox" name="Test[checkbox]" type="checkbox" value="1">' . PHP_EOL, $this->object->checkbox('Test.checkbox'));
     }
 
-    public function testCheckboxes() {
+    public function testCheckboxes(): void {
         $options = Vector {'red', 'blue', 'green'};
 
         // regular
@@ -148,11 +148,11 @@ class FormHelperTest extends TestCase {
         }, $this->object->checkboxes('Test.checkboxes_multi', $options, Map {'default' => 'blue'}));
     }
 
-    public function testClose() {
+    public function testClose(): void {
         $this->assertEquals('</form>' . PHP_EOL, $this->object->close());
     }
 
-    public function testDay() {
+    public function testDay(): void {
         $this->assertEquals(
             '<select id="day" name="day">' . PHP_EOL .
             '<option value="1">1</option>' . PHP_EOL .
@@ -304,7 +304,7 @@ class FormHelperTest extends TestCase {
         , $this->object->day('Test.day', Map {'defaultDay' => 13}));
     }
 
-    public function testDate() {
+    public function testDate(): void {
         $this->assertEquals(
             '<select id="created-month" name="created[month]">' . PHP_EOL .
             '<option value="1">January</option>' . PHP_EOL .
@@ -367,7 +367,7 @@ class FormHelperTest extends TestCase {
         }));
     }
 
-    public function testDateTime() {
+    public function testDateTime(): void {
         $this->object->use12Hour();
 
         $this->assertEquals(
@@ -574,7 +574,7 @@ class FormHelperTest extends TestCase {
         }));
     }
 
-    public function testEmail() {
+    public function testEmail(): void {
         $this->assertEquals('<input id="email" name="email" type="email" value="">' . PHP_EOL, $this->object->email('email'));
 
         // with data
@@ -586,21 +586,21 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input id="test-email" name="Test[email]" type="email" value="email@domain.com">' . PHP_EOL, $this->object->email('Test.email'));
     }
 
-    public function testFile() {
+    public function testFile(): void {
         $this->assertEquals('<input id="file" name="file" type="file">' . PHP_EOL, $this->object->file('file'));
 
         // no value
         $this->assertEquals('<input id="file" name="file" type="file">' . PHP_EOL, $this->object->file('file', Map {'value' => 'none'}));
     }
 
-    public function testFormatID() {
+    public function testFormatID(): void {
         $this->assertEquals('key', $this->object->formatID('key'));
         $this->assertEquals('key-nested', $this->object->formatID('key.nested'));
         $this->assertEquals('key-nested-again', $this->object->formatID('key.nested.again'));
         $this->assertEquals('key-nested-again', $this->object->formatID('key.nested.again..'));
     }
 
-    public function testFormatIDWithModel() {
+    public function testFormatIDWithModel(): void {
         if (!class_exists('Titon\Model\Model')) {
             $this->markTestSkipped('Test skipped; Please install titon/model via Composer');
         }
@@ -613,7 +613,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('model-key-nested-again', $this->object->formatID('key.nested.again..'));
     }
 
-    public function testFormatName() {
+    public function testFormatName(): void {
         $this->assertEquals('key', $this->object->formatName('key'));
         $this->assertEquals('key[nested]', $this->object->formatName('key.nested'));
         $this->assertEquals('key[nested][again]', $this->object->formatName('key.nested.again'));
@@ -622,12 +622,12 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('key[nested][again][0]', $this->object->formatName('key.nested.again.[0]'));
     }
 
-    public function testGetDefaultValue() {
+    public function testGetDefaultValue(): void {
         $this->assertEquals(null, $this->object->getDefaultValue(Map {}));
         $this->assertEquals('foo', $this->object->getDefaultValue(Map {'default' => 'foo'}));
     }
 
-    public function testGetRequestValue() {
+    public function testGetRequestValue(): void {
         $this->assertEquals(null, $this->object->getRequestValue('foo'));
 
         $_POST['foo'] = 'bar';
@@ -646,7 +646,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('baz', $this->object->getRequestValue('Test.foo'));
     }
 
-    public function testGetValueModel() {
+    public function testGetValueModel(): void {
         if (!class_exists('Titon\Model\Model')) {
             $this->markTestSkipped('Test skipped; Please install titon/model via Composer');
         }
@@ -664,7 +664,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('baz', $this->object->getValue('Test.foo'));
     }
 
-    public function testGetValue() {
+    public function testGetValue(): void {
         $this->assertEquals(null, $this->object->getValue('foo'));
         $this->assertEquals('bar', $this->object->getValue('foo', Map {'default' => 'bar'}));
 
@@ -674,7 +674,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('baz', $this->object->getValue('foo', Map {'default' => 'bar'}));
     }
 
-    public function testHidden() {
+    public function testHidden(): void {
         $this->assertEquals('<input id="hidden" name="hidden" type="hidden" value="">' . PHP_EOL, $this->object->hidden('hidden'));
         $this->assertEquals('<input id="hidden" name="hidden" type="hidden" value="foobar">' . PHP_EOL, $this->object->hidden('hidden', 'foobar'));
 
@@ -687,7 +687,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input id="test-hidden" name="Test[hidden]" type="hidden" value="yes">' . PHP_EOL, $this->object->hidden('Test.hidden', 'no'));
     }
 
-    public function testHour() {
+    public function testHour(): void {
         $this->object->use12Hour();
 
         $this->assertEquals(
@@ -843,7 +843,7 @@ class FormHelperTest extends TestCase {
         , $this->object->hour('Test.hour24', Map {'defaultHour' => 2}));
     }
 
-    public function testIsChecked() {
+    public function testIsChecked(): void {
         $this->assertFalse($this->object->isChecked(null, 'foo'));
         $this->assertFalse($this->object->isChecked(false, 'foo'));
         $this->assertFalse($this->object->isChecked('bar', 'foo'));
@@ -854,7 +854,7 @@ class FormHelperTest extends TestCase {
         $this->assertTrue($this->object->isChecked(['bar', 'foo'], 'foo'));
     }
 
-    public function testIsSelected() {
+    public function testIsSelected(): void {
         $this->assertFalse($this->object->isSelected(null, 'foo'));
         $this->assertFalse($this->object->isSelected('bar', 'foo'));
         $this->assertFalse($this->object->isSelected(['bar'], 'foo'));
@@ -863,7 +863,7 @@ class FormHelperTest extends TestCase {
         $this->assertTrue($this->object->isSelected(['bar', 'foo'], 'foo'));
     }
 
-    public function testLabel() {
+    public function testLabel(): void {
         $this->assertEquals('<label for="label">Title</label>' . PHP_EOL, $this->object->label('label', 'Title'));
 
         // escaping
@@ -876,7 +876,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<label for="label"><input id="label" name="label" type="checkbox" value="1">' . PHP_EOL . '</label>' . PHP_EOL, $this->object->label('label', $this->object->checkbox('label'), Map {'escape' => false}));
     }
 
-    public function testMeridiem() {
+    public function testMeridiem(): void {
         $this->assertEquals(
             '<select id="meridiem" name="meridiem">' . PHP_EOL .
             '<option value="am">AM</option>' . PHP_EOL .
@@ -903,7 +903,7 @@ class FormHelperTest extends TestCase {
         , $this->object->meridiem('Test.meridiem', Map {'defaultMeridiem' => 'pm'}));
     }
 
-    public function testMinute() {
+    public function testMinute(): void {
         $this->assertEquals(
             '<select id="minute" name="minute">' . PHP_EOL .
             '<option value="0">00</option>' . PHP_EOL .
@@ -1105,7 +1105,7 @@ class FormHelperTest extends TestCase {
         , $this->object->minute('Test.minute', Map {'defaultMinute' => 38}));
     }
 
-    public function testModel() {
+    public function testModel(): void {
         if (!class_exists('Titon\Model\Model')) {
             $this->markTestSkipped('Test skipped; Please install titon/model via Composer');
         }
@@ -1116,7 +1116,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals($model, $this->object->getModel());
     }
 
-    public function testMonth() {
+    public function testMonth(): void {
         $this->assertEquals(
             '<select id="month" name="month">' . PHP_EOL .
             '<option value="1">January</option>' . PHP_EOL .
@@ -1174,7 +1174,7 @@ class FormHelperTest extends TestCase {
         , $this->object->month('Test.month', Map {'defaultMonth' => 8, 'monthFormat' => 'm'}));
     }
 
-    public function testOpen() {
+    public function testOpen(): void {
         $this->assertEquals('<form accept-charset="UTF-8" action="/" enctype="application/x-www-form-urlencoded" id="form-2" method="POST">' . PHP_EOL, $this->object->open('/'));
 
         // file
@@ -1184,7 +1184,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<form accept-charset="UTF-8" action="/search" enctype="application/x-www-form-urlencoded" id="form-4" method="GET">' . PHP_EOL, $this->object->open('/search', Map {'method' => 'get'}));
     }
 
-    public function testPassword() {
+    public function testPassword(): void {
         $this->assertEquals('<input id="password" name="password" type="password">' . PHP_EOL, $this->object->password('password'));
 
         // no value
@@ -1197,7 +1197,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input id="test-password" name="Test[password]" type="password">' . PHP_EOL, $this->object->password('Test.password'));
     }
 
-    public function testPrepareAttributes() {
+    public function testPrepareAttributes(): void {
         $this->assertEquals(Map {
             'name' => 'foo[bar]',
             'multiple' => 'multiple',
@@ -1217,7 +1217,7 @@ class FormHelperTest extends TestCase {
         }, $this->object->prepareAttributes(Map {'name' => 'foo.bar', 'id' => 'custom-id'}, Map {'empty' => true}));
     }
 
-    public function testRadio() {
+    public function testRadio(): void {
         $this->assertEquals('<input id="radio" name="radio" type="radio" value="1">' . PHP_EOL, $this->object->radio('radio', '1'));
 
         // tiered depth
@@ -1244,7 +1244,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input checked="checked" id="test-radio" name="Test[radio]" type="radio" value="yes">' . PHP_EOL, $this->object->radio('Test.radio', 'yes'));
     }
 
-    public function testRadios() {
+    public function testRadios(): void {
         $options = Vector {'red', 'blue', 'green'};
 
         // regular
@@ -1272,7 +1272,7 @@ class FormHelperTest extends TestCase {
         }, $this->object->radios('Test.radio', $options));
     }
 
-    public function testReset() {
+    public function testReset(): void {
         $this->assertEquals('<button id="form-1-reset" type="reset">Title</button>' . PHP_EOL, $this->object->reset('Title'));
 
         // escaping
@@ -1282,7 +1282,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<button class="reset" id="reset" type="reset">Title</button>' . PHP_EOL, $this->object->reset('Title', Map {'class' => 'reset', 'id' => 'reset'}));
     }
 
-    public function testSecond() {
+    public function testSecond(): void {
         $this->assertEquals(
             '<select id="second" name="second">' . PHP_EOL .
             '<option value="0">00</option>' . PHP_EOL .
@@ -1484,7 +1484,7 @@ class FormHelperTest extends TestCase {
         , $this->object->second('Test.second', Map {'defaultSecond' => 58}));
     }
 
-    public function testSelect() {
+    public function testSelect(): void {
         $options = Map {'warrior' => 'Warrior', 'ranger' => 'Ranger', 'mage' => 'Mage'};
 
         $this->assertEquals(
@@ -1623,7 +1623,7 @@ class FormHelperTest extends TestCase {
         , $this->object->select('Test.select_group', $optgroup, Map {'multiple' => true}));
     }
 
-    public function testSubmit() {
+    public function testSubmit(): void {
         $this->assertEquals('<button id="form-1-submit" type="submit">Title</button>' . PHP_EOL, $this->object->submit('Title'));
 
         // escaping
@@ -1633,7 +1633,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<button class="reset" id="submit" type="submit">Title</button>' . PHP_EOL, $this->object->submit('Title', Map {'class' => 'reset', 'id' => 'submit'}));
     }
 
-    public function testText() {
+    public function testText(): void {
         $this->assertEquals('<input id="text" name="text" type="text" value="">' . PHP_EOL, $this->object->text('text'));
         $this->assertEquals('<input class="input" id="text" name="text" placeholder="Testing &quot;quotes&quot; placeholder" readonly="readonly" type="text" value="">' . PHP_EOL, $this->object->text('text', '', Map {
             'placeholder' => 'Testing "quotes" placeholder',
@@ -1650,7 +1650,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input id="test-text" name="Test[text]" type="text" value="bar">' . PHP_EOL, $this->object->text('Test.text', 'foo'));
     }
 
-    public function testTextarea() {
+    public function testTextarea(): void {
         $this->assertEquals('<textarea cols="25" id="textarea" name="textarea" rows="5"></textarea>' . PHP_EOL, $this->object->textarea('textarea'));
         $this->assertEquals('<textarea class="input" cols="50" disabled="disabled" id="textarea" name="textarea" rows="10"></textarea>' . PHP_EOL, $this->object->textarea('textarea', '', Map {
             'class' => 'input',
@@ -1668,7 +1668,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<textarea cols="25" id="test-textarea" name="Test[textarea]" rows="5">bar</textarea>' . PHP_EOL, $this->object->textarea('Test.textarea', 'foo'));
     }
 
-    public function testTime() {
+    public function testTime(): void {
         $this->object->use12Hour();
 
         $this->assertEquals('<select id="created-hour" name="created[hour]">' . PHP_EOL .
@@ -1970,11 +1970,11 @@ class FormHelperTest extends TestCase {
         , $this->object->time('created'));
     }
 
-    public function testToken() {
+    public function testToken(): void {
         $this->assertEquals('<input id="token" name="_token" type="hidden" value="AJW9120SJ">' . PHP_EOL, $this->object->token('AJW9120SJ'));
     }
 
-    public function testUrl() {
+    public function testUrl(): void {
         $this->assertEquals('<input id="url" name="url" type="url" value="">' . PHP_EOL, $this->object->url('url'));
 
         // with data
@@ -1986,7 +1986,7 @@ class FormHelperTest extends TestCase {
         $this->assertEquals('<input id="test-url" name="Test[url]" type="url" value="http://domain.com">' . PHP_EOL, $this->object->url('Test.url'));
     }
 
-    public function testYear() {
+    public function testYear(): void {
         $this->assertEquals(
             '<select id="year" name="year">' . PHP_EOL .
             '<option value="2005">2005</option>' . PHP_EOL .

--- a/tests/Titon/View/Helper/HtmlHelperTest.hh
+++ b/tests/Titon/View/Helper/HtmlHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;
@@ -10,13 +10,13 @@ use Titon\View\EngineView;
  */
 class HtmlHelperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new HtmlHelper();
     }
 
-    public function testAnchor() {
+    public function testAnchor(): void {
         $this->assertEquals('<a href="">Anchor</a>' . PHP_EOL, $this->object->anchor('Anchor', ''));
         $this->assertEquals('<a href="/">Anchor Link!</a>' . PHP_EOL, $this->object->anchor('Anchor Link!', '/'));
 
@@ -29,11 +29,11 @@ class HtmlHelperTest extends TestCase {
         $this->assertEquals('<a class="className" href="/" id="id-name">Anchor</a>' . PHP_EOL, $this->object->anchor('Anchor', '/', Map {'id' => 'id-name', 'class' => 'className'}));
     }
 
-    public function testDoctype() {
+    public function testDoctype(): void {
         $this->assertEquals('<!DOCTYPE html>' . PHP_EOL, $this->object->doctype());
     }
 
-    public function testImage() {
+    public function testImage(): void {
         $this->assertEquals('<img alt="" src="image.png">' . PHP_EOL, $this->object->image('image.png'));
         $this->assertEquals('<img alt="Foobar" src="/some/path/image.JPG">' . PHP_EOL, $this->object->image('/some/path/image.JPG', Map {'alt' => 'Foobar'}));
         $this->assertEquals('<img alt="Foobar" src="invalid path/image.gif" title="&quot;Image&quot;">' . PHP_EOL, $this->object->image('invalid path/image.gif', Map {'alt' => 'Foobar', 'title' => '"Image"'}));
@@ -44,12 +44,12 @@ class HtmlHelperTest extends TestCase {
         $this->assertEquals('<a href="/users"><img alt="" src="image.png"></a>' . PHP_EOL, $this->object->image('image.png', Map {}, '/users'));
     }
 
-    public function testLink() {
+    public function testLink(): void {
         $this->assertEquals('<link href="style.css" media="screen" rel="stylesheet" type="text/css">' . PHP_EOL, $this->object->link('style.css'));
         $this->assertEquals('<link href="path/style.css" media="handheld" rel="stylesheet" type="text/css">' . PHP_EOL, $this->object->link('path/style.css', Map {'media' => 'handheld'}));
     }
 
-    public function testMailto() {
+    public function testMailto(): void {
         $domain = Crypt::obfuscate('test@domain.com');
 
         $this->assertEquals('<a href="mailto:' . $domain . '" title="">' . $domain . '</a>' . PHP_EOL, $this->object->mailto('test@domain.com'));
@@ -58,7 +58,7 @@ class HtmlHelperTest extends TestCase {
         $this->assertEquals('<a href="mailto:' . $domain . '" onclick="alert();" title="Email me!">' . $domain . '</a>' . PHP_EOL, $this->object->mailto('test@domain.com', Map {'title' => 'Email me!', 'onclick' => 'alert();'}));
     }
 
-    public function testMeta() {
+    public function testMeta(): void {
         $this->assertEquals('<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">' . PHP_EOL, $this->object->meta('Content-Type'));
         $this->assertEquals('<meta content="application/json" http-equiv="Content-Type">' . PHP_EOL, $this->object->meta('content-type', 'application/json'));
         $this->assertEquals('<meta content="text/javascript" http-equiv="Content-Script-Type">' . PHP_EOL, $this->object->meta('content-script-type'));
@@ -91,19 +91,19 @@ class HtmlHelperTest extends TestCase {
         }));
     }
 
-    public function testScript() {
+    public function testScript(): void {
         $this->assertEquals('<script src="script.js" type="text/javascript"></script>' . PHP_EOL, $this->object->script('script.js'));
         $this->assertEquals('<script src="path/script.js" type="text/javascript"></script>' . PHP_EOL, $this->object->script('path/script.js'));
         $this->assertEquals('<script type="text/javascript"><![CDATA[script.js]]></script>' . PHP_EOL, $this->object->script('script.js', true));
-        $this->assertEquals('<script type="text/javascript"><![CDATA[(function() { alert(); })();]]></script>' . PHP_EOL, $this->object->script('(function() { alert(); })();', true));
+        $this->assertEquals('<script type="text/javascript"><![CDATA[(function(): void { alert(); })();]]></script>' . PHP_EOL, $this->object->script('(function(): void { alert(); })();', true));
     }
 
-    public function testStyle() {
+    public function testStyle(): void {
         $this->assertEquals('<style type="text/css">#id { color: red; }</style>' . PHP_EOL, $this->object->style('#id { color: red; }'));
         $this->assertEquals('<style type="text/css">#id { color: red; }' . PHP_EOL . '.class { text-align: left; }</style>' . PHP_EOL, $this->object->style('#id { color: red; }' . PHP_EOL . '.class { text-align: left; }'));
     }
 
-    public function testTitle() {
+    public function testTitle(): void {
         $view = new EngineView(Vector {'/'});
         $this->object->setView($view);
 

--- a/tests/Titon/View/Helper/HtmlHelperTest.hh
+++ b/tests/Titon/View/Helper/HtmlHelperTest.hh
@@ -95,7 +95,7 @@ class HtmlHelperTest extends TestCase {
         $this->assertEquals('<script src="script.js" type="text/javascript"></script>' . PHP_EOL, $this->object->script('script.js'));
         $this->assertEquals('<script src="path/script.js" type="text/javascript"></script>' . PHP_EOL, $this->object->script('path/script.js'));
         $this->assertEquals('<script type="text/javascript"><![CDATA[script.js]]></script>' . PHP_EOL, $this->object->script('script.js', true));
-        $this->assertEquals('<script type="text/javascript"><![CDATA[(function(): void { alert(); })();]]></script>' . PHP_EOL, $this->object->script('(function(): void { alert(); })();', true));
+        $this->assertEquals('<script type="text/javascript"><![CDATA[(function() { alert(); })();]]></script>' . PHP_EOL, $this->object->script('(function() { alert(); })();', true));
     }
 
     public function testStyle(): void {

--- a/tests/Titon/View/Helper/HtmlHelperTest.hh
+++ b/tests/Titon/View/Helper/HtmlHelperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;

--- a/tests/Titon/View/HelperTest.hh
+++ b/tests/Titon/View/HelperTest.hh
@@ -1,10 +1,8 @@
 <?hh
 namespace Titon\View;
 
-use Titon\Http\Server\Request;
+use Titon\Test\Stub\View\HelperStub;
 use Titon\Test\TestCase;
-use Titon\View\Helper\AbstractHelper;
-use Titon\View\EngineView;
 use Titon\View\Helper\TagMap;
 
 /**
@@ -66,16 +64,5 @@ class HelperTest extends TestCase {
         $this->object->setView($view);
         $this->assertEquals($view, $this->object->getView());
     }
-
-}
-
-class HelperStub extends AbstractHelper {
-
-    protected TagMap $tags = Map {
-        'noattr' => '<tag>{body}</tag>',
-        'nobody' => '<tag{attr} />',
-        'custom' => '<tag {one} {two}>{three}</tag>',
-        'default' => '<tag {0}>{1}</tag>{2}'
-    };
 
 }

--- a/tests/Titon/View/HelperTest.hh
+++ b/tests/Titon/View/HelperTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View;
 
 use Titon\Test\Stub\View\HelperStub;
@@ -10,13 +10,13 @@ use Titon\View\Helper\TagMap;
  */
 class HelperTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new HelperStub();
     }
 
-    public function testAttributes() {
+    public function testAttributes(): void {
         $this->assertEquals('', $this->object->attributes(Map {}));
         $this->assertEquals(' key="value"', $this->object->attributes(Map {'key' => 'value'}));
         $this->assertEquals(' foo="bar" key="value" number="1"', $this->object->attributes(Map {'key' => 'value', 'foo' => 'bar', 'number' => 1}));
@@ -35,7 +35,7 @@ class HelperTest extends TestCase {
         $this->assertEquals(' bool="1"', $this->object->attributes(Map {'key' => 'value', 'null' => null, 'bool' => true}, Vector {'key', 'null'}));
     }
 
-    public function testEscape() {
+    public function testEscape(): void {
         $value = 'This is "double" and \'single\' quotes.';
 
         $this->assertEquals('This is &quot;double&quot; and &#039;single&#039; quotes.', $this->object->escape($value));
@@ -49,7 +49,7 @@ class HelperTest extends TestCase {
         $this->assertEquals('This is &quot;double&quot; and &#039;single&#039; quotes.', $this->object->escape($value));
     }
 
-    public function testTag() {
+    public function testTag(): void {
         $this->assertEquals('<tag>{body}</tag>' . PHP_EOL, $this->object->tag('noattr'));
         $this->assertEquals('<tag>body</tag>' . PHP_EOL, $this->object->tag('noattr', Map {'fake' => 'attr', 'body' => 'body'}));
         $this->assertEquals('<tag value />' . PHP_EOL, $this->object->tag('nobody', Map {'attr' => ' value'}));
@@ -57,7 +57,7 @@ class HelperTest extends TestCase {
         $this->assertEquals('<tag 1>2</tag>3' . PHP_EOL, $this->object->tag('default', Map {'0' => 1, '1' => 2, '2' => 3}));
     }
 
-    public function testGetSetView() {
+    public function testGetSetView(): void {
         $view = new EngineView(Vector {'/'});
         $this->assertEquals(null, $this->object->getView());
 

--- a/tests/Titon/View/HelperTest.hh
+++ b/tests/Titon/View/HelperTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View;
 
 use Titon\Test\Stub\View\HelperStub;

--- a/tests/Titon/View/ViewTest.hh
+++ b/tests/Titon/View/ViewTest.hh
@@ -2,6 +2,7 @@
 namespace Titon\View;
 
 use Titon\Common\DataMap;
+use Titon\Test\Stub\View\ViewStub;
 use Titon\Utility\Config;
 use Titon\View\Helper\HtmlHelper;
 use Titon\View\Helper\FormHelper;
@@ -184,12 +185,5 @@ class ViewTest extends TestCase {
 
         $this->assertEquals($rootPath . 'public/lang/index.fr.tpl', $localePath);
     }
-
-}
-
-class ViewStub extends AbstractView {
-
-    public function render(string $template, bool $private = false): string {}
-    public function renderTemplate(string $path, DataMap $variables = Map {}): string {}
 
 }

--- a/tests/Titon/View/ViewTest.hh
+++ b/tests/Titon/View/ViewTest.hh
@@ -1,4 +1,4 @@
-<?hh
+<?hh // strict
 namespace Titon\View;
 
 use Titon\Common\DataMap;
@@ -13,7 +13,7 @@ use Titon\Test\TestCase;
  */
 class ViewTest extends TestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->setupVFS();
@@ -71,7 +71,7 @@ class ViewTest extends TestCase {
         ]);
     }
 
-    public function testPaths() {
+    public function testPaths(): void {
         $expected = Vector {
             $this->vfs->path('/views/'),
             $this->vfs->path('/views/fallback/'),
@@ -84,7 +84,7 @@ class ViewTest extends TestCase {
         $this->assertEquals($expected, $this->object->getPaths());
     }
 
-    public function testHelpers() {
+    public function testHelpers(): void {
         $form = new FormHelper();
         $html = new HtmlHelper();
 
@@ -107,11 +107,11 @@ class ViewTest extends TestCase {
     /**
      * @expectedException \Titon\View\Exception\MissingHelperException
      */
-    public function testHelperMissing() {
+    public function testHelperMissing(): void {
         $this->object->getHelper('foobar');
     }
 
-    public function testVariables() {
+    public function testVariables(): void {
         $expected = Map {};
         $this->assertEquals($expected, $this->object->getVariables());
 
@@ -130,7 +130,7 @@ class ViewTest extends TestCase {
         $this->assertEquals('bar', $this->object->getVariable('foo'));
     }
 
-    public function testLocateTemplate() {
+    public function testLocateTemplate(): void {
         $this->assertEquals($this->vfs->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index/add'));
         $this->assertEquals($this->vfs->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index\add'));
         $this->assertEquals($this->vfs->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index/add.tpl'));
@@ -156,11 +156,11 @@ class ViewTest extends TestCase {
     /**
      * @expectedException \Titon\View\Exception\MissingTemplateException
      */
-    public function testLocateTemplateMissing() {
+    public function testLocateTemplateMissing(): void {
         $this->object->locateTemplate('index/missing');
     }
 
-    public function testLocateTemplateLocales() {
+    public function testLocateTemplateLocales(): void {
         $localePath = '';
         $rootPath = $this->vfs->path('/views/');
 

--- a/tests/Titon/View/ViewTest.hh
+++ b/tests/Titon/View/ViewTest.hh
@@ -1,4 +1,4 @@
-<?hh // strict
+<?hh
 namespace Titon\View;
 
 use Titon\Common\DataMap;
@@ -16,8 +16,7 @@ class ViewTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->setupVFS();
-        $this->vfs->createStructure([
+        $this->vfs()->createStructure([
             '/views/' => [
                 'fallback/' => [
                     'private/' => [
@@ -63,19 +62,19 @@ class ViewTest extends TestCase {
             ]
         ]);
 
-        Config::set('titon.path.views', Vector {$this->vfs->path('/views/inherited/')});
+        Config::set('titon.path.views', Vector {$this->vfs()->path('/views/inherited/')});
 
         $this->object = new ViewStub([
-            $this->vfs->path('/views'),
-            $this->vfs->path('/views/fallback')
+            $this->vfs()->path('/views'),
+            $this->vfs()->path('/views/fallback')
         ]);
     }
 
     public function testPaths(): void {
         $expected = Vector {
-            $this->vfs->path('/views/'),
-            $this->vfs->path('/views/fallback/'),
-            $this->vfs->path('/views/inherited/')
+            $this->vfs()->path('/views/'),
+            $this->vfs()->path('/views/fallback/'),
+            $this->vfs()->path('/views/inherited/')
         };
         $this->assertEquals($expected, $this->object->getPaths());
 
@@ -131,26 +130,26 @@ class ViewTest extends TestCase {
     }
 
     public function testLocateTemplate(): void {
-        $this->assertEquals($this->vfs->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index/add'));
-        $this->assertEquals($this->vfs->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index\add'));
-        $this->assertEquals($this->vfs->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index/add.tpl'));
-        $this->assertEquals($this->vfs->path('/views/public/index/view.xml.tpl'), $this->object->locateTemplate('index/view.xml'));
+        $this->assertEquals($this->vfs()->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index/add'));
+        $this->assertEquals($this->vfs()->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index\add'));
+        $this->assertEquals($this->vfs()->path('/views/public/index/add.tpl'), $this->object->locateTemplate('index/add.tpl'));
+        $this->assertEquals($this->vfs()->path('/views/public/index/view.xml.tpl'), $this->object->locateTemplate('index/view.xml'));
 
         // partials
-        $this->assertEquals($this->vfs->path('/views/private/partials/include.tpl'), $this->object->locateTemplate('include', Template::PARTIAL));
-        $this->assertEquals($this->vfs->path('/views/private/partials/nested/include.tpl'), $this->object->locateTemplate('nested/include', Template::PARTIAL));
+        $this->assertEquals($this->vfs()->path('/views/private/partials/include.tpl'), $this->object->locateTemplate('include', Template::PARTIAL));
+        $this->assertEquals($this->vfs()->path('/views/private/partials/nested/include.tpl'), $this->object->locateTemplate('nested/include', Template::PARTIAL));
 
         // wrapper
-        $this->assertEquals($this->vfs->path('/views/private/wrappers/wrapper.tpl'), $this->object->locateTemplate('wrapper', Template::WRAPPER));
-        $this->assertEquals($this->vfs->path('/views/fallback/private/wrappers/fallback.tpl'), $this->object->locateTemplate('fallback', Template::WRAPPER));
+        $this->assertEquals($this->vfs()->path('/views/private/wrappers/wrapper.tpl'), $this->object->locateTemplate('wrapper', Template::WRAPPER));
+        $this->assertEquals($this->vfs()->path('/views/fallback/private/wrappers/fallback.tpl'), $this->object->locateTemplate('fallback', Template::WRAPPER));
 
         // layout
-        $this->assertEquals($this->vfs->path('/views/private/layouts/default.tpl'), $this->object->locateTemplate('default', Template::LAYOUT));
-        $this->assertEquals($this->vfs->path('/views/fallback/private/layouts/fallback.tpl'), $this->object->locateTemplate('fallback', Template::LAYOUT));
+        $this->assertEquals($this->vfs()->path('/views/private/layouts/default.tpl'), $this->object->locateTemplate('default', Template::LAYOUT));
+        $this->assertEquals($this->vfs()->path('/views/fallback/private/layouts/fallback.tpl'), $this->object->locateTemplate('fallback', Template::LAYOUT));
 
         // private
-        $this->assertEquals($this->vfs->path('/views/private/errors/404.tpl'), $this->object->locateTemplate('errors/404', Template::CLOSED));
-        $this->assertEquals($this->vfs->path('/views/fallback/private/emails/example.html.tpl'), $this->object->locateTemplate('emails/example.html', Template::CLOSED));
+        $this->assertEquals($this->vfs()->path('/views/private/errors/404.tpl'), $this->object->locateTemplate('errors/404', Template::CLOSED));
+        $this->assertEquals($this->vfs()->path('/views/fallback/private/emails/example.html.tpl'), $this->object->locateTemplate('emails/example.html', Template::CLOSED));
     }
 
     /**
@@ -162,7 +161,7 @@ class ViewTest extends TestCase {
 
     public function testLocateTemplateLocales(): void {
         $localePath = '';
-        $rootPath = $this->vfs->path('/views/');
+        $rootPath = $this->vfs()->path('/views/');
 
         $this->object->on('view.located', function($event, $path, $type) use (&$localePath) {
             $localePath = $path;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?hh
 /**
  * @copyright   2010-2015, The Titon Project
  * @license     http://opensource.org/licenses/bsd-license.php
@@ -9,21 +9,10 @@
 date_default_timezone_set('UTC');
 
 // Set testing constants
-if (!defined('TEST_DIR')) {
-    define('TEST_DIR', __DIR__);
-}
-
-if (!defined('TEMP_DIR')) {
-    define('TEMP_DIR', TEST_DIR . '/tmp');
-}
-
-if (!defined('VENDOR_DIR')) {
-    define('VENDOR_DIR', dirname(TEST_DIR) . '/vendor');
-}
-
-if (!defined('DS')) {
-    define('DS', DIRECTORY_SEPARATOR);
-}
+const string TEST_DIR = __DIR__;
+const string TEMP_DIR = TEST_DIR . '/tmp';
+const string VENDOR_DIR = TEST_DIR . '/../vendor';
+const string DS = DIRECTORY_SEPARATOR;
 
 // Start autoloader
 if (!file_exists(VENDOR_DIR . '/autoload.php')) {


### PR DESCRIPTION
- Updated the type checker to also check tests.
- Updated all tests with type hints.
- All tests should be tested in partial mode (strict in the future).
- Stubs are now separate classes located in tests/Titon/Test/Stub.
- Replaced closures with lambdas when applicable.
- Cleaned up VFS usage.

Fixes #64 