### PR TITLE
SOLID Decouple Audit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,15 +30,11 @@ Looking for more information? Find us in [#titon](http://webchat.freenode.net/?c
 
 Upcoming features and release plan.
 
-* March
-    * Console package - Command line tools [IN PROGRESS]
-    * Cleaned up unit tests [COMPLETE]
-    * SOLID audits [IN PROGRESS]
 * April
-    * [MVC package](https://github.com/titon/mvc) - Model-view-controller application
+    * [G11N package](https://github.com/titon/g11n) - Internationalization and localization [IN PROGRESS]
+    * [MVC package](https://github.com/titon/mvc) - Model-view-controller application [DELAYED UNTIL PSR-7]
     * CommandBus package - Command bus layer
 * May - June
-    * [G11N package](https://github.com/titon/g11n) - Internationalization and localization
     * [DB package](https://github.com/titon/db) - Database abstraction layer
 * July
     * [Model package](https://github.com/titon/model) - Object relational mapper and active record for DB entities

--- a/src/Titon/Context/Definition/CallableDefinition.hh
+++ b/src/Titon/Context/Definition/CallableDefinition.hh
@@ -50,14 +50,14 @@ class CallableDefinition extends AbstractDefinition {
 
         if ($this->class) {
             // UNSAFE
-            // Since inst_meth() requires literal strings and we are passing variables.
+            // Since `inst_meth()` requires literal strings and we are passing variables
             $callable = inst_meth($this->depository->make($this->class), $this->function);
 
             return $callable(...$arguments);
         }
 
         // UNSAFE
-        // Since fun() requires literal strings and we are passing variables.
+        // Since `fun()` requires literal strings and we are passing variables
         $callable = fun($this->function);
 
         return $callable(...$arguments);

--- a/src/Titon/Controller/AbstractController.hh
+++ b/src/Titon/Controller/AbstractController.hh
@@ -225,7 +225,7 @@ abstract class AbstractController implements Controller, Subject {
         $action->setController($this);
 
         // UNSAFE
-        // Since inst_meth() requires literal strings and we are passing variables.
+        // Since `inst_meth()` requires literal strings and we are passing variables
         $callback = inst_meth($action, strtolower($this->getRequest()->getMethod()));
         $arguments = $this->getCurrentArguments();
 

--- a/src/Titon/Controller/Controller.hh
+++ b/src/Titon/Controller/Controller.hh
@@ -27,10 +27,9 @@ interface Controller {
      *
      * @param string $action
      * @param \Titon\Controller\ArgumentList $args
-     * @param bool $emit
      * @return \Psr\Http\Message\OutgoingResponseInterface
      */
-    public function dispatchTo(string $action, ArgumentList $args, bool $emit = true): OutgoingResponseInterface;
+    public function dispatchTo(string $action, ArgumentList $args): OutgoingResponseInterface;
 
     /**
      * Forward the current request to a new action, instead of doing an additional HTTP request.

--- a/src/Titon/Debug/Annotation/Monitor.hh
+++ b/src/Titon/Debug/Annotation/Monitor.hh
@@ -38,7 +38,7 @@ class Monitor extends Annotation implements Wireable {
      */
     public function __construct(string $callback = '') {
         // UNSAFE
-        // Since both `fun()` and `class_meth()` require literal strings and we're passing variables.
+        // Since both `fun()` and `class_meth()` require literal strings and we're passing variables
         if (strpos($callback, '::')) {
             list($class, $method) = explode('::', $callback);
 

--- a/src/Titon/Event/Annotation/Observer.hh
+++ b/src/Titon/Event/Annotation/Observer.hh
@@ -93,7 +93,7 @@ class Observer extends Annotation implements Wireable {
     public function wire<T>(T $class, string $method = ''): this {
         if ($class instanceof Subject) {
             // UNSAFE
-            // Since inst_meth() requires literal strings and we are passing variables.
+            // Since `inst_meth()` requires literal strings and we are passing variables
             $class->on($this->getEvent(), inst_meth($class, $method), $this->getPriority(), $this->isOnce());
         }
 

--- a/src/Titon/Event/Emitter.hh
+++ b/src/Titon/Event/Emitter.hh
@@ -170,7 +170,7 @@ class Emitter {
         foreach ($listener->subscribeToEvents() as $event => $options) {
             foreach ($this->parseListenerMap($options) as $opt) {
                 // UNSAFE
-                // Since inst_meth() requires literal strings and we are passing variables
+                // Since `inst_meth()` requires literal strings and we are passing variables
                 $this->subscribe($event, inst_meth($listener, $opt['method']), $opt['priority'], $opt['once']);
             }
         }
@@ -212,7 +212,7 @@ class Emitter {
         foreach ($listener->subscribeToEvents() as $event => $options) {
             foreach ($this->parseListenerMap($options) as $opt) {
                 // UNSAFE
-                // Since inst_meth() requires literal strings and we are passing variables
+                // Since `inst_meth()` requires literal strings and we are passing variables
                 $this->unsubscribe($event, inst_meth($listener, $opt['method']));
             }
         }

--- a/src/Titon/Event/Observer.hh
+++ b/src/Titon/Event/Observer.hh
@@ -82,7 +82,8 @@ class Observer {
         $this->executed = true;
 
         // UNSAFE
-        // As the callback return type is not Awaitable<mixed> but simply mixed
+        // As the callback return type is not `Awaitable<mixed>` but simply mixed
+        // TODO
         return await call_user_func($this->getCallback(), $event);
     }
 

--- a/src/Titon/Io/Folder.hh
+++ b/src/Titon/Io/Folder.hh
@@ -183,7 +183,7 @@ class Folder extends Node {
      */
     public function files(bool $sort = false, bool $recursive = false): Vector<File> {
         // UNSAFE
-        // Because read() returns Vector<Node> while we need Vector<File>
+        // Because `read()` returns `Vector<Node>` while we need `Vector<File>`
         return $this->read($sort, $recursive, self::FILES);
     }
 
@@ -228,7 +228,7 @@ class Folder extends Node {
      */
     public function folders(bool $sort = false, bool $recursive = false): Vector<Folder> {
         // UNSAFE
-        // Because read() returns Vector<Node> while we need Vector<Folder>
+        // Because `read()` returns `Vector<Node>` while we need `Vector<Folder>`
         return $this->read($sort, $recursive, self::FOLDERS);
     }
 

--- a/src/Titon/Kernel/AbstractKernel.hh
+++ b/src/Titon/Kernel/AbstractKernel.hh
@@ -71,7 +71,7 @@ abstract class AbstractKernel<Ta as Application, Ti as Input, To as Output> impl
      * @param \Titon\Kernel\Application $app
      * @param \Titon\Kernel\Middleware\Pipeline $pipeline
      */
-    public function __construct(Ta $app, Pipeline<Ti, To> $pipeline = null) {
+    public function __construct(Ta $app, ?Pipeline<Ti, To> $pipeline = null) {
         if ($pipeline === null) {
             $pipeline = new Pipeline();
         }

--- a/src/Titon/Kernel/AbstractKernel.hh
+++ b/src/Titon/Kernel/AbstractKernel.hh
@@ -71,7 +71,11 @@ abstract class AbstractKernel<Ta as Application, Ti as Input, To as Output> impl
      * @param \Titon\Kernel\Application $app
      * @param \Titon\Kernel\Middleware\Pipeline $pipeline
      */
-    public function __construct(Ta $app, Pipeline<Ti, To> $pipeline) {
+    public function __construct(Ta $app, Pipeline<Ti, To> $pipeline = null) {
+        if ($pipeline === null) {
+            $pipeline = new Pipeline();
+        }
+
         $this->app = $app;
         $this->pipeline = $pipeline;
         $this->startTime = microtime(true);

--- a/src/Titon/Route/Annotation/Route.hh
+++ b/src/Titon/Route/Annotation/Route.hh
@@ -11,6 +11,8 @@ use Titon\Annotation\Annotation;
 use Titon\Route\Mixin\FilterMixin;
 use Titon\Route\Mixin\MethodMixin;
 use Titon\Route\Mixin\PatternMixin;
+use Titon\Route\Route as BaseRoute;
+use Titon\Route\Router;
 use Titon\Utility\Col;
 
 /**
@@ -43,9 +45,9 @@ class Route extends Annotation {
      *
      * @param string $key
      * @param string $path
-     * @param mixed  $methods
-     * @param mixed  $filters
-     * @param mixed  $patterns
+     * @param mixed $methods
+     * @param mixed $filters
+     * @param mixed $patterns
      */
     public function __construct(string $key, string $path, mixed $methods = [], mixed $filters = [], array<string, string> $patterns = []) {
         $this->key = $key;
@@ -71,6 +73,22 @@ class Route extends Annotation {
      */
     public function getPath(): string {
         return $this->path;
+    }
+
+    /**
+     * Convert the annotation to a `Route` object.
+     *
+     * @param string $class
+     * @param string $action
+     * @return \Titon\Route\Route
+     */
+    public function toRoute(string $class, string $action = 'index'): BaseRoute {
+        $route = new BaseRoute($this->getPath(), Router::buildAction(shape('class' => $class, 'action' => $action)));
+        $route->setMethods($this->getMethods());
+        $route->setFilters($this->getFilters());
+        $route->setPatterns($this->getPatterns());
+
+        return $route;
     }
 
 }

--- a/src/Titon/Route/Router.hh
+++ b/src/Titon/Route/Router.hh
@@ -633,7 +633,7 @@ class Router implements Subject {
         // Map resource routes if the annotation is on the class
         foreach ($reader->getClassAnnotations() as $annotation) {
             if ($annotation instanceof RouteAnnotation) {
-                $this->resource($annotation->getKey(), $this->buildAnnotationRoute($annotation, $class));
+                $this->resource($annotation->getKey(), $annotation->toRoute($class));
             }
         }
 
@@ -641,29 +641,12 @@ class Router implements Subject {
         foreach ($reader->getAnnotatedMethods() as $method => $annotations) {
             foreach ($annotations as $annotation) {
                 if ($annotation instanceof RouteAnnotation) {
-                    $this->map($annotation->getKey(), $this->buildAnnotationRoute($annotation, $class, $method));
+                    $this->map($annotation->getKey(), $annotation->toRoute($class, $method));
                 }
             }
         }
 
         return $this;
-    }
-
-    /**
-     * Build a route object from an annotation.
-     *
-     * @param \Titon\Route\Annotation\Route $annotation
-     * @param string $class
-     * @param string $method
-     * @return \Titon\Route\Route
-     */
-    protected function buildAnnotationRoute(RouteAnnotation $annotation, string $class, string $method = 'index'): Route {
-        $route = new Route($annotation->getPath(), static::buildAction(shape('class' => $class, 'action' => $method)));
-        $route->setMethods($annotation->getMethods());
-        $route->setFilters($annotation->getFilters());
-        $route->setPatterns($annotation->getPatterns());
-
-        return $route;
     }
 
 }

--- a/src/Titon/Route/UrlBuilder.hh
+++ b/src/Titon/Route/UrlBuilder.hh
@@ -127,6 +127,29 @@ class UrlBuilder {
     }
 
     /**
+     * Return the current absolute URL.
+     *
+     * @return string
+     */
+    public function getAbsoluteUrl(): string {
+        $base = $this->getBase();
+        $segments = $this->getSegments();
+        $url = (string) $segments['scheme'] . '://' . (string) $segments['host'];
+
+        if ($base !== '/') {
+            $url .= $base;
+        }
+
+        $url .= (string) $segments['path'];
+
+        if ($segments['query']) {
+            $url .= '?' . http_build_query($segments['query']);
+        }
+
+        return $url;
+    }
+
+    /**
      * Return the base URL if the app was not placed in the root directory.
      *
      * @return string
@@ -166,29 +189,6 @@ class UrlBuilder {
      */
     public function getSegments(): SegmentMap {
         return $this->segments;
-    }
-
-    /**
-     * Return the current URL.
-     *
-     * @return string
-     */
-    public function url(): string {
-        $base = $this->getBase();
-        $segments = $this->getSegments();
-        $url = (string) $segments['scheme'] . '://' . (string) $segments['host'];
-
-        if ($base !== '/') {
-            $url .= $base;
-        }
-
-        $url .= (string) $segments['path'];
-
-        if ($segments['query']) {
-            $url .= '?' . http_build_query($segments['query']);
-        }
-
-        return $url;
     }
 
 }

--- a/src/Titon/Route/UrlBuilder.hh
+++ b/src/Titon/Route/UrlBuilder.hh
@@ -7,9 +7,12 @@
 
 namespace Titon\Route;
 
+use Titon\Route\Exception\MissingSegmentException;
 use Titon\Route\Exception\MissingTokenException;
 use Titon\Utility\Config;
 use Titon\Utility\Inflector;
+use Titon\Utility\State\Get;
+use Titon\Utility\State\Server;
 
 /**
  * The UrlBuilder helps ease the process of building dynamic URLs based on the routes mapped in the Router.
@@ -20,11 +23,25 @@ use Titon\Utility\Inflector;
 class UrlBuilder {
 
     /**
+     * Base folder structure if the application was placed within a directory.
+     *
+     * @var string
+     */
+    protected string $base = '/';
+
+    /**
      * Router instance.
      *
      * @var \Titon\Route\Router
      */
     protected Router $router;
+
+    /**
+     * The current URL broken up into multiple segments: protocol, host, route, query, base, etc.
+     *
+     * @var \Titon\Route\SegmentMap
+     */
+    protected SegmentMap $segments = Map {};
 
     /**
      * Store the Router instance.
@@ -33,6 +50,21 @@ class UrlBuilder {
      */
     public function __construct(Router $router) {
         $this->router = $router;
+
+        // Determine if app is within a base folder
+        $base = dirname(str_replace(Server::get('DOCUMENT_ROOT'), '', Server::get('SCRIPT_FILENAME')));
+
+        if ($base && $base !== '.') {
+            $this->base = rtrim(str_replace('\\', '/', $base), '/') ?: '/';
+        }
+
+        // Store the current URL and query as router segments
+        $this->segments = (new Map(parse_url(Server::get('REQUEST_URI'))))->setAll(Map {
+            'scheme' => (Server::get('HTTPS') === 'on') ? 'https' : 'http',
+            'query' => Get::all(),
+            'host' => Server::get('HTTP_HOST'),
+            'port' => Server::get('SERVER_PORT')
+        });
     }
 
     /**
@@ -47,9 +79,8 @@ class UrlBuilder {
      */
     <<__Memoize>>
     public function build(string $key, ParamMap $params = Map {}, QueryMap $query = Map {}): string {
-        $router = $this->getRouter();
-        $route = $router->getRoute($key);
-        $base = $router->base();
+        $base = $this->getBase();
+        $route = $this->getRouter()->getRoute($key);
         $url = str_replace([']', ')', '>'], '}', str_replace(['[', '(', '<'], '{', $route->getPath()));
 
         // Set the locale if it is missing
@@ -96,6 +127,15 @@ class UrlBuilder {
     }
 
     /**
+     * Return the base URL if the app was not placed in the root directory.
+     *
+     * @return string
+     */
+    public function getBase(): string {
+        return $this->base;
+    }
+
+    /**
      * Return the Router instance.
      *
      * @return \Titon\Route\Router
@@ -105,14 +145,37 @@ class UrlBuilder {
     }
 
     /**
+     * Return a segment by key.
+     *
+     * @param string $key
+     * @return mixed
+     * @throws \Titon\Route\Exception\MissingSegmentException
+     */
+    public function getSegment(string $key): mixed {
+        if ($this->segments->contains($key)) {
+            return $this->segments[$key];
+        }
+
+        throw new MissingSegmentException(sprintf('Routing segment %s does not exist', $key));
+    }
+
+    /**
+     * Return all segments.
+     *
+     * @return \Titon\Route\SegmentMap
+     */
+    public function getSegments(): SegmentMap {
+        return $this->segments;
+    }
+
+    /**
      * Return the current URL.
      *
      * @return string
      */
     public function url(): string {
-        $router = $this->getRouter();
-        $segments = $router->getSegments();
-        $base = $router->base();
+        $base = $this->getBase();
+        $segments = $this->getSegments();
         $url = (string) $segments['scheme'] . '://' . (string) $segments['host'];
 
         if ($base !== '/') {

--- a/src/Titon/Route/bootstrap.hh
+++ b/src/Titon/Route/bootstrap.hh
@@ -69,28 +69,33 @@ namespace {
 namespace {
     use Titon\Route\ParamMap;
     use Titon\Route\QueryMap;
-    use Titon\Context\Depository;
     use Titon\Route\UrlBuilder;
+    use Titon\Context\Depository;
+
+    /**
+     * Make and return a UrlBuilder instance from the depository.
+     *
+     * @return \Titon\Route\UrlBuilder
+     */
+    function load_url_builder(): UrlBuilder {
+        $builder = Depository::getInstance()->make('Titon\Route\UrlBuilder');
+
+        invariant($builder instanceof UrlBuilder, 'Must be a UrlBuilder.');
+
+        return $builder;
+    }
 
     /**
      * @see Titon\Route\UrlBuilder::build()
      */
     function link_to(string $key, ParamMap $params = Map {}, QueryMap $query = Map {}): string {
-        $builder = Depository::getInstance()->make('Titon\Route\UrlBuilder');
-
-        invariant($builder instanceof UrlBuilder, 'Must be a UrlBuilder.');
-
-        return $builder->build($key, $params, $query);
+        return load_url_builder()->build($key, $params, $query);
     }
 
     /**
      * @see Titon\Route\UrlBuilder::url()
      */
     function url(): string {
-        $builder = Depository::getInstance()->make('Titon\Route\UrlBuilder');
-
-        invariant($builder instanceof UrlBuilder, 'Must be a UrlBuilder.');
-
-        return $builder->url();
+        return load_url_builder()->url();
     }
 }

--- a/src/Titon/Route/bootstrap.hh
+++ b/src/Titon/Route/bootstrap.hh
@@ -73,11 +73,32 @@ namespace {
     use Titon\Context\Depository;
 
     /**
+     * @see Titon\Route\UrlBuilder::getAbsoluteUrl()
+     */
+    function current_url(): string {
+        return url_builder()->getAbsoluteUrl();
+    }
+
+    /**
+     * @see Titon\Route\UrlBuilder::build()
+     */
+    function url(string $key, ParamMap $params = Map {}, QueryMap $query = Map {}): string {
+        return url_builder()->build($key, $params, $query);
+    }
+
+    /**
+     * @see Titon\Route\UrlBuilder::getSegment()
+     */
+    function url_segment(string $segment): mixed {
+        return url_builder()->getSegment($segment);
+    }
+
+    /**
      * Make and return a UrlBuilder instance from the depository.
      *
      * @return \Titon\Route\UrlBuilder
      */
-    function load_url_builder(): UrlBuilder {
+    function url_builder(): UrlBuilder {
         $builder = Depository::getInstance()->make('Titon\Route\UrlBuilder');
 
         invariant($builder instanceof UrlBuilder, 'Must be a UrlBuilder.');
@@ -85,17 +106,4 @@ namespace {
         return $builder;
     }
 
-    /**
-     * @see Titon\Route\UrlBuilder::build()
-     */
-    function link_to(string $key, ParamMap $params = Map {}, QueryMap $query = Map {}): string {
-        return load_url_builder()->build($key, $params, $query);
-    }
-
-    /**
-     * @see Titon\Route\UrlBuilder::url()
-     */
-    function url(): string {
-        return load_url_builder()->url();
-    }
 }

--- a/src/Titon/Type/ArrayList.hh
+++ b/src/Titon/Type/ArrayList.hh
@@ -106,7 +106,7 @@ class ArrayList<Tv> implements
             if (in_array($method, $this->chainable)) {
 
                 // UNSAFE
-                // Since inst_meth() requires literal strings and we are passing variables
+                // Since `inst_meth()` requires literal strings and we are passing variables
                 call_user_func_array(inst_meth($vector, $method), $args);
 
                 return $this;
@@ -118,7 +118,7 @@ class ArrayList<Tv> implements
                 $clonedList = $vector->toVector();
 
                 // UNSAFE
-                // Since inst_meth() requires literal strings and we are passing variables
+                // Since `inst_meth()` requires literal strings and we are passing variables
                 $mutatedList = call_user_func_array(inst_meth($clonedList, $method), $args);
 
                 // Some methods return void/null (reverse, etc) so use the cloned list

--- a/src/Titon/Type/HashMap.hh
+++ b/src/Titon/Type/HashMap.hh
@@ -101,7 +101,7 @@ class HashMap<Tk, Tv> implements
             if (in_array($method, $this->chainable)) {
 
                 // UNSAFE
-                // Since inst_meth() requires literal strings and we are passing variables
+                // Since `inst_meth()` requires literal strings and we are passing variables
                 call_user_func_array(inst_meth($map, $method), $args);
 
                 return $this;
@@ -113,7 +113,7 @@ class HashMap<Tk, Tv> implements
                 $clonedList = $map->toMap();
 
                 // UNSAFE
-                // Since inst_meth() requires literal strings and we are passing variables
+                // Since `inst_meth()` requires literal strings and we are passing variables
                 $mutatedList = call_user_func_array(inst_meth($clonedList, $method), $args);
 
                 // Some methods return void/null so use the cloned list
@@ -591,7 +591,7 @@ class HashMap<Tk, Tv> implements
      */
     public function toXml(string $root = 'document'): string {
         // UNSAFE
-        // The HashMap value is Map<Tk, Tv> while the XmlMap is Map<string, mixed>.
+        // The HashMap value is `Map<Tk, Tv>` while the XmlMap is `Map<string, mixed>`
         return Xml::fromMap($root, $this->value())->toString();
     }
 

--- a/src/Titon/Utility/Inflector.hh
+++ b/src/Titon/Utility/Inflector.hh
@@ -180,7 +180,7 @@ class Inflector {
      */
     <<__Memoize>>
     public static function underscore(string $string): string {
-        return trim(mb_strtolower(str_replace('__', '_', preg_replace('/([A-Z]{1})/', '_$1', preg_replace('/[^_a-z0-9]+/i', '', preg_replace('/[\s]+/', '_', $string))))), '_');
+        return trim(mb_strtolower(str_replace('__', '_', preg_replace('/([A-Z]{1})/', '_$1', preg_replace('/[^_a-z0-9]+/i', '', preg_replace('/[\s\-]+/', '_', $string))))), '_');
     }
 
     /**

--- a/src/Titon/Utility/Registry.hh
+++ b/src/Titon/Utility/Registry.hh
@@ -81,7 +81,7 @@ class Registry<T> {
 
             if (is_callable($object)) {
                 // UNSAFE
-                // Because you can't invariant() a callable
+                // Because you can't `invariant()` a callable
                 $object = static::set(call_user_func($object), $key);
             }
 
@@ -118,7 +118,7 @@ class Registry<T> {
      */
     public static function register(string $key, RegistryCallback<T> $callback): void {
         // UNSAFE
-        // Since the property generics is T while the callback is RegistryCallback<T>
+        // Since the property generics is `T` while the callback is `RegistryCallback<T>`
         static::$registered[$key] = $callback;
     }
 

--- a/src/Titon/Validate/Constraint.hh
+++ b/src/Titon/Validate/Constraint.hh
@@ -25,7 +25,7 @@ class Constraint extends Validate implements ConstraintProvider {
 
         foreach (get_class_methods($this) as $method) {
             // UNSAFE
-            // Since class_meth() requires literal strings and we are passing variables
+            // Since `class_meth()` requires literal strings and we are passing variables
             $constraints[$method] = class_meth($class, $method);
         }
 

--- a/src/Titon/View/AbstractView.hh
+++ b/src/Titon/View/AbstractView.hh
@@ -39,6 +39,13 @@ abstract class AbstractView implements View, Subject {
     protected HelperMap $helpers = Map {};
 
     /**
+     * Template locator instance.
+     *
+     * @var \Titon\View\Locator
+     */
+    protected Locator $locator;
+
+    /**
      * Storage engine.
      *
      * @var \Titon\Cache\Storage

--- a/src/Titon/View/Engine/AbstractEngine.hh
+++ b/src/Titon/View/Engine/AbstractEngine.hh
@@ -99,7 +99,7 @@ abstract class AbstractEngine implements Engine {
         $view = $this->getView();
 
         if (!$view) {
-            throw new MissingViewException('View manager has not been set on this engine');
+            throw new MissingViewException('View has not been set on this engine');
         }
 
         return $this->render(

--- a/src/Titon/View/Engine/AbstractEngine.hh
+++ b/src/Titon/View/Engine/AbstractEngine.hh
@@ -103,7 +103,7 @@ abstract class AbstractEngine implements Engine {
         }
 
         return $this->render(
-            $view->locateTemplate($partial, Template::PARTIAL),
+            $view->getLocator()->locate($partial, Template::PARTIAL),
             $view->getVariables()->toMap()->setAll($variables)
         );
     }

--- a/src/Titon/View/EngineView.hh
+++ b/src/Titon/View/EngineView.hh
@@ -34,14 +34,15 @@ class EngineView extends AbstractView {
      * @param \Titon\View\Locator $locator
      * @param \Titon\View\Engine $engine
      */
-    public function __construct(Locator $locator, Engine $engine = null) {
+    public function __construct(Locator $locator, ?Engine $engine = null) {
         parent::__construct($locator);
 
         if ($engine === null) {
             $engine = new TemplateEngine();
         }
 
-        $this->engine = $engine->setView($this);
+        $this->engine = $engine;
+        $this->engine->setView($this);
     }
 
     /**

--- a/src/Titon/View/Helper.hh
+++ b/src/Titon/View/Helper.hh
@@ -34,22 +34,18 @@ interface Helper extends Listener {
     public function getView(): ?View;
 
     /**
-     * Triggered before all templates are rendered at once.
+     * Triggered before a template (include layouts, wrappers, and partials) is rendered.
      *
      * @param \Titon\Event\Event $event
-     * @param \Titon\View\View $view
-     * @param string $template
      */
-    public function preRender(Event $event, View $view, string $template): void;
+    public function preRender(Event $event): void;
 
     /**
-     * Triggered after all templates are rendered at once.
+     * Triggered after a template is rendered.
      *
      * @param \Titon\Event\Event $event
-     * @param \Titon\View\View $view
-     * @param string $response
      */
-    public function postRender(Event $event, View $view, string $response): void;
+    public function postRender(Event $event): void;
 
     /**
      * Set the view manager.

--- a/src/Titon/View/Locator.hh
+++ b/src/Titon/View/Locator.hh
@@ -7,6 +7,13 @@
 
 namespace Titon\View;
 
+use Titon\View\Locator\PathList;
+
+/**
+ * The Locator provides an interface for locating a defined template within a list of lookup paths.
+ *
+ * @package Titon\View
+ */
 interface Locator {
 
     /**
@@ -24,14 +31,6 @@ interface Locator {
      * @return $this
      */
     public function addPaths(PathList $paths): this;
-
-    /**
-     * Format the current template path by converting slashes and removing extensions.
-     *
-     * @param string $template
-     * @return string
-     */
-    public function formatPath(string $template): string;
 
     /**
      * Return the template file extension.

--- a/src/Titon/View/Locator.hh
+++ b/src/Titon/View/Locator.hh
@@ -1,0 +1,75 @@
+<?hh // strict
+/**
+ * @copyright   2010-2015, The Titon Project
+ * @license     http://opensource.org/licenses/bsd-license.php
+ * @link        http://titon.io
+ */
+
+namespace Titon\View;
+
+interface Locator {
+
+    /**
+     * Add a lookup path.
+     *
+     * @param string $path
+     * @return $this
+     */
+    public function addPath(string $path): this;
+
+    /**
+     * Add multiple lookup paths.
+     *
+     * @param \Titon\View\PathList $paths
+     * @return $this
+     */
+    public function addPaths(PathList $paths): this;
+
+    /**
+     * Format the current template path by converting slashes and removing extensions.
+     *
+     * @param string $template
+     * @return string
+     */
+    public function formatPath(string $template): string;
+
+    /**
+     * Return the template file extension.
+     *
+     * @return string
+     */
+    public function getExtension(): string;
+
+    /**
+     * Return all lookup paths.
+     *
+     * @return \Titon\View\PathList
+     */
+    public function getPaths(): PathList;
+
+    /**
+     * Locate a template within the lookup paths and organize based on the type of template.
+     *
+     * @param string $template
+     * @param \Titon\View\Template $type
+     * @return string
+     */
+    public function locate(string $template, Template $type = Template::OPEN): string;
+
+    /**
+     * Set the template file extension.
+     *
+     * @param string $ext
+     * @return $this
+     */
+    public function setExtension(string $ext): this;
+
+    /**
+     * Set a list of lookup paths and overwrite any previously defined paths.
+     *
+     * @param \Titon\View\PathList $paths
+     * @return $this
+     */
+    public function setPaths(PathList $paths): this;
+
+}

--- a/src/Titon/View/Locator/AbstractLocator.hh
+++ b/src/Titon/View/Locator/AbstractLocator.hh
@@ -1,0 +1,168 @@
+<?hh // strict
+/**
+ * @copyright   2010-2015, The Titon Project
+ * @license     http://opensource.org/licenses/bsd-license.php
+ * @link        http://titon.io
+ */
+
+namespace Titon\View\Locator;
+
+use Titon\Utility\Config;
+use Titon\Utility\Col;
+use Titon\Utility\Path;
+use Titon\View\Exception\MissingTemplateException;
+use Titon\View\Locator;
+use Titon\View\Template;
+use Titon\View\PathList;
+
+abstract class AbstractLocator implements Locator {
+
+    /**
+     * The extension used for templates.
+     *
+     * @var string
+     */
+    protected string $extension = 'tpl';
+
+    /**
+     * List of lookup paths.
+     *
+     * @var \Titon\View\PathList
+     */
+    protected PathList $paths = Vector {};
+
+    public function __construct(mixed $paths, string $ext = 'tpl') {
+        if ($paths) {
+            $this->addPaths(Col::toVector($paths));
+        }
+
+        if ($paths = Config::get('titon.path.views')) {
+            $this->addPaths(Col::toVector($paths));
+        }
+
+        $this->setExtension($ext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addPath(string $path): this {
+        $this->paths[] = Path::ds($path, true);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addPaths(PathList $paths): this {
+        foreach ($paths as $path) {
+            $this->addPath($path);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function formatPath(string $template): string {
+        return trim(str_replace(['.' . $this->getExtension(), '\\'], ['', '/'], $template), '/');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtension(): string {
+        return $this->extension;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaths(): PathList {
+        return $this->paths;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    <<__Memoize>>
+    public function locate(string $template, Template $type = Template::OPEN): string {
+        $template = $this->formatPath($template);
+        $paths = $this->getPaths();
+
+        // Prepend parent path
+        switch ($type) {
+            case Template::LAYOUT:
+                $template = sprintf('private/layouts/%s', $template);
+            break;
+            case Template::WRAPPER:
+                $template = sprintf('private/wrappers/%s', $template);
+            break;
+            case Template::PARTIAL:
+                $template = sprintf('private/partials/%s', $template);
+            break;
+            case Template::OPEN:
+                $template = sprintf('public/%s', $template);
+            break;
+            case Template::CLOSED:
+                $template = sprintf('private/%s', $template);
+            break;
+        }
+
+        // Generate a list of locale appended templates
+        $templates = Vector {};
+        //$locales = $this->getLocales();
+        $ext = $this->getExtension();
+
+        //if ($locales) {
+        //    foreach ($locales as $locale) {
+        //        $templates[] = $template . '.' . $locale . '.' . $ext;
+        //   }
+        //}
+
+        $templates[] = $template . '.' . $ext;
+
+        // Locate absolute path
+        $absPath = '';
+
+        foreach ($paths as $path) {
+            if ($absPath) {
+                break;
+            }
+
+            foreach ($templates as $template) {
+                if (file_exists($path . $template)) {
+                    $absPath = $path . $template;
+                    break;
+                }
+            }
+        }
+
+        if (!$absPath) {
+            throw new MissingTemplateException(sprintf('View template `%s` does not exist', $template));
+        }
+
+        return $absPath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExtension(string $ext): this {
+        $this->extension = $ext;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPaths(PathList $paths): this {
+        $this->paths = $paths;
+
+        return $this;
+    }
+
+}

--- a/src/Titon/View/Locator/LocaleTemplateLocator.hh
+++ b/src/Titon/View/Locator/LocaleTemplateLocator.hh
@@ -1,0 +1,84 @@
+<?hh // strict
+/**
+ * @copyright   2010-2015, The Titon Project
+ * @license     http://opensource.org/licenses/bsd-license.php
+ * @link        http://titon.io
+ */
+
+namespace Titon\View\Locator;
+
+use Titon\Utility\Config;
+use Titon\Utility\Col;
+use Titon\View\Locator;
+
+class LocaleTemplateLocator extends TemplateLocator {
+
+    /**
+     * List of locales to use during template locating.
+     *
+     * @var \Titon\View\LocaleList
+     */
+    protected LocaleList $locales = Vector {};
+
+    public function __construct(mixed $paths, mixed $locales, string $ext = 'tpl') {
+        parent::__construct($paths, $ext);
+
+        if ($locales) {
+            $this->addLocales(Col::toVector($locales));
+        }
+
+        if ($locales = Config::get('titon.locale.cascade')) {
+            $this->addLocales(Col::toVector($locales));
+        }
+    }
+
+    /**
+     * Add a locale lookup.
+     *
+     * @param string $locale
+     * @return $this
+     */
+    public function addLocale(string $locale): this {
+        if (!in_array($locale, $this->locales)) {
+            $this->locales[] = $locale;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add multiple locale lookups.
+     *
+     * @param \Titon\View\LocaleList $locales
+     * @return $this
+     */
+    public function addLocales(LocaleList $locales): this {
+        foreach ($locales as $locale) {
+            $this->addLocale($locale);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return all locales.
+     *
+     * @return \Titon\View\LocaleList
+     */
+    public function getLocales(): LocaleList {
+        return $this->locales;
+    }
+
+    /**
+     * Set a list of locales and overwrite any previously defined paths.
+     *
+     * @param \Titon\View\LocaleList $locales
+     * @return $this
+     */
+    public function setLocales(LocaleList $locales): this {
+        $this->locales = $locales;
+
+        return $this;
+    }
+
+}

--- a/src/Titon/View/Locator/LocaleTemplateLocator.hh
+++ b/src/Titon/View/Locator/LocaleTemplateLocator.hh
@@ -11,6 +11,11 @@ use Titon\Utility\Config;
 use Titon\Utility\Col;
 use Titon\View\Locator;
 
+/**
+ * An extension of the base `TemplateLocator` that provides locale aware lookups.
+ *
+ * @package Titon\View\Locator
+ */
 class LocaleTemplateLocator extends TemplateLocator {
 
     /**
@@ -20,6 +25,14 @@ class LocaleTemplateLocator extends TemplateLocator {
      */
     protected LocaleList $locales = Vector {};
 
+    /**
+     * Store the lookup paths, locales, and template extension.
+     * If locales are defined in the config, also store them.
+     *
+     * @param mixed $paths
+     * @param mixed $locales
+     * @param string $ext
+     */
     public function __construct(mixed $paths, mixed $locales, string $ext = 'tpl') {
         parent::__construct($paths, $ext);
 
@@ -33,7 +46,7 @@ class LocaleTemplateLocator extends TemplateLocator {
     }
 
     /**
-     * Add a locale lookup.
+     * Add a locale.
      *
      * @param string $locale
      * @return $this
@@ -47,7 +60,7 @@ class LocaleTemplateLocator extends TemplateLocator {
     }
 
     /**
-     * Add multiple locale lookups.
+     * Add multiple locales.
      *
      * @param \Titon\View\LocaleList $locales
      * @return $this
@@ -61,6 +74,24 @@ class LocaleTemplateLocator extends TemplateLocator {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function buildTemplateLookup(string $template): PathList {
+        $paths = Vector {};
+        $ext = $this->getExtension();
+
+        if ($locales = $this->getLocales()) {
+            foreach ($locales as $locale) {
+                $paths[] = $template . '.' . $locale . '.' . $ext;
+           }
+        }
+
+        $paths[] = $template . '.' . $ext;
+
+        return $paths;
+    }
+
+    /**
      * Return all locales.
      *
      * @return \Titon\View\LocaleList
@@ -70,13 +101,15 @@ class LocaleTemplateLocator extends TemplateLocator {
     }
 
     /**
-     * Set a list of locales and overwrite any previously defined paths.
+     * Set a list of locales and overwrite any previously defined locales.
      *
      * @param \Titon\View\LocaleList $locales
      * @return $this
      */
     public function setLocales(LocaleList $locales): this {
-        $this->locales = $locales;
+        $this->locales->clear();
+
+        $this->addLocales($locales);
 
         return $this;
     }

--- a/src/Titon/View/Locator/TemplateLocator.hh
+++ b/src/Titon/View/Locator/TemplateLocator.hh
@@ -7,6 +7,11 @@
 
 namespace Titon\View\Locator;
 
+/**
+ * Default implementation for locating templates.
+ *
+ * @package Titon\View\Locator
+ */
 class TemplateLocator extends AbstractLocator {
 
 }

--- a/src/Titon/View/Locator/TemplateLocator.hh
+++ b/src/Titon/View/Locator/TemplateLocator.hh
@@ -1,0 +1,12 @@
+<?hh // strict
+/**
+ * @copyright   2010-2015, The Titon Project
+ * @license     http://opensource.org/licenses/bsd-license.php
+ * @link        http://titon.io
+ */
+
+namespace Titon\View\Locator;
+
+class TemplateLocator extends AbstractLocator {
+
+}

--- a/src/Titon/View/View.hh
+++ b/src/Titon/View/View.hh
@@ -18,46 +18,6 @@ use Titon\Cache\Storage;
 interface View {
 
     /**
-     * Add a view helper.
-     *
-     * @param string $key
-     * @param \Titon\View\Helper $helper
-     * @return $this
-     */
-    public function addHelper(string $key, Helper $helper): this;
-
-    /**
-     * Add a lookup path.
-     *
-     * @param string $path
-     * @return $this
-     */
-    public function addPath(string $path): this;
-
-    /**
-     * Add multiple lookup paths.
-     *
-     * @param \Titon\View\PathList $paths
-     * @return $this
-     */
-    public function addPaths(PathList $paths): this;
-
-    /**
-     * Format the current template path by converting slashes and removing extensions.
-     *
-     * @param string $template
-     * @return string
-     */
-    public function formatPath(string $template): string;
-
-    /**
-     * Return the template file extension.
-     *
-     * @return string
-     */
-    public function getExtension(): string;
-
-    /**
      * Return a helper by key.
      *
      * @param string $key
@@ -73,11 +33,11 @@ interface View {
     public function getHelpers(): HelperMap;
 
     /**
-     * Return all lookup paths.
+     * Return the template locator instance.
      *
-     * @return \Titon\View\PathList
+     * @return \Titon\View\Locator
      */
-    public function getPaths(): PathList;
+    public function getLocator(): Locator;
 
     /**
      * Return a variable by key.
@@ -93,15 +53,6 @@ interface View {
      * @return \Titon\View\DataMap
      */
     public function getVariables(): DataMap;
-
-    /**
-     * Locate a template within the lookup paths and organize based on the type of template.
-     *
-     * @param string $template
-     * @param \Titon\View\Template $type
-     * @return string
-     */
-    public function locateTemplate(string $template, Template $type = Template::OPEN): string;
 
     /**
      * The all-in-one rendering method that pieces together the layout, wrapper, and template,
@@ -126,20 +77,13 @@ interface View {
     public function renderTemplate(string $path, DataMap $variables = Map {}): string;
 
     /**
-     * Set the template file extension.
+     * Set a view helper.
      *
-     * @param string $ext
+     * @param string $key
+     * @param \Titon\View\Helper $helper
      * @return $this
      */
-    public function setExtension(string $ext): this;
-
-    /**
-     * Set a list of lookup paths and overwrite any previously defined paths.
-     *
-     * @param \Titon\View\PathList $paths
-     * @return $this
-     */
-    public function setPaths(PathList $paths): this;
+    public function setHelper(string $key, Helper $helper): this;
 
     /**
      * Set a view variable.

--- a/src/Titon/View/bootstrap.hh
+++ b/src/Titon/View/bootstrap.hh
@@ -16,8 +16,6 @@
 namespace Titon\View {
     type DataMap = Map<string, mixed>;
     type HelperMap = Map<string, Helper>;
-    type LocaleList = Vector<string>;
-    type PathList = Vector<string>;
 }
 
 namespace Titon\View\Engine {
@@ -40,4 +38,9 @@ namespace Titon\View\Helper {
 
     // Breadcrumb
     type Breadcrumb = shape('title' => string, 'url' => string, 'attributes' => AttributeMap);
+}
+
+namespace Titon\View\Locator {
+    type LocaleList = Vector<string>;
+    type PathList = Vector<string>;
 }

--- a/src/Titon/View/composer.json
+++ b/src/Titon/View/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "titon/view",
     "type": "library",
-    "description": "The view package provides template and helper management, and template rendering through engines.",
-    "keywords": ["titon", "view", "helper", "engine", "template", "renderer"],
+    "description": "The view package provides template helpers, lookup, and rendering through engines.",
+    "keywords": ["titon", "view", "helper", "engine", "template", "renderer", "locator"],
     "homepage": "http://titon.io",
     "license": "BSD-3-Clause",
     "authors": [

--- a/tests/Titon/Controller/ControllerTest.hh
+++ b/tests/Titon/Controller/ControllerTest.hh
@@ -8,6 +8,7 @@ use Titon\Test\Stub\Controller\ControllerStub;
 use Titon\Test\TestCase;
 use Titon\View\Engine\TemplateEngine;
 use Titon\View\EngineView;
+use Titon\View\Locator\TemplateLocator;
 
 /**
  * @property \Titon\Test\Stub\Controller\ControllerStub $object
@@ -21,11 +22,11 @@ class ControllerTest extends TestCase {
             '/views/' => [
                 'private/' => [
                     'errors/' => [
-                        'error.tpl' => '<?php echo $message; ?>',
-                        'http.tpl' => '<?php echo $code . \': \' . $message; ?>'
+                        'error.tpl' => '<?= $message; ?>',
+                        'http.tpl' => '<?= $code . \': \' . $message; ?>'
                     ],
                     'layouts/' => [
-                        'default.tpl' => '<?php echo $this->getContent(); ?>'
+                        'default.tpl' => '<?= $this->getContent(); ?>'
                     ]
                 ],
                 'public/' => [
@@ -38,7 +39,7 @@ class ControllerTest extends TestCase {
             ]
         ]);
 
-        $view = new EngineView($this->vfs()->path('/views/'));
+        $view = new EngineView(new TemplateLocator($this->vfs()->path('/views/')));
         $view->setEngine(new TemplateEngine());
 
         $this->object = new ControllerStub(Request::createFromGlobals(), new Response());
@@ -142,7 +143,7 @@ class ControllerTest extends TestCase {
     }
 
     public function testGetSetView(): void {
-        $view = new EngineView($this->vfs()->path('/other-views/'));
+        $view = new EngineView(new TemplateLocator($this->vfs()->path('/other-views/')));
 
         $this->assertNotEquals($view, $this->object->getView());
 

--- a/tests/Titon/Controller/ControllerTest.hh
+++ b/tests/Titon/Controller/ControllerTest.hh
@@ -46,6 +46,12 @@ class ControllerTest extends TestCase {
         $this->object->setView($view);
     }
 
+    public function testBuildViewPath(): void {
+        $this->assertEquals('stub/index', $this->object->viewPath('index'));
+        $this->assertEquals('stub/dashed-route', $this->object->viewPath('dashed-route'));
+        $this->assertEquals('stub/underscore-route', $this->object->viewPath('underscore_route'));
+    }
+
     public function testDispatchTo(): void {
         $this->assertEquals('actionNoArgs', (string) $this->object->dispatchTo('action-no-args', [])->getBody());
         $this->assertEquals('actionNoArgs', (string) $this->object->dispatchTo('actionNoArgs', [])->getBody());

--- a/tests/Titon/Route/RouterTest.hh
+++ b/tests/Titon/Route/RouterTest.hh
@@ -55,19 +55,18 @@ class RouterTest extends TestCase {
 
         $this->assertFalse($storage->has('routes'));
 
-        $router1->initialize();
+        $router1->match('/');
 
         $this->assertTrue($storage->has('routes'));
 
         // Now load another instance
-
         $router2 = new Router();
         $router2->setStorage($storage);
 
         $this->assertEquals(Map {}, $router2->getRoutes());
 
         $router2->map('root', new Route('/foobar', 'Module\Controller@action'));
-        $router2->initialize();
+        $router2->match('/');
 
         $this->assertEquals(Map {'module' => $route1, 'root' => $route2}, $router2->getRoutes());
 
@@ -481,7 +480,7 @@ class RouterTest extends TestCase {
         $this->assertEquals(Vector {'delete', 'post'}, $routes['rest.delete']->getMethods());
     }
 
-    public function TestRouteStubs(): void {
+    public function testRouteStubs(): void {
         $route = new Route('/', 'Controller@action');
         $router = new Router();
         $router->map('key', $route);
@@ -493,115 +492,8 @@ class RouterTest extends TestCase {
     /**
      * @expectedException \Titon\Route\Exception\MissingRouteException
      */
-    public function TestRouteStubsMissingKey(): void {
+    public function testRouteStubsMissingKey(): void {
         $this->object->getRoute('fakeKey');
-    }
-
-    public function testSegments(): void {
-        $_SERVER['DOCUMENT_ROOT'] = '';
-        $_SERVER['HTTP_HOST'] = 'localhost';
-        $_SERVER['SCRIPT_FILENAME'] = '/index.php';
-        $_SERVER['REQUEST_URI'] = '/';
-        Server::initialize($_SERVER);
-
-        $router = new Router();
-        $this->assertEquals('/', $router->base());
-        $this->assertEquals('/', $router->getSegment('path'));
-        $this->assertInstanceOf('HH\Map', $router->getSegment('query'));
-        $this->assertEquals(Map {
-            'path' => '/',
-            'scheme' => 'http',
-            'query' => Map {},
-            'host' => 'localhost',
-            'port' => 80
-        }, $router->getSegments());
-
-        // module, controller
-        $_SERVER['HTTP_HOST'] = 'domain.com';
-        $_SERVER['SCRIPT_FILENAME'] = '/index.php';
-        $_SERVER['REQUEST_URI'] = '/module/index';
-        Server::initialize($_SERVER);
-
-        $router = new Router();
-        $this->assertEquals('/', $router->base());
-        $this->assertEquals('/module/index', $router->getSegment('path'));
-        $this->assertInstanceOf('HH\Map', $router->getSegment('query'));
-        $this->assertEquals(Map {
-            'path' => '/module/index',
-            'scheme' => 'http',
-            'query' => Map {},
-            'host' => 'domain.com',
-            'port' => 80
-        }, $router->getSegments());
-
-        // module, controller, action, ext, base,
-        $_SERVER['HTTP_HOST'] = 'sub.domain.com';
-        $_SERVER['SCRIPT_FILENAME'] = '/root/dir/index.php';
-        $_SERVER['REQUEST_URI'] = '/module/controller/action.html';
-        Server::initialize($_SERVER);
-
-        $router = new Router();
-        $this->assertEquals('/root/dir', $router->base());
-        $this->assertEquals('/module/controller/action.html', $router->getSegment('path'));
-        $this->assertInstanceOf('HH\Map', $router->getSegment('query'));
-        $this->assertEquals(Map {
-            'path' => '/module/controller/action.html',
-            'scheme' => 'http',
-            'query' => Map {},
-            'host' => 'sub.domain.com',
-            'port' => 80
-        }, $router->getSegments());
-
-        // module, controller, action, ext, base, query, https
-        $_SERVER['HTTP_HOST'] = 'subber.sub.domain.com';
-        $_SERVER['SCRIPT_FILENAME'] = '/rooter/root/dir/index.php'; // query doesn't show up here
-        $_SERVER['REQUEST_URI'] = '/module/controller/action.html?foo=bar&int=123';
-        $_SERVER['HTTPS'] = 'on';
-        Server::initialize($_SERVER);
-
-        $_GET = ['foo' => 'bar', 'int' => 123];
-        Get::initialize($_GET);
-
-        $router = new Router();
-        $this->assertEquals('/rooter/root/dir', $router->base());
-        $this->assertEquals('/module/controller/action.html', $router->getSegment('path'));
-        $this->assertInstanceOf('HH\Map', $router->getSegment('query'));
-        $this->assertEquals(Map {
-            'path' => '/module/controller/action.html',
-            'scheme' => 'https',
-            'query' => Map {'foo' => 'bar', 'int' => 123},
-            'host' => 'subber.sub.domain.com',
-            'port' => 80
-        }, $router->getSegments());
-
-        // module, controller, action, ext, base, query, https, args
-        $_SERVER['HTTP_HOST'] = 'subbest.subber.sub.domain.com';
-        $_SERVER['SCRIPT_FILENAME'] = '/base/rooter/root/dir/index.php'; // query doesn't show up here
-        $_SERVER['REQUEST_URI'] = '/module/controller/action.html/123/abc?foo=bar&int=123';
-        $_SERVER['HTTPS'] = 'on';
-        Server::initialize($_SERVER);
-
-        $_GET = ['foo' => 'bar', 'int' => 123];
-        Get::initialize($_GET);
-
-        $router = new Router();
-        $this->assertEquals('/base/rooter/root/dir', $router->base());
-        $this->assertEquals('/module/controller/action.html/123/abc', $router->getSegment('path'));
-        $this->assertInstanceOf('HH\Map', $router->getSegment('query'));
-        $this->assertEquals(Map {
-            'path' => '/module/controller/action.html/123/abc',
-            'scheme' => 'https',
-            'query' => Map {'foo' => 'bar', 'int' => 123},
-            'host' => 'subbest.subber.sub.domain.com',
-            'port' => 80
-        }, $router->getSegments());
-    }
-
-    /**
-     * @expectedException \Titon\Route\Exception\MissingSegmentException
-     */
-    public function testSegmentsMissingKey(): void {
-        $this->object->getSegment('fakeKey');
     }
 
     public function testWireClassMapping(): void {

--- a/tests/Titon/Route/UrlBuilderTest.hh
+++ b/tests/Titon/Route/UrlBuilderTest.hh
@@ -103,10 +103,6 @@ class UrlBuilderTest extends TestCase {
         $this->assertEquals('/users/profile/feed.json', $this->object->build('action.ext', Map {'module' => 'Users', 'controller' => 'ProfILE', 'action' => 'feeD', 'ext' => 'JSON'}));
     }
 
-    public function testBuildLinkToFunction(): void {
-        $this->assertEquals('/users/profile/feed.json', link_to('action.ext', Map {'module' => 'users', 'controller' => 'profile', 'action' => 'feed', 'ext' => 'json'}));
-    }
-
     /**
      * @expectedException \Titon\Route\Exception\MissingRouteException
      */
@@ -119,6 +115,22 @@ class UrlBuilderTest extends TestCase {
      */
     public function testBuildMissingToken(): void {
         $this->object->build('module');
+    }
+
+    public function testGetAbsoluteUrl(): void {
+        $_SERVER['DOCUMENT_ROOT'] = '/root';
+        $_SERVER['HTTP_HOST'] = 'sub.domain.com';
+        $_SERVER['SCRIPT_FILENAME'] = '/root/base/app/index.php';
+        $_SERVER['REQUEST_URI'] = '/module/controller/action.html/123?foo=bar';
+        $_SERVER['HTTPS'] = 'on';
+        Server::initialize($_SERVER);
+
+        $_GET = ['foo' => 'bar'];
+        Get::initialize($_GET);
+
+        $builder = new UrlBuilder(new Router());
+
+        $this->assertEquals('https://sub.domain.com/base/app/module/controller/action.html/123?foo=bar', $builder->getAbsoluteUrl());
     }
 
     public function testSegments(): void {
@@ -230,24 +242,12 @@ class UrlBuilderTest extends TestCase {
         $this->object->getSegment('fakeKey');
     }
 
-    public function testUrl(): void {
-        $_SERVER['DOCUMENT_ROOT'] = '/root';
-        $_SERVER['HTTP_HOST'] = 'sub.domain.com';
-        $_SERVER['SCRIPT_FILENAME'] = '/root/base/app/index.php';
-        $_SERVER['REQUEST_URI'] = '/module/controller/action.html/123?foo=bar';
-        $_SERVER['HTTPS'] = 'on';
-        Server::initialize($_SERVER);
-
-        $_GET = ['foo' => 'bar'];
-        Get::initialize($_GET);
-
-        $builder = new UrlBuilder(new Router());
-
-        $this->assertEquals('https://sub.domain.com/base/app/module/controller/action.html/123?foo=bar', $builder->url());
+    public function testUrlGlobalFunction(): void {
+        $this->assertEquals('/users/profile/feed.json', url('action.ext', Map {'module' => 'users', 'controller' => 'profile', 'action' => 'feed', 'ext' => 'json'}));
     }
 
-    public function testUrlGlobalFunction(): void {
-        $this->assertEquals('http://localhost/', url());
+    public function testCurrentUrlGlobalFunction(): void {
+        $this->assertEquals('http://localhost/', current_url());
     }
 
 }

--- a/tests/Titon/Test/Stub/Controller/ControllerStub.hh
+++ b/tests/Titon/Test/Stub/Controller/ControllerStub.hh
@@ -41,4 +41,8 @@ class ControllerStub extends AbstractController {
         return null;
     }
 
+    public function viewPath(string $action): string {
+        return $this->buildViewPath($action);
+    }
+
 }

--- a/tests/Titon/Test/Stub/View/LocatorStub.hh
+++ b/tests/Titon/Test/Stub/View/LocatorStub.hh
@@ -1,0 +1,8 @@
+<?hh // strict
+namespace Titon\Test\Stub\View;
+
+use Titon\View\Locator\AbstractLocator;
+
+class LocatorStub extends AbstractLocator {
+
+}

--- a/tests/Titon/Utility/InflectorTest.hh
+++ b/tests/Titon/Utility/InflectorTest.hh
@@ -102,7 +102,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lowercase', Inflector::snakeCase('lowercase'));
         $this->assertEquals('u_p_p_e_r_c_a_s_e', Inflector::snakeCase('UPPERCASE'));
         $this->assertEquals('under_score', Inflector::snakeCase('under_score'));
-        $this->assertEquals('dashes', Inflector::snakeCase('dash-es'));
+        $this->assertEquals('dash_es', Inflector::snakeCase('dash-es'));
         $this->assertEquals('123_numbers', Inflector::snakeCase('123 numbers'));
         $this->assertEquals('with_e_x_txml', Inflector::snakeCase('with EXT.xml'));
         $this->assertEquals('lots_of_white_space', Inflector::snakeCase('lots  of     white space'));
@@ -124,7 +124,7 @@ class InflectorTest extends TestCase {
         $this->assertEquals('lowercase', Inflector::underscore('lowercase'));
         $this->assertEquals('u_p_p_e_r_c_a_s_e', Inflector::underscore('UPPERCASE'));
         $this->assertEquals('under_score', Inflector::underscore('under_score'));
-        $this->assertEquals('dashes', Inflector::underscore('dash-es'));
+        $this->assertEquals('dash_es', Inflector::underscore('dash-es'));
         $this->assertEquals('123_numbers', Inflector::underscore('123 numbers'));
         $this->assertEquals('with_e_x_txml', Inflector::underscore('with EXT.xml'));
         $this->assertEquals('lots_of_white_space', Inflector::underscore('lots  of     white space'));

--- a/tests/Titon/View/Engine/TemplateEngineTest.hh
+++ b/tests/Titon/View/Engine/TemplateEngineTest.hh
@@ -1,8 +1,10 @@
 <?hh
 namespace Titon\View\Engine;
 
-use Titon\View\EngineView;
 use Titon\Test\TestCase;
+use Titon\View\EngineView;
+use Titon\View\Locator\TemplateLocator;
+use Titon\View\ViewTest;
 
 /**
  * @property \Titon\View\EngineView $object
@@ -13,28 +15,11 @@ class TemplateEngineTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $this->vfs()->createStructure([
-            '/views/' => [
-                'private/' => [
-                    'partials/' => [
-                        'nested/' => [
-                            'include.tpl' => 'nested/include.tpl'
-                        ],
-                        'variables.tpl' => '<?php echo $name; ?> - <?php echo $type; ?> - <?php echo $filename; ?>'
-                    ]
-                ],
-                'public/' => [
-                    'index/' => [
-                        'add.tpl' => 'add.tpl',
-                        'test-include.tpl' => 'test-include.tpl <?php echo $this->open(\'nested/include\'); ?>'
-                    ]
-                ]
-            ]
-        ]);
+        $this->vfs()->createStructure(ViewTest::generateViewStructure());
 
         $this->engine = new TemplateEngine();
 
-        $this->object = new EngineView([$this->vfs()->path('/views')]);
+        $this->object = new EngineView(new TemplateLocator($this->vfs()->path('/views')));
         $this->object->setEngine($this->engine);
     }
 
@@ -56,12 +41,12 @@ class TemplateEngineTest extends TestCase {
     }
 
     public function testRender(): void {
-        $this->assertEquals('add.tpl', $this->object->renderTemplate($this->object->locateTemplate('index/add')));
-        $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($this->object->locateTemplate('index/test-include')));
+        $this->assertEquals('add.tpl', $this->object->renderTemplate($this->object->getLocator()->locate('index/add')));
+        $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($this->object->getLocator()->locate('index/test-include')));
     }
 
     public function testData(): void {
-        $this->assertEquals('add.tpl', $this->engine->render($this->object->locateTemplate('index/add'), Map {
+        $this->assertEquals('add.tpl', $this->engine->render($this->object->getLocator()->locate('index/add'), Map {
             'foo' => 'bar'
         }));
 

--- a/tests/Titon/View/Engine/TemplateEngineTest.hh
+++ b/tests/Titon/View/Engine/TemplateEngineTest.hh
@@ -24,8 +24,8 @@ class TemplateEngineTest extends TestCase {
     }
 
     public function testOpen(): void {
-        $this->assertEquals('nested/include.tpl', $this->object->getEngine()->open('nested/include'));
-        $this->assertEquals('nested/include.tpl', $this->object->getEngine()->open('nested/include.tpl'));
+        $this->assertEquals('private.partials.nested.include', $this->object->getEngine()->open('nested/include'));
+        $this->assertEquals('private.partials.nested.include', $this->object->getEngine()->open('nested/include.tpl'));
         $this->assertEquals('Titon - partial - variables.tpl', $this->object->getEngine()->open('variables', Map {
             'name' => 'Titon',
             'type' => 'partial',
@@ -41,12 +41,12 @@ class TemplateEngineTest extends TestCase {
     }
 
     public function testRender(): void {
-        $this->assertEquals('add.tpl', $this->object->renderTemplate($this->object->getLocator()->locate('index/add')));
-        $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($this->object->getLocator()->locate('index/test-include')));
+        $this->assertEquals('public.index.add', $this->object->renderTemplate($this->object->getLocator()->locate('index/add')));
+        $this->assertEquals('public.index.include - private.partials.nested.include', $this->object->renderTemplate($this->object->getLocator()->locate('index/include')));
     }
 
     public function testData(): void {
-        $this->assertEquals('add.tpl', $this->engine->render($this->object->getLocator()->locate('index/add'), Map {
+        $this->assertEquals('public.index.add', $this->engine->render($this->object->getLocator()->locate('index/add'), Map {
             'foo' => 'bar'
         }));
 

--- a/tests/Titon/View/EngineViewTest.hh
+++ b/tests/Titon/View/EngineViewTest.hh
@@ -17,36 +17,35 @@ class EngineViewTest extends TestCase {
 
         $this->object = new EngineView(new TemplateLocator([
             $this->vfs()->path('/views/'),
-            $this->vfs()->path('/views/fallback/')
+            $this->vfs()->path('/views-fallback/')
         ]));
     }
 
     public function testRender(): void {
-        $this->assertEquals('<layout>edit.tpl</layout>', $this->object->render('index/edit'));
+        $this->assertEquals('<layout>public.index.edit</layout>', $this->object->render('index/edit'));
 
         $this->object->getEngine()->useLayout('fallback');
-        $this->assertEquals('<fallbackLayout>add.tpl</fallbackLayout>', $this->object->render('index/add'));
+        $this->assertEquals('<fallbackLayout>public.index.add</fallbackLayout>', $this->object->render('index/add'));
 
         $this->object->getEngine()->wrapWith('wrapper');
-        $this->assertEquals('<fallbackLayout><wrapper>index.tpl</wrapper></fallbackLayout>', $this->object->render('index/index'));
+        $this->assertEquals('<fallbackLayout><wrapper>public.index.index</wrapper></fallbackLayout>', $this->object->render('index/index'));
 
         $this->object->getEngine()->wrapWith('wrapper', 'fallback');
-        $this->assertEquals('<fallbackLayout><fallbackWrapper><wrapper>view.tpl</wrapper></fallbackWrapper></fallbackLayout>', $this->object->render('index/view'));
+        $this->assertEquals('<fallbackLayout><fallbackWrapper><wrapper>public.index.view</wrapper></fallbackWrapper></fallbackLayout>', $this->object->render('index/view'));
 
         $this->object->getEngine()->wrapWith()->useLayout('');
-        $this->assertEquals('view.xml.tpl', $this->object->render('index/view.xml'));
+        $this->assertEquals('public.index.view.xml', $this->object->render('index/view.xml'));
     }
 
     public function testRenderPrivate(): void {
-        $this->assertEquals('<layout>public/root.tpl</layout>', $this->object->render('root'));
-        $this->assertEquals('<layout>private/root.tpl</layout>', $this->object->render('root', true));
+        $this->assertEquals('<layout>public.root</layout>', $this->object->render('root'));
+        $this->assertEquals('<layout>private.root</layout>', $this->object->render('root', true));
     }
 
     public function testRenderTemplate(): void {
-        $this->assertEquals('add.tpl', $this->object->renderTemplate($this->object->getLocator()->locate('index/add')));
-        $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($this->object->getLocator()->locate('index/test-include')));
+        $this->assertEquals('public.index.add', $this->object->renderTemplate($this->object->getLocator()->locate('index/add')));
+        $this->assertEquals('public.index.include - private.partials.nested.include', $this->object->renderTemplate($this->object->getLocator()->locate('index/include')));
 
-        // variables
         $this->assertEquals('Titon - partial - variables.tpl', $this->object->renderTemplate($this->object->getLocator()->locate('variables', Template::PARTIAL), Map {
             'name' => 'Titon',
             'type' => 'partial',
@@ -59,17 +58,17 @@ class EngineViewTest extends TestCase {
 
         $this->object->setStorage($storage);
 
-        $path = $this->object->getLocator()->locate('index/test-include');
+        $path = $this->object->getLocator()->locate('index/include');
         $key = md5($path);
 
         $this->assertFalse($storage->has($key));
 
-        $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($path));
+        $this->assertEquals('public.index.include - private.partials.nested.include', $this->object->renderTemplate($path));
 
         $this->assertTrue($storage->has($key));
 
         // Validate it returns the cached value
-        $this->assertEquals('test-include.tpl nested/include.tpl', $this->object->renderTemplate($path));
+        $this->assertEquals('public.index.include - private.partials.nested.include', $this->object->renderTemplate($path));
 
         $storage->flush();
 

--- a/tests/Titon/View/Helper/AssetHelperTest.hh
+++ b/tests/Titon/View/Helper/AssetHelperTest.hh
@@ -3,6 +3,7 @@ namespace Titon\View\Helper;
 
 use Titon\Test\TestCase;
 use Titon\View\EngineView;
+use Titon\View\Locator\TemplateLocator;
 
 /**
  * @property \Titon\View\Helper\AssetHelper $object
@@ -15,8 +16,8 @@ class AssetHelperTest extends TestCase {
         $this->vfs()->createDirectory('/css/');
         $this->vfs()->createFile('/css/test.css');
 
-        $view = new EngineView(TEMP_DIR);
-        $view->addHelper('html', new HtmlHelper());
+        $view = new EngineView(new TemplateLocator(TEMP_DIR));
+        $view->setHelper('html', new HtmlHelper());
 
         $this->object = new AssetHelper($this->vfs()->path('/'));
         $this->object->setView($view);

--- a/tests/Titon/View/Helper/BreadcrumbHelperTest.hh
+++ b/tests/Titon/View/Helper/BreadcrumbHelperTest.hh
@@ -4,6 +4,7 @@ namespace Titon\View\Helper;
 use Titon\Test\TestCase;
 use Titon\Type\ArrayList;
 use Titon\View\EngineView;
+use Titon\View\Locator\TemplateLocator;
 
 /**
  * @property \Titon\View\Helper\BreadcrumbHelper $object
@@ -13,8 +14,8 @@ class BreadcrumbHelperTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        $view = new EngineView(TEMP_DIR);
-        $view->addHelper('html', new HtmlHelper());
+        $view = new EngineView(new TemplateLocator(TEMP_DIR));
+        $view->setHelper('html', new HtmlHelper());
 
         $this->object = new BreadcrumbHelper();
         $this->object->setView($view);

--- a/tests/Titon/View/Helper/HtmlHelperTest.hh
+++ b/tests/Titon/View/Helper/HtmlHelperTest.hh
@@ -4,6 +4,7 @@ namespace Titon\View\Helper;
 use Titon\Test\TestCase;
 use Titon\Utility\Crypt;
 use Titon\View\EngineView;
+use Titon\View\Locator\TemplateLocator;
 
 /**
  * @property \Titon\View\Helper\HtmlHelper $object
@@ -104,7 +105,7 @@ class HtmlHelperTest extends TestCase {
     }
 
     public function testTitle(): void {
-        $view = new EngineView(Vector {'/'});
+        $view = new EngineView(new TemplateLocator('/'));
         $this->object->setView($view);
 
         $view->setVariable('pageTitle', 'Page Title');

--- a/tests/Titon/View/HelperTest.hh
+++ b/tests/Titon/View/HelperTest.hh
@@ -2,9 +2,10 @@
 namespace Titon\View;
 
 use Titon\Test\Stub\View\HelperStub;
+use Titon\Test\Stub\View\LocatorStub;
+use Titon\Test\Stub\View\ViewStub;
 use Titon\Test\TestCase;
 use Titon\View\Helper\TagMap;
-use Titon\View\Locator\TemplateLocator;
 
 /**
  * @property \Titon\View\Helper $object
@@ -43,11 +44,60 @@ class HelperTest extends TestCase {
         $this->assertEquals('This is "double" and \'single\' quotes.', $this->object->escape($value, false));
 
         $this->object->setEscaping(false);
+
         $this->assertEquals('This is "double" and \'single\' quotes.', $this->object->escape($value));
         $this->assertEquals('This is &quot;double&quot; and &#039;single&#039; quotes.', $this->object->escape($value, true));
 
         $this->object->setEscaping(true);
+
         $this->assertEquals('This is &quot;double&quot; and &#039;single&#039; quotes.', $this->object->escape($value));
+    }
+
+    public function testGetSetEscaping(): void {
+        $this->assertTrue($this->object->getEscaping());
+
+        $this->object->setEscaping(false);
+
+        $this->assertFalse($this->object->getEscaping());
+    }
+
+    public function testGetHelper(): void {
+        $helper = new HelperStub();
+
+        $view = new ViewStub(new LocatorStub('/'));
+        $view->setHelper('html', $helper);
+
+        $this->object->setView($view);
+
+        $this->assertEquals($helper, $this->object->getHelper('html'));
+    }
+
+    /**
+     * @expectedException \Titon\View\Exception\MissingHelperException
+     */
+    public function testGetHelperThrowsMissing(): void {
+        $this->object->getHelper('html');
+    }
+
+    public function testGetTag(): void {
+        $this->assertEquals('<tag>{body}</tag>', $this->object->getTag('noattr'));
+    }
+
+    /**
+     * @expectedException \Titon\View\Exception\MissingTagException
+     */
+    public function testGetTagThrowsMissing(): void {
+        $this->object->getTag('foobar');
+    }
+
+    public function testGetSetView(): void {
+        $view = new ViewStub(new LocatorStub('/'));
+
+        $this->assertEquals(null, $this->object->getView());
+
+        $this->object->setView($view);
+
+        $this->assertEquals($view, $this->object->getView());
     }
 
     public function testTag(): void {
@@ -56,14 +106,6 @@ class HelperTest extends TestCase {
         $this->assertEquals('<tag value />' . PHP_EOL, $this->object->tag('nobody', Map {'attr' => ' value'}));
         $this->assertEquals('<tag 1 2>3</tag>' . PHP_EOL, $this->object->tag('custom', Map {'one' => 1, 'two' => 2, 'three' => 3}));
         $this->assertEquals('<tag 1>2</tag>3' . PHP_EOL, $this->object->tag('default', Map {'0' => 1, '1' => 2, '2' => 3}));
-    }
-
-    public function testGetSetView(): void {
-        $view = new EngineView(new TemplateLocator('/'));
-        $this->assertEquals(null, $this->object->getView());
-
-        $this->object->setView($view);
-        $this->assertEquals($view, $this->object->getView());
     }
 
 }

--- a/tests/Titon/View/HelperTest.hh
+++ b/tests/Titon/View/HelperTest.hh
@@ -4,6 +4,7 @@ namespace Titon\View;
 use Titon\Test\Stub\View\HelperStub;
 use Titon\Test\TestCase;
 use Titon\View\Helper\TagMap;
+use Titon\View\Locator\TemplateLocator;
 
 /**
  * @property \Titon\View\Helper $object
@@ -58,7 +59,7 @@ class HelperTest extends TestCase {
     }
 
     public function testGetSetView(): void {
-        $view = new EngineView(Vector {'/'});
+        $view = new EngineView(new TemplateLocator('/'));
         $this->assertEquals(null, $this->object->getView());
 
         $this->object->setView($view);

--- a/tests/Titon/View/Locator/LocaleTemplateLocatorTest.hh
+++ b/tests/Titon/View/Locator/LocaleTemplateLocatorTest.hh
@@ -1,0 +1,82 @@
+<?hh
+namespace Titon\View\Locator;
+
+use Titon\Test\TestCase;
+use Titon\Utility\Config;
+use Titon\View\Template;
+use Titon\View\ViewTest;
+
+/**
+ * @property \Titon\View\Locator\TemplateLocator $object
+ */
+class LocaleTemplateLocatorTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->vfs()->createStructure(ViewTest::generateViewStructure());
+
+        $this->object = new LocaleTemplateLocator([
+            $this->vfs()->path('/views'),
+            $this->vfs()->path('/views-fallback')
+        ], ['en', 'fr']);
+    }
+
+    public function testAddGetSetLocales(): void {
+        $this->assertEquals(Vector {'en', 'fr'}, $this->object->getLocales());
+
+        $this->object->addLocale('en');
+        $this->object->addLocale('de');
+
+        $this->assertEquals(Vector {'en', 'fr', 'de'}, $this->object->getLocales());
+
+        $this->object->addLocales(Vector {'en-us', 'fr', 'it', 'nl'});
+
+        $this->assertEquals(Vector {'en', 'fr', 'de', 'en-us', 'it', 'nl'}, $this->object->getLocales());
+
+        $this->object->setLocales(Vector {'en', 'en', 'es'});
+
+        $this->assertEquals(Vector {'en', 'es'}, $this->object->getLocales());
+    }
+
+    public function testConfigLocalesAreLoaded(): void {
+        Config::set('titon.locale.cascade', Vector {'en-us', 'en-gb', 'en', 'es-co', 'es'});
+
+        $object = new LocaleTemplateLocator('/views', ['it']);
+
+        $this->assertEquals(Vector {
+            'it',
+            'en-us',
+            'en-gb',
+            'en',
+            'es-co',
+            'es'
+        }, $object->getLocales());
+    }
+
+    public function testBuildTemplateLookup(): void {
+        $this->assertEquals(Vector {
+            'foo/bar.en.tpl',
+            'foo/bar.fr.tpl',
+            'foo/bar.tpl'
+        }, $this->object->buildTemplateLookup('foo/bar'));
+    }
+
+    public function testLocate(): void {
+        $this->assertEquals($this->vfs()->path('/views/public/lang/index.fr.tpl'), $this->object->locate('lang/index'));
+    }
+
+    public function testLocateFallThrough(): void {
+        $this->object->setLocales(Vector {'en'});
+
+        $this->assertEquals($this->vfs()->path('/views/public/lang/index.tpl'), $this->object->locate('lang/index'));
+    }
+
+    public function testLocateDoubleLocaleCode(): void {
+        $this->object->setLocales(Vector {'en-us'});
+
+        $this->assertEquals($this->vfs()->path('/views/public/lang/index.en-us.tpl'), $this->object->locate('lang/index'));
+    }
+
+}
+

--- a/tests/Titon/View/Locator/TemplateLocatorTest.hh
+++ b/tests/Titon/View/Locator/TemplateLocatorTest.hh
@@ -1,0 +1,55 @@
+<?hh
+namespace Titon\View\Locator;
+
+use Titon\Test\TestCase;
+use Titon\View\Template;
+use Titon\View\ViewTest;
+
+/**
+ * @property \Titon\View\Locator\TemplateLocator $object
+ */
+class AssetHelperTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->vfs()->createStructure(ViewTest::generateViewStructure());
+
+        $this->object = new TemplateLocator([
+            $this->vfs()->path('/views'),
+            $this->vfs()->path('/views/fallback')
+        ]);
+    }
+
+    public function testLocate(): void {
+        $this->assertEquals($this->vfs()->path('/views/public/index/add.tpl'), $this->object->locate('index/add'));
+        $this->assertEquals($this->vfs()->path('/views/public/index/add.tpl'), $this->object->locate('index\add'));
+        $this->assertEquals($this->vfs()->path('/views/public/index/add.tpl'), $this->object->locate('index/add.tpl'));
+        $this->assertEquals($this->vfs()->path('/views/public/index/view.xml.tpl'), $this->object->locate('index/view.xml'));
+
+        // partials
+        $this->assertEquals($this->vfs()->path('/views/private/partials/include.tpl'), $this->object->locate('include', Template::PARTIAL));
+        $this->assertEquals($this->vfs()->path('/views/private/partials/nested/include.tpl'), $this->object->locate('nested/include', Template::PARTIAL));
+
+        // wrapper
+        $this->assertEquals($this->vfs()->path('/views/private/wrappers/wrapper.tpl'), $this->object->locate('wrapper', Template::WRAPPER));
+        $this->assertEquals($this->vfs()->path('/views/fallback/private/wrappers/fallback.tpl'), $this->object->locate('fallback', Template::WRAPPER));
+
+        // layout
+        $this->assertEquals($this->vfs()->path('/views/private/layouts/default.tpl'), $this->object->locate('default', Template::LAYOUT));
+        $this->assertEquals($this->vfs()->path('/views/fallback/private/layouts/fallback.tpl'), $this->object->locate('fallback', Template::LAYOUT));
+
+        // private
+        $this->assertEquals($this->vfs()->path('/views/private/errors/404.tpl'), $this->object->locate('errors/404', Template::CLOSED));
+        $this->assertEquals($this->vfs()->path('/views/fallback/private/emails/example.html.tpl'), $this->object->locate('emails/example.html', Template::CLOSED));
+    }
+
+    /**
+     * @expectedException \Titon\View\Exception\MissingTemplateException
+     */
+    public function testLocateMissing(): void {
+        $this->object->locate('index/missing');
+    }
+
+}
+

--- a/tests/Titon/View/Locator/TemplateLocatorTest.hh
+++ b/tests/Titon/View/Locator/TemplateLocatorTest.hh
@@ -8,7 +8,7 @@ use Titon\View\ViewTest;
 /**
  * @property \Titon\View\Locator\TemplateLocator $object
  */
-class AssetHelperTest extends TestCase {
+class TemplateLocatorTest extends TestCase {
 
     protected function setUp(): void {
         parent::setUp();
@@ -17,8 +17,20 @@ class AssetHelperTest extends TestCase {
 
         $this->object = new TemplateLocator([
             $this->vfs()->path('/views'),
-            $this->vfs()->path('/views/fallback')
+            $this->vfs()->path('/views-fallback')
         ]);
+    }
+
+    public function testFormatTemplate(): void {
+        $this->assertEquals('foo/bar', $this->object->formatTemplate('foo/bar'));
+        $this->assertEquals('foo/bar', $this->object->formatTemplate('foo\\bar'));
+        $this->assertEquals('foo/bar', $this->object->formatTemplate('foo\\bar.tpl'));
+        $this->assertEquals('foo/bar', $this->object->formatTemplate('/foo/bar'));
+        $this->assertEquals('foo/bar', $this->object->formatTemplate('foo/bar/'));
+    }
+
+    public function testBuildTemplateLookup(): void {
+        $this->assertEquals(Vector {'foo/bar.tpl'}, $this->object->buildTemplateLookup('foo/bar'));
     }
 
     public function testLocate(): void {
@@ -33,15 +45,15 @@ class AssetHelperTest extends TestCase {
 
         // wrapper
         $this->assertEquals($this->vfs()->path('/views/private/wrappers/wrapper.tpl'), $this->object->locate('wrapper', Template::WRAPPER));
-        $this->assertEquals($this->vfs()->path('/views/fallback/private/wrappers/fallback.tpl'), $this->object->locate('fallback', Template::WRAPPER));
+        $this->assertEquals($this->vfs()->path('/views-fallback/private/wrappers/fallback.tpl'), $this->object->locate('fallback', Template::WRAPPER));
 
         // layout
         $this->assertEquals($this->vfs()->path('/views/private/layouts/default.tpl'), $this->object->locate('default', Template::LAYOUT));
-        $this->assertEquals($this->vfs()->path('/views/fallback/private/layouts/fallback.tpl'), $this->object->locate('fallback', Template::LAYOUT));
+        $this->assertEquals($this->vfs()->path('/views-fallback/private/layouts/fallback.tpl'), $this->object->locate('fallback', Template::LAYOUT));
 
         // private
         $this->assertEquals($this->vfs()->path('/views/private/errors/404.tpl'), $this->object->locate('errors/404', Template::CLOSED));
-        $this->assertEquals($this->vfs()->path('/views/fallback/private/emails/example.html.tpl'), $this->object->locate('emails/example.html', Template::CLOSED));
+        $this->assertEquals($this->vfs()->path('/views-fallback/private/emails/example.html.tpl'), $this->object->locate('emails/example.html', Template::CLOSED));
     }
 
     /**

--- a/tests/Titon/View/LocatorTest.hh
+++ b/tests/Titon/View/LocatorTest.hh
@@ -1,0 +1,93 @@
+<?hh
+namespace Titon\View;
+
+use Titon\Test\TestCase;
+use Titon\Test\Stub\View\LocatorStub;
+use Titon\Utility\Config;
+
+/**
+ * @property \Titon\View\Locator $object
+ */
+class LocatorTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->object = new LocatorStub([
+            '/views',
+            '/views/fallback/',
+            '/views/misc'
+        ]);
+    }
+
+    public function testAddGetSetPaths(): void {
+        $expected = Vector {
+            '/views/',
+            '/views/fallback/',
+            '/views/misc/'
+        };
+        $this->assertEquals($expected, $this->object->getPaths());
+
+        $this->object->addPath('/templates');
+
+        $expected[] = '/templates/';
+        $this->assertEquals($expected, $this->object->getPaths());
+
+        $this->object->addPaths(Vector {
+            '/templates/fallback',
+            '/templates/misc'
+        });
+
+        $expected[] = '/templates/fallback/';
+        $expected[] = '/templates/misc/';
+        $this->assertEquals($expected, $this->object->getPaths());
+
+        $this->object->setPaths(Vector {'/views'});
+
+        $this->assertEquals(Vector {'/views/'}, $this->object->getPaths());
+    }
+
+    public function testPathFormatsThroughConstructor(): void {
+        $object = new LocatorStub('/views');
+
+        $this->assertEquals(Vector {'/views/'}, $object->getPaths());
+
+        $object = new LocatorStub(['/views']);
+
+        $this->assertEquals(Vector {'/views/'}, $object->getPaths());
+
+        $object = new LocatorStub(Vector {'/views'});
+
+        $this->assertEquals(Vector {'/views/'}, $object->getPaths());
+    }
+
+    public function testConfigPathsAreLoaded(): void {
+        Config::set('titon.paths.views', Vector {'/views/inherited/'});
+
+        $object = new LocatorStub('/views');
+
+        $this->assertEquals(Vector {
+            '/views/',
+            '/views/inherited/'
+        }, $object->getPaths());
+    }
+
+    public function testGetSetExtension(): void {
+        $this->assertEquals('tpl', $this->object->getExtension());
+
+        $this->object->setExtension('html');
+
+        $this->assertEquals('html', $this->object->getExtension());
+
+        $this->object->setExtension('.html'); // Strip period
+
+        $this->assertEquals('html', $this->object->getExtension());
+    }
+
+    public function testExtensionIsSetThroughConstructor() : void {
+        $object = new LocatorStub('/', 'html');
+
+        $this->assertEquals('html', $object->getExtension());
+    }
+
+}

--- a/tests/Titon/View/ViewTest.hh
+++ b/tests/Titon/View/ViewTest.hh
@@ -1,12 +1,12 @@
 <?hh
 namespace Titon\View;
 
-use Titon\Utility\Config;
+use Titon\Test\Stub\View\LocatorStub;
 use Titon\Test\Stub\View\ViewStub;
 use Titon\Test\TestCase;
+use Titon\Utility\Registry;
 use Titon\View\Helper\HtmlHelper;
 use Titon\View\Helper\FormHelper;
-use Titon\View\Locator\TemplateLocator;
 
 /**
  * @property \Titon\View\View $object
@@ -18,116 +18,105 @@ class ViewTest extends TestCase {
 
         $this->vfs()->createStructure(static::generateViewStructure());
 
-        Config::set('titon.path.views', Vector {$this->vfs()->path('/views/inherited/')});
-
-        $this->object = new ViewStub(new TemplateLocator([
+        $this->object = new ViewStub(new LocatorStub([
             $this->vfs()->path('/views'),
-            $this->vfs()->path('/views/fallback')
+            $this->vfs()->path('/views-fallback')
         ]));
     }
 
     public static function generateViewStructure(): array<string, mixed> {
         return [
             '/views/' => [
-                'fallback/' => [
-                    'private/' => [
-                        'emails/' => [
-                            'example.html.tpl' => "<!DOCTYPE html>\n<html>\n<body>\n    This is an example email template.<br>\n    It is an <b>HTML</b> specific <i>template</i>.<br>\n    - Titon\n</body>\n</html>",
-                        ],
-                        'layouts/' => [
-                            'fallback.tpl' => '<fallbackLayout><?php echo $this->getContent(); ?></fallbackLayout>'
-                        ],
-                        'wrappers/' => [
-                            'fallback.tpl' => '<fallbackWrapper><?php echo $this->getContent(); ?></fallbackWrapper>'
-                        ]
-                    ]
-                ],
                 'private/' => [
                     'errors/' => [
-                        '404.tpl' => '404.tpl'
+                        '404.tpl' => 'private.errors.404'
                     ],
                     'layouts/' => [
-                        'default.tpl' => '<layout><?php echo $this->getContent(); ?></layout>'
+                        'default.tpl' => '<layout><?= $this->getContent(); ?></layout>'
                     ],
                     'partials/' => [
                         'nested/' => [
-                            'include.tpl' => 'nested/include.tpl'
+                            'include.tpl' => 'private.partials.nested.include'
                         ],
-                        'include.tpl' => 'include.tpl',
-                        'variables.tpl' => '<?php echo $name; ?> - <?php echo $type; ?> - <?php echo $filename; ?>'
+                        'include.tpl' => 'private.partials.include',
+                        'variables.tpl' => '<?= $name; ?> - <?= $type; ?> - <?= $filename; ?>'
                     ],
                     'wrappers/' => [
-                        'wrapper.tpl' => '<wrapper><?php echo $this->getContent(); ?></wrapper>'
+                        'wrapper.tpl' => '<wrapper><?= $this->getContent(); ?></wrapper>'
                     ],
-                    'root.tpl' => 'private/root.tpl'
+                    'root.tpl' => 'private.root'
                 ],
                 'public/' => [
                     'index/' => [
-                        'add.tpl' => 'add.tpl',
-                        'edit.tpl' => 'edit.tpl',
-                        'index.tpl' => 'index.tpl',
-                        'test-include.tpl' => 'test-include.tpl <?php echo $this->open(\'nested/include\'); ?>',
-                        'view.tpl' => 'view.tpl',
-                        'view.xml.tpl' => 'view.xml.tpl',
+                        'add.tpl' => 'public.index.add',
+                        'edit.tpl' => 'public.index.edit',
+                        'index.tpl' => 'public.index.index',
+                        'include.tpl' => 'public.index.include - <?= $this->open(\'nested/include\'); ?>',
+                        'view.tpl' => 'public.index.view',
+                        'view.xml.tpl' => 'public.index.view.xml',
                     ],
                     'lang/' => [
-                        'index.en-us.tpl' => 'index.en-us.tpl',
-                        'index.fr.tpl' => 'index.fr.tpl',
-                        'index.tpl' => 'index.tpl',
+                        'index.en-us.tpl' => 'public.lang.index.en-us',
+                        'index.fr.tpl' => 'public.lang.index.fr',
+                        'index.tpl' => 'public.lang.index',
                     ],
-                    'root.tpl' => 'public/root.tpl'
+                    'root.tpl' => 'public.root'
+                ]
+            ],
+
+            '/views-fallback' => [
+                'private/' => [
+                    'emails/' => [
+                        'example.html.tpl' => "<!DOCTYPE html>\n<html>\n<body>\n    This is an example email template.<br>\n    It is an <b>HTML</b> specific <i>template</i>.<br>\n    - Titon\n</body>\n</html>",
+                    ],
+                    'layouts/' => [
+                        'fallback.tpl' => '<fallbackLayout><?= $this->getContent(); ?></fallbackLayout>'
+                    ],
+                    'wrappers/' => [
+                        'fallback.tpl' => '<fallbackWrapper><?= $this->getContent(); ?></fallbackWrapper>'
+                    ]
                 ]
             ]
         ];
     }
 
-/*
-    public function testPaths(): void {
-        $expected = Vector {
-            $this->vfs()->path('/views/'),
-            $this->vfs()->path('/views/fallback/'),
-            $this->vfs()->path('/views/inherited/')
-        };
-        $this->assertEquals($expected, $this->object->getPaths());
-
-        $this->object->addPath(TEST_DIR);
-        $expected[] = str_replace('\\', '/', TEST_DIR) . '/';
-        $this->assertEquals($expected, $this->object->getPaths());
-    } */
-
-    public function testHelpers(): void {
+    public function testGetSetHelpers(): void {
         $form = new FormHelper();
         $html = new HtmlHelper();
 
         $this->assertEquals(Map {}, $this->object->getHelpers());
 
         $this->object->setHelper('html', $html);
+
         $this->assertEquals(Map {
             'html' => $html
         }, $this->object->getHelpers());
 
         $this->object->setHelper('form', $form);
+
         $this->assertEquals(Map {
             'html' => $html,
             'form' => $form
         }, $this->object->getHelpers());
 
         $this->assertInstanceOf('Titon\View\Helper', $this->object->getHelper('html'));
+        $this->assertInstanceOf('Titon\View\Helper\HtmlHelper', $this->object->getHelper('html'));
     }
 
     /**
      * @expectedException \Titon\View\Exception\MissingHelperException
      */
-    public function testHelperMissing(): void {
+    public function testGetHelperMissingThrowsException(): void {
         $this->object->getHelper('foobar');
     }
 
-    public function testVariables(): void {
+    public function testGetSetVariables(): void {
         $expected = Map {};
         $this->assertEquals($expected, $this->object->getVariables());
 
         $this->object->setVariable('foo', 'bar');
         $expected['foo'] = 'bar';
+
         $this->assertEquals($expected, $this->object->getVariables());
 
         $this->object->setVariables(Map {
@@ -136,29 +125,39 @@ class ViewTest extends TestCase {
         });
         $expected['numeric'] = 1337;
         $expected['boolean'] = false;
+
         $this->assertEquals($expected, $this->object->getVariables());
 
         $this->assertEquals('bar', $this->object->getVariable('foo'));
     }
 
-/*
-    public function testLocateTemplateLocales(): void {
-        $rootPath = $this->vfs()->path('/views/');
+    public function testSetHelperSetsVariable(): void {
+        $this->assertEquals(null, $this->object->getVariable('html'));
 
-        $view1 = new ViewStub([$rootPath]);
-        $view1->setLocales(Vector {});
+        $helper = new HtmlHelper();
+        $this->object->setHelper('html', $helper);
 
-        $this->assertEquals($rootPath . 'public/lang/index.tpl', $view1->locateTemplate('lang/index'));
+        $this->assertEquals($helper, $this->object->getVariable('html'));
+    }
 
-        $view2 = new ViewStub([$rootPath]);
-        $view2->setLocales(Vector {'en-us'});
+    public function testSetHelperSetsRegistry(): void {
+        $this->assertFalse(Registry::has('Titon\View\Helper\HtmlHelper'));
 
-        $this->assertEquals($rootPath . 'public/lang/index.en-us.tpl', $view2->locateTemplate('lang/index'));
+        $this->object->setHelper('html', new HtmlHelper());
 
-        $view3 = new ViewStub([$rootPath]);
-        $view3->setLocales(Vector {'en', 'fr'});
+        $this->assertTrue(Registry::has('Titon\View\Helper\HtmlHelper'));
+    }
 
-        $this->assertEquals($rootPath . 'public/lang/index.fr.tpl', $view3->locateTemplate('lang/index'));
-    }*/
+    public function testSetVariableInflectsName(): void {
+        $this->object->setVariable('123', 'abc');
+
+        $this->assertEquals(null, $this->object->getVariable('123'));
+        $this->assertEquals('abc', $this->object->getVariable('_123'));
+
+        $this->object->setVariable('foo bar', 'abc');
+
+        $this->assertEquals(null, $this->object->getVariable('foo bar'));
+        $this->assertEquals('abc', $this->object->getVariable('foobar'));
+    }
 
 }


### PR DESCRIPTION
Fixes #77.

- [x] Break up the `View` class and add a new `Locator` interface for template lookup.
- [x] Separate the segment and URL logic from `Router`.
- [x] Move `Route` annotation building (out of `Router`).
- [x] Split up `Controller` logic to make it simpler.