### PR TITLE
Fix error if a super global array is null

### DIFF
--- a/src/Titon/Utility/State/Request.hh
+++ b/src/Titon/Utility/State/Request.hh
@@ -72,10 +72,14 @@ abstract class Request {
      * Initialize the class by supplying an array of data that recursively gets converted to a map.
      * That data should only be initialized once, unless it is running through the command line.
      *
-     * @param array<string, mixed> $data
+     * @param array<string, mixed>|null $data
      */
-    public static function initialize(array<string, mixed> $data): void {
+    public static function initialize(?array<string, mixed> $data): void {
         $class = static::class;
+
+        if (null === $data) {
+            $data = [];
+        }
 
         if (php_sapi_name() === 'cli' || !static::$loaded->contains($class)) {
             static::$data[$class] = static::package($data);


### PR DESCRIPTION
After requiring autoload.php I get the following error:

nCatchable fatal error: Argument 1 passed to
Titon\Utility\State\Request::initialize() must be an instance of
array, null given in titon/framework/src/Titon/Utility/State/Request.hh
on line 84
